### PR TITLE
Don't crash when deleting at the end of the line

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -1712,8 +1712,8 @@ class Reline::LineEditor
   end
 
   private def ed_delete_next_char(key, arg: 1)
-    unless @line.empty?
-      byte_size = Reline::Unicode.get_next_mbchar_size(@line, @byte_pointer)
+    byte_size = Reline::Unicode.get_next_mbchar_size(@line, @byte_pointer)
+    unless @line.empty? || byte_size == 0
       @line, mbchar = byteslice!(@line, @byte_pointer, byte_size)
       copy_for_vi(mbchar)
       width = Reline::Unicode.get_mbchar_width(mbchar)

--- a/test/reline/test_key_actor_emacs.rb
+++ b/test/reline/test_key_actor_emacs.rb
@@ -443,6 +443,16 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
     assert_line('abc')
   end
 
+  def test_ed_delete_next_char
+    input_keys('abc')
+    assert_cursor(3)
+    assert_cursor_max(3)
+    @line_editor.input_key(Reline::Key.new(:key_delete, :key_delete, false))
+    assert_cursor(3)
+    assert_cursor_max(3)
+    assert_line('abc')
+  end
+
   def test_em_next_word
     assert_byte_pointer_size('')
     assert_cursor(0)


### PR DESCRIPTION
To reproduce this bug, type one character into irb, then press the
delete key on your keyboard.