### PR TITLE
Stop using "bundle exec" for "rake build" and "rake install"

### DIFF
--- a/.github/workflows/ubuntu-rvm-with-irb.yml
+++ b/.github/workflows/ubuntu-rvm-with-irb.yml
@@ -32,8 +32,8 @@ jobs:
     - name: Install reline
       run: |
         source $HOME/.rvm/scripts/rvm
-        bundle exec rake build
-        bundle exec rake install
+        rake build
+        rake install
     - name: Download ruby/irb
       run: |
         git clone https://github.com/ruby/irb


### PR DESCRIPTION
This closes https://github.com/ruby/reline/pull/76.