### PR TITLE
Suppress `stty` error on Apple Terminal

### DIFF
--- a/lib/reline/ansi.rb
+++ b/lib/reline/ansi.rb
@@ -135,7 +135,7 @@ class Reline::ANSI
 
   def self.deprep(otio)
     int_handle = Signal.trap('INT', 'IGNORE')
-    `stty #{otio}`
+    system("stty #{otio}", err: File::NULL)
     Signal.trap('INT', int_handle)
     Signal.trap('WINCH', @@old_winch_handler) if @@old_winch_handler
   end


### PR DESCRIPTION
`stty` called in `Reline::ANSI.deprep` command shows the following error message on macOS Apple Terminal, with some settings.

```
$ LANG=C irb
irb(main):001:0>
stty: 'standard input': unable to perform all requested operations
stty: 'standard input': unable to perform all requested operations
```