### PR TITLE
Add RubyCore test/readline to CI test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,8 @@
 /pkg/
 /spec/reports/
 /tmp/
+/test/ext/
+/test/lib/
+/tool/
 *.swp
 Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,21 +5,5 @@ rvm:
 before_install:
   - gem update --system
   - gem update bundler
-  - mkdir -p ./test/ext/readline
-  - wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/readline/helper.rb -P ./test/ext/readline
-  - wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/readline/test_readline.rb -P ./test/ext/readline
-  - wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/readline/test_readline_history.rb -P ./test/ext/readline
-  - mkdir -p ./tool/
-  - wget https://raw.githubusercontent.com/ruby/ruby/trunk/tool/colorize.rb -P ./tool
-  - mkdir -p ./test/lib/
-  - wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/lib/leakchecker.rb -P ./test/lib
-  - wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/lib/envutil.rb -P ./test/lib
-  - wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/lib/find_executable.rb -P ./test/lib
-  - mkdir -p ./test/lib/unit/minitest
-  - wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/lib/minitest/unit.rb -P ./test/lib/minitest
-  - mkdir -p ./test/lib/unit/test
-  - wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/lib/test/unit.rb -P ./test/lib/test
-  - wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/lib/test/unit/assertions.rb -P ./test/lib/test/unit
-  - wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/lib/test/unit/parallel.rb -P ./test/lib/test/unit
-  - wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/lib/test/unit/testcase.rb -P ./test/lib/test/unit
+  - sh ./download-test_readline.sh
 script: rake ci-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,21 @@ rvm:
 before_install:
   - gem update --system
   - gem update bundler
-script: rake
+  - mkdir -p ./test/ext/readline
+  - wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/readline/helper.rb -P ./test/ext/readline
+  - wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/readline/test_readline.rb -P ./test/ext/readline
+  - wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/readline/test_readline_history.rb -P ./test/ext/readline
+  - mkdir -p ./tool/
+  - wget https://raw.githubusercontent.com/ruby/ruby/trunk/tool/colorize.rb -P ./tool
+  - mkdir -p ./test/lib/
+  - wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/lib/leakchecker.rb -P ./test/lib
+  - wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/lib/envutil.rb -P ./test/lib
+  - wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/lib/find_executable.rb -P ./test/lib
+  - mkdir -p ./test/lib/unit/minitest
+  - wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/lib/minitest/unit.rb -P ./test/lib/minitest
+  - mkdir -p ./test/lib/unit/test
+  - wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/lib/test/unit.rb -P ./test/lib/test
+  - wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/lib/test/unit/assertions.rb -P ./test/lib/test/unit
+  - wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/lib/test/unit/parallel.rb -P ./test/lib/test/unit
+  - wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/lib/test/unit/testcase.rb -P ./test/lib/test/unit
+script: rake ci-test

--- a/Rakefile
+++ b/Rakefile
@@ -21,4 +21,18 @@ end
 
 task test: ENCODING_LIST.keys
 
+
+ENCODING_LIST.each_pair do |task_name, encoding|
+  Rake::TestTask.new("ci-#{task_name}") do |t|
+    t.ruby_opts << %Q{-I. -e "RELINE_TEST_ENCODING=Encoding.find('#{encoding.name}')"}
+    t.libs << 'test'
+    t.libs << 'lib'
+    t.libs << 'test/lib'
+    t.loader = :direct
+    t.pattern = 'test/**/test_*.rb'
+  end
+end
+
+task "ci-test": ENCODING_LIST.keys.map { |task_name| "ci-#{task_name}" }
+
 task default: :test

--- a/download-test_readline.sh
+++ b/download-test_readline.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+echo "-- Download test/readline --"
+mkdir -p ./test/ext/readline
+wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/readline/helper.rb -P ./test/ext/readline
+wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/readline/test_readline.rb -P ./test/ext/readline
+wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/readline/test_readline_history.rb -P ./test/ext/readline
+mkdir -p ./tool/
+wget https://raw.githubusercontent.com/ruby/ruby/trunk/tool/colorize.rb -P ./tool
+mkdir -p ./test/lib/
+wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/lib/leakchecker.rb -P ./test/lib
+wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/lib/envutil.rb -P ./test/lib
+wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/lib/find_executable.rb -P ./test/lib
+mkdir -p ./test/lib/unit/minitest
+wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/lib/minitest/unit.rb -P ./test/lib/minitest
+mkdir -p ./test/lib/unit/test
+wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/lib/test/unit.rb -P ./test/lib/test
+wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/lib/test/unit/assertions.rb -P ./test/lib/test/unit
+wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/lib/test/unit/parallel.rb -P ./test/lib/test/unit
+wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/lib/test/unit/testcase.rb -P ./test/lib/test/unit
+echo "-- Finish download test/readline --"


### PR DESCRIPTION
Add RubyCore [`test/readline`](https://github.com/ruby/ruby/tree/trunk/test/readline) to CI test.

## Run `rake ci-test` in local

```shell
$ sh ./download-test_readline.sh
$ rake ci-test
```