### PR TITLE
fix issue with 'SIGINT' handling in LineEditor#reset

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -64,7 +64,7 @@ class Reline::LineEditor
     @old_trap = Signal.trap('SIGINT') {
       scroll_down(@highest_in_all - @first_line_started_from)
       Reline::IOGate.move_cursor_column(0)
-      @old_trap.()
+      @old_trap.call if @old_trap.respond_to?(:call) # can also be string, ex: "DEFAULT"
     }
   end
 


### PR DESCRIPTION
@old_trap is the string "DEFAULT" and not a callable object (Proc)
if there are no other signal handlers for SIGINT signal to chain.

Found running 'make test-all' running Ruby's test suite and CTRL-C'ing the terminal, resulted in NoMethodError 'call' on string "DEFAULT".