### PR TITLE
Fix to test tools download path in CI

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,9 +25,9 @@ task test: ENCODING_LIST.keys
 ENCODING_LIST.each_pair do |task_name, encoding|
   Rake::TestTask.new("ci-#{task_name}") do |t|
     t.ruby_opts << %Q{-I. -e "RELINE_TEST_ENCODING=Encoding.find('#{encoding.name}')"}
-    t.libs << 'test'
+    t.libs << 'tool'
     t.libs << 'lib'
-    t.libs << 'test/lib'
+    t.libs << 'tool/lib'
     t.loader = :direct
     t.pattern = 'test/**/test_*.rb'
   end

--- a/download-test_readline.sh
+++ b/download-test_readline.sh
@@ -6,15 +6,15 @@ wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/readline/test_readli
 wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/readline/test_readline_history.rb -P ./test/ext/readline
 mkdir -p ./tool/
 wget https://raw.githubusercontent.com/ruby/ruby/trunk/tool/colorize.rb -P ./tool
-mkdir -p ./test/lib/
-wget https://raw.githubusercontent.com/ruby/ruby/trunk/tool/lib/leakchecker.rb -P ./test/lib
-wget https://raw.githubusercontent.com/ruby/ruby/trunk/tool/lib/envutil.rb -P ./test/lib
-wget https://raw.githubusercontent.com/ruby/ruby/trunk/tool/lib/find_executable.rb -P ./test/lib
-mkdir -p ./test/lib/unit/minitest
-wget https://raw.githubusercontent.com/ruby/ruby/trunk/tool/lib/minitest/unit.rb -P ./test/lib/minitest
-mkdir -p ./test/lib/unit/test
-wget https://raw.githubusercontent.com/ruby/ruby/trunk/tool/lib/test/unit.rb -P ./test/lib/test
-wget https://raw.githubusercontent.com/ruby/ruby/trunk/tool/lib/test/unit/assertions.rb -P ./test/lib/test/unit
-wget https://raw.githubusercontent.com/ruby/ruby/trunk/tool/lib/test/unit/parallel.rb -P ./test/lib/test/unit
-wget https://raw.githubusercontent.com/ruby/ruby/trunk/tool/lib/test/unit/testcase.rb -P ./test/lib/test/unit
+mkdir -p ./tool/lib/
+wget https://raw.githubusercontent.com/ruby/ruby/trunk/tool/lib/leakchecker.rb -P ./tool/lib
+wget https://raw.githubusercontent.com/ruby/ruby/trunk/tool/lib/envutil.rb -P ./tool/lib
+wget https://raw.githubusercontent.com/ruby/ruby/trunk/tool/lib/find_executable.rb -P ./tool/lib
+mkdir -p ./tool/lib/unit/minitest
+wget https://raw.githubusercontent.com/ruby/ruby/trunk/tool/lib/minitest/unit.rb -P ./tool/lib/minitest
+mkdir -p ./tool/lib/unit/test
+wget https://raw.githubusercontent.com/ruby/ruby/trunk/tool/lib/test/unit.rb -P ./tool/lib/test
+wget https://raw.githubusercontent.com/ruby/ruby/trunk/tool/lib/test/unit/assertions.rb -P ./tool/lib/test/unit
+wget https://raw.githubusercontent.com/ruby/ruby/trunk/tool/lib/test/unit/parallel.rb -P ./tool/lib/test/unit
+wget https://raw.githubusercontent.com/ruby/ruby/trunk/tool/lib/test/unit/testcase.rb -P ./tool/lib/test/unit
 echo "-- Finish download test/readline --"

--- a/download-test_readline.sh
+++ b/download-test_readline.sh
@@ -7,14 +7,14 @@ wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/readline/test_readli
 mkdir -p ./tool/
 wget https://raw.githubusercontent.com/ruby/ruby/trunk/tool/colorize.rb -P ./tool
 mkdir -p ./test/lib/
-wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/lib/leakchecker.rb -P ./test/lib
-wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/lib/envutil.rb -P ./test/lib
-wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/lib/find_executable.rb -P ./test/lib
+wget https://raw.githubusercontent.com/ruby/ruby/trunk/tool/lib/leakchecker.rb -P ./test/lib
+wget https://raw.githubusercontent.com/ruby/ruby/trunk/tool/lib/envutil.rb -P ./test/lib
+wget https://raw.githubusercontent.com/ruby/ruby/trunk/tool/lib/find_executable.rb -P ./test/lib
 mkdir -p ./test/lib/unit/minitest
-wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/lib/minitest/unit.rb -P ./test/lib/minitest
+wget https://raw.githubusercontent.com/ruby/ruby/trunk/tool/lib/minitest/unit.rb -P ./test/lib/minitest
 mkdir -p ./test/lib/unit/test
-wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/lib/test/unit.rb -P ./test/lib/test
-wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/lib/test/unit/assertions.rb -P ./test/lib/test/unit
-wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/lib/test/unit/parallel.rb -P ./test/lib/test/unit
-wget https://raw.githubusercontent.com/ruby/ruby/trunk/test/lib/test/unit/testcase.rb -P ./test/lib/test/unit
+wget https://raw.githubusercontent.com/ruby/ruby/trunk/tool/lib/test/unit.rb -P ./test/lib/test
+wget https://raw.githubusercontent.com/ruby/ruby/trunk/tool/lib/test/unit/assertions.rb -P ./test/lib/test/unit
+wget https://raw.githubusercontent.com/ruby/ruby/trunk/tool/lib/test/unit/parallel.rb -P ./test/lib/test/unit
+wget https://raw.githubusercontent.com/ruby/ruby/trunk/tool/lib/test/unit/testcase.rb -P ./test/lib/test/unit
 echo "-- Finish download test/readline --"


### PR DESCRIPTION
Test tools path has changed.
see: https://github.com/ruby/ruby/commit/c3c0e3f5c9444c197779cb242de46dfffda79dec
Fixed download path.