### PR TITLE
Use host_os from RbConfig to detect host OS.

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -14,7 +14,7 @@ module Reline
   FILENAME_COMPLETION_PROC = nil
   USERNAME_COMPLETION_PROC = nil
 
-  if RUBY_PLATFORM =~ /mswin|mingw/
+  if RbConfig::CONFIG['host_os'] =~ /mswin|msys|mingw|cygwin|bccwin|wince|emc/
     IS_WINDOWS = true
   else
     IS_WINDOWS = false


### PR DESCRIPTION
RUBY_PLATFORM on JRuby is always "java", so it will not reflect the host operating system. This regex appears to be the consensus way to detect Windows based on a search of Ruby code on Github:

https://github.com/search?q=%2Fmswin%7Cmsys%7Cmingw%7Ccygwin%7Cbccwin%7Cwince%7Cemc%2F&type=Code

The regex appears to date back to at least 2012, judging by @enebo's comment here: https://stackoverflow.com/questions/11784109/detecting-operating-systems-in-ruby

The "os" gem is mentioned there as well, but probably is overkill (and would also need to be shipped with Ruby).