### PR TITLE
Get rid of `IO.select` to fix multiline paste

### DIFF
--- a/lib/reline/ansi.rb
+++ b/lib/reline/ansi.rb
@@ -24,14 +24,7 @@ class Reline::ANSI
     unless @@buf.empty?
       return @@buf.shift
     end
-    c = nil
-    loop do
-      result = select([@@input], [], [], 0.001)
-      next if result.nil?
-      c = @@input.read(1)
-      break
-    end
-    c&.ord
+    @@input.getbyte
   end
 
   def self.ungetc(c)


### PR DESCRIPTION
Pasting multilines at starting up, the pasted input is truncated.

```
irb(main):001:1* def foo
irb(main):002:0> end
=> :foo
def bar
irb(main):003:1* def bar
irb(main):004:1*   [<= no end]
```
