### PR TITLE
Reline#readline and Reline#readmultiline to private.

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -348,6 +348,7 @@ module Reline
   def_single_delegators :core, :vi_editing_mode, :emacs_editing_mode
   def_single_delegators :core, :readline
   def_instance_delegators self, :readline
+  private :readline
 
 
   #--------------------------------------------------------
@@ -375,6 +376,7 @@ module Reline
 
   def_single_delegators :core, :readmultiline
   def_instance_delegators self, :readmultiline
+  private :readmultiline
 
   def self.core
     @core ||= Core.new { |core|

--- a/test/reline/test_reline.rb
+++ b/test/reline/test_reline.rb
@@ -218,14 +218,14 @@ class Reline::Test < Reline::TestCase
 
   def test_readmultiline
     # readmultiline is module function
-    assert_equal(Reline.methods.include?(:readmultiline), true)
-    assert_equal(Reline.private_instance_methods.include?(:readmultiline), true)
+    assert_equal(true, Reline.methods.include?(:readmultiline))
+    assert_equal(true, Reline.private_instance_methods.include?(:readmultiline))
   end
 
   def test_readline
     # readline is module function
-    assert_equal(Reline.methods.include?(:readline), true)
-    assert_equal(Reline.private_instance_methods.include?(:readline), true)
+    assert_equal(true, Reline.methods.include?(:readline))
+    assert_equal(true, Reline.private_instance_methods.include?(:readline))
   end
 
   def test_inner_readline

--- a/test/reline/test_reline.rb
+++ b/test/reline/test_reline.rb
@@ -217,11 +217,15 @@ class Reline::Test < Reline::TestCase
   end
 
   def test_readmultiline
-    # TODO
+    # readmultiline is module function
+    assert_equal(Reline.methods.include?(:readmultiline), true)
+    assert_equal(Reline.private_instance_methods.include?(:readmultiline), true)
   end
 
   def test_readline
-    # TODO
+    # readline is module function
+    assert_equal(Reline.methods.include?(:readline), true)
+    assert_equal(Reline.private_instance_methods.include?(:readline), true)
   end
 
   def test_inner_readline


### PR DESCRIPTION

## Summary

* `Reline#readline` and `Reline#readmultiline` to `private`
* (`Reline.readline` and `Reline.readmultiline` to `module_function`)


## Steps to reproduce

1. `include Reline`
2. call `#readline` with receiver.

```ruby
class X
  include Reline
end
x = X.new
x.readline
```


## Expected behavior

```ruby
require "reline"

class X
  include Reline
end
x = X.new

# No error: call without receiver
x.instance_eval { readline }

# Error: private method `readline' called for #<X:0x00007f8a049252d0> (NoMethodError)
x.readline
```


## Actual behavior

```ruby
require "reline"

class X
  include Reline
end
x = X.new

# No error: call without receiver
x.instance_eval { readline }

# No error
x.readline
```


## Note

* `Readline#readline` is `private`
* (`Readline.readline` is `module_function`)
* I think `Reline` needs to be compatible with `Readline`
  * `readmultiline` also needs to follow `readline`

```ruby
require "readline"

class X
  include Readline
end
x = X.new

# OK
x.instance_eval { readline }

# Error: private method `readline' called for #<X:0x00007f8a049252d0> (NoMethodError)
x.readline
```

