### PR TITLE
Add `shell: cmd`

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -27,6 +27,7 @@ jobs:
     - name: Download test readline
       run: |
         download-test_readline.bat
+      shell: cmd
     - name: Run test
       run: |
         rake ci-test


### PR DESCRIPTION
Use cmd instead of new default shell for `call`.
https://github.blog/changelog/2019-10-17-github-actions-default-shell-on-windows-runners-is-changing-to-powershell/