### PR TITLE
Drop unnecessary index check in Reline::HISTORY.check_index

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -52,7 +52,6 @@ module Reline
 
     private def check_index(index)
       index += size if index < 0
-      raise RangeError.new("index=<#{index}>") if index < -@@config.history_size or @@config.history_size < index
       raise IndexError.new("index=<#{index}>") if index < 0 or size <= index
       index
     end


### PR DESCRIPTION
Hi, thank you for your hard work for irb and reline.

I tried the irb on current trunk and after the history buffer size exceeded 500, suddenly Ctrl-P (ed_prev_history) raise RangeError and irb process was aborted with the backtraces as follows.

```
         9: from /Users/nagachika/.rbenv/versions/trunk-O3/lib/ruby/2.7.0/reline.rb:331:in `block (3 levels) in inner_readline'
         8: from /Users/nagachika/.rbenv/versions/trunk-O3/lib/ruby/2.7.0/reline/line_editor.rb:717:in `input_key'
         7: from /Users/nagachika/.rbenv/versions/trunk-O3/lib/ruby/2.7.0/reline/line_editor.rb:675:in `normal_char'
         6: from /Users/nagachika/.rbenv/versions/trunk-O3/lib/ruby/2.7.0/reline/line_editor.rb:635:in `process_key'
         5: from /Users/nagachika/.rbenv/versions/trunk-O3/lib/ruby/2.7.0/reline/line_editor.rb:605:in `run_for_operators'
         4: from /Users/nagachika/.rbenv/versions/trunk-O3/lib/ruby/2.7.0/reline/line_editor.rb:636:in `block in process_key'
         3: from /Users/nagachika/.rbenv/versions/trunk-O3/lib/ruby/2.7.0/reline/line_editor.rb:636:in `call'
         2: from /Users/nagachika/.rbenv/versions/trunk-O3/lib/ruby/2.7.0/reline/line_editor.rb:1116:in `ed_prev_history'
         1: from /Users/nagachika/.rbenv/versions/trunk-O3/lib/ruby/2.7.0/reline.rb:39:in `[]'
/Users/nagachika/.rbenv/versions/trunk-O3/lib/ruby/2.7.0/reline.rb:59:in `check_index': index=<507> (RangeError)
```

I believe the index range check against `@@config.history_size` is unnecessary. Does it?