### PR TITLE
Only taint on Ruby <2.7

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -166,7 +166,7 @@ module Reline
       inner_readline(prompt, add_hist, true, &confirm_multiline_termination)
 
       whole_buffer = line_editor.whole_buffer.dup
-      whole_buffer.taint
+      whole_buffer.taint if RUBY_VERSION < '2.7'
       if add_hist and whole_buffer and whole_buffer.chomp.size > 0
         Reline::HISTORY << whole_buffer
       end
@@ -179,7 +179,7 @@ module Reline
       inner_readline(prompt, add_hist, false)
 
       line = line_editor.line.dup
-      line.taint
+      line.taint if RUBY_VERSION < '2.7'
       if add_hist and line and line.chomp.size > 0
         Reline::HISTORY << line.chomp
       end


### PR DESCRIPTION
Ruby 2.7 deprecates taint and it no longer has an effect.