### PR TITLE
Change argument `Proc` to `#call` defined object

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -90,22 +90,22 @@ module Reline
     end
 
     def completion_proc=(p)
-      raise ArgumentError unless p.is_a?(Proc)
+      raise ArgumentError unless p.respond_to?(:call)
       @completion_proc = p
     end
 
     def output_modifier_proc=(p)
-      raise ArgumentError unless p.is_a?(Proc)
+      raise ArgumentError unless p.respond_to?(:call)
       @output_modifier_proc = p
     end
 
     def prompt_proc=(p)
-      raise ArgumentError unless p.is_a?(Proc)
+      raise ArgumentError unless p.respond_to?(:call)
       @prompt_proc = p
     end
 
     def auto_indent_proc=(p)
-      raise ArgumentError unless p.is_a?(Proc)
+      raise ArgumentError unless p.respond_to?(:call)
       @auto_indent_proc = p
     end
 
@@ -114,7 +114,7 @@ module Reline
     end
 
     def dig_perfect_match_proc=(p)
-      raise ArgumentError unless p.is_a?(Proc)
+      raise ArgumentError unless p.respond_to?(:call)
       @dig_perfect_match_proc = p
     end
 

--- a/test/reline/test_reline.rb
+++ b/test/reline/test_reline.rb
@@ -2,6 +2,10 @@ require_relative 'helper'
 require "reline"
 
 class Reline::Test < Reline::TestCase
+  class DummyCallbackObject
+    def call; end
+  end
+
   def setup
   end
 
@@ -102,6 +106,10 @@ class Reline::Test < Reline::TestCase
 
     assert_raise(ArgumentError) { Reline.completion_proc = 42 }
     assert_raise(ArgumentError) { Reline.completion_proc = "hoge" }
+
+    dummy = DummyCallbackObject.new
+    Reline.completion_proc = dummy
+    assert_equal(dummy, Reline.completion_proc)
   end
 
   def test_output_modifier_proc
@@ -117,6 +125,10 @@ class Reline::Test < Reline::TestCase
 
     assert_raise(ArgumentError) { Reline.output_modifier_proc = 42 }
     assert_raise(ArgumentError) { Reline.output_modifier_proc = "hoge" }
+
+    dummy = DummyCallbackObject.new
+    Reline.output_modifier_proc = dummy
+    assert_equal(dummy, Reline.output_modifier_proc)
   end
 
   def test_prompt_proc
@@ -132,6 +144,10 @@ class Reline::Test < Reline::TestCase
 
     assert_raise(ArgumentError) { Reline.prompt_proc = 42 }
     assert_raise(ArgumentError) { Reline.prompt_proc = "hoge" }
+
+    dummy = DummyCallbackObject.new
+    Reline.prompt_proc = dummy
+    assert_equal(dummy, Reline.prompt_proc)
   end
 
   def test_auto_indent_proc
@@ -147,6 +163,10 @@ class Reline::Test < Reline::TestCase
 
     assert_raise(ArgumentError) { Reline.auto_indent_proc = 42 }
     assert_raise(ArgumentError) { Reline.auto_indent_proc = "hoge" }
+
+    dummy = DummyCallbackObject.new
+    Reline.auto_indent_proc = dummy
+    assert_equal(dummy, Reline.auto_indent_proc)
   end
 
   def test_pre_input_hook
@@ -174,6 +194,10 @@ class Reline::Test < Reline::TestCase
 
     assert_raise(ArgumentError) { Reline.dig_perfect_match_proc = 42 }
     assert_raise(ArgumentError) { Reline.dig_perfect_match_proc = "hoge" }
+
+    dummy = DummyCallbackObject.new
+    Reline.dig_perfect_match_proc = dummy
+    assert_equal(dummy, Reline.dig_perfect_match_proc)
   end
 
   def test_insert_text


### PR DESCRIPTION
## Summary

Change argument `Proc` to `#call` defined object.
This is the same as the behavior of Readline.

## Expected behavior

```ruby
class DefineCall
  def call; end
end

# OK
Readline.completion_proc = DefineCall.new

# OK
Reline.completion_proc = DefineCall.new
```

## Actual behavior

```ruby
class DefineCall
  def call; end
end

# OK
Readline.completion_proc = DefineCall.new

# Error: ArgumentError
Reline.completion_proc = DefineCall.new
```

## Changed methdos

* `Reline.completion_proc=`
* `Reline.output_modifier_proc=`
* `Reline.prompt_proc=`
* `Reline.auto_indent_proc=`
* `Reline.dig_perfect_match_proc=`
