### PR TITLE
Fix history navigation in vi_insert mode

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -1279,7 +1279,7 @@ class Reline::LineEditor
         @line = Reline::HISTORY[@history_pointer]
       end
     end
-    if @config.editing_mode_is?(:emacs)
+    if @config.editing_mode_is?(:emacs, :vi_insert)
       @cursor_max = @cursor = calculate_width(@line)
       @byte_pointer = @line.bytesize
     elsif @config.editing_mode_is?(:vi_command)

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -1326,7 +1326,7 @@ class Reline::LineEditor
       end
     end
     @line = '' unless @line
-    if @config.editing_mode_is?(:emacs)
+    if @config.editing_mode_is?(:emacs, :vi_insert)
       @cursor_max = @cursor = calculate_width(@line)
       @byte_pointer = @line.bytesize
     elsif @config.editing_mode_is?(:vi_command)


### PR DESCRIPTION
Previously, `:vi_insert` mode did not match any of the cursor-reset cases when navigating history. This could allow the cursor to go passed the end of the line, for example when going to a previous line, moving the cursor, and then going back to the current empty line. Trying to move the cursor left or right afterwards results in an exception. I couldn't get the arrow key codes working in the tests or I would have added one like:
```ruby
  def test_insert_mode_history
    Reline::HISTORY.concat(%w{abcd 123 AAA})
    assert_line('')
    assert_byte_pointer_size('')
    assert_cursor(0)
    assert_cursor_max(0)
    input_keys("\C-[[A")
    assert_line('AAA')
    assert_byte_pointer_size('')
    assert_cursor(3)
    assert_cursor_max(3)
    input_keys("\C-[[A\C-[[A")
    assert_line('abc')
    assert_byte_pointer_size('')
    assert_cursor(4)
    assert_cursor_max(4)
    input_keys("\C-[[B")
    assert_line('123')
    assert_byte_pointer_size('')
    assert_cursor(3)
    assert_cursor_max(3)
    input_keys("\C-[[D\C-[[B\C-[[B")
    assert_line('')
    assert_byte_pointer_size('')
    assert_cursor(0)
    assert_cursor_max(0)
  end
```