### PR TITLE
Update CI - Windows, forks, etc

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,12 +1,6 @@
 name: macos
 
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - '*'
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -14,6 +14,7 @@ jobs:
     - name: Download test readline
       run: |
         sh ./download-test_readline.sh
-    - name: Run test
-      run: |
-        rake ci-test
+    - name: rake test
+      run:  rake test
+    - name: rake ci-test
+      run:  rake ci-test

--- a/.github/workflows/ubuntu-rvm-with-irb.yml
+++ b/.github/workflows/ubuntu-rvm-with-irb.yml
@@ -1,12 +1,6 @@
 name: ubuntu-rvm with irb
 
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - '*'
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/ubuntu-rvm.yml
+++ b/.github/workflows/ubuntu-rvm.yml
@@ -1,12 +1,6 @@
 name: ubuntu-rvm
 
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - '*'
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/ubuntu-rvm.yml
+++ b/.github/workflows/ubuntu-rvm.yml
@@ -26,7 +26,11 @@ jobs:
     - name: Download test readline
       run: |
         sh ./download-test_readline.sh
-    - name: Run test
+    - name: rake test
+      run: |
+        source $HOME/.rvm/scripts/rvm
+        bundle exec rake test
+    - name: rake ci-test
       run: |
         source $HOME/.rvm/scripts/rvm
         bundle exec rake ci-test

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,12 +1,6 @@
 name: ubuntu
 
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - '*'
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -21,6 +21,7 @@ jobs:
     - name: Download test readline
       run: |
         sh ./download-test_readline.sh
-    - name: Run test
-      run: |
-        rake ci-test
+    - name: rake test
+      run:  rake test
+    - name: rake ci-test
+      run:  rake ci-test

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,5 +22,7 @@ jobs:
           bundle install
       - name: Download test readline
         run:  ./download-test_readline.ps1
-      - name: Run test
-        run: rake ci-test
+      - name: rake test
+        run:  rake test
+      - name: rake ci-test
+        run:  rake ci-test

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,33 +1,26 @@
 name: windows
 
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - '*'
+on: [push, pull_request]
 
 jobs:
   build:
     runs-on: windows-latest
     strategy:
+      fail-fast: false
       matrix:
-        ruby: [ '2.6.x', '2.5.x' ]
+        ruby: [ '9.9.x', '2.6.x', '2.5.x' ]
     steps:
-    - uses: actions/checkout@master
-    - name: Set up Ruby
-      uses: actions/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby }}
-    - name: Install dependencies
-      run: |
-        gem install bundler --no-document
-        bundle install
-    - name: Download test readline
-      run: |
-        download-test_readline.bat
-      shell: cmd
-    - name: Run test
-      run: |
-        rake ci-test
+      - uses: actions/checkout@master
+      - name: Set up Ruby
+        uses: MSP-Greg/actions-ruby@master
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: Install dependencies
+        if: matrix.ruby != '9.9.x'
+        run: |
+          gem install bundler --no-document --conservative
+          bundle install
+      - name: Download test readline
+        run:  ./download-test_readline.ps1
+      - name: Run test
+        run: rake ci-test

--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,7 @@ ENCODING_LIST.each_pair do |task_name, encoding|
     t.libs << 'test'
     t.libs << 'lib'
     t.loader = :direct
-    t.pattern = 'test/**/test_*.rb'
+    t.pattern = 'test/reline/**/test_*.rb'
   end
 end
 
@@ -29,7 +29,7 @@ ENCODING_LIST.each_pair do |task_name, encoding|
     t.libs << 'lib'
     t.libs << 'tool/lib'
     t.loader = :direct
-    t.pattern = 'test/**/test_*.rb'
+    t.pattern = 'test/ext/**/test_*.rb'
   end
 end
 

--- a/download-test_readline.ps1
+++ b/download-test_readline.ps1
@@ -1,0 +1,45 @@
+<# Copies files from ruby/ruby/test/readline, renames
+   readline.so to readline.no so tests won't run on it
+
+   Note: the file name is not reset using rake or Actions scripts
+#>
+
+$__dir__ = $PSScriptRoot
+
+$wc = $(New-Object System.Net.WebClient)
+
+$ruby_uri = "https://raw.githubusercontent.com/ruby/ruby/master"
+
+function download_files($uri2, $dir, $files) {
+  if ( !(Test-Path -Path "$__dir__/$dir" -PathType Container)) {
+    New-Item -Path "$__dir__/$dir" -ItemType Directory 1> $null
+  }
+  foreach ($file in $files) {
+    try {
+      $wc.DownloadFile("$ruby_uri/$uri2/$file", "$__dir__/$dir/$file")
+    } catch {
+      Write-Host "Can't download $ruby_uri/$uri2/$file"
+      exit 1
+    }
+  }
+}
+
+$files = "helper.rb", "test_readline.rb", "test_readline_history.rb"
+download_files "test/readline" "test/ext/readline" $files
+
+$files = "leakchecker.rb", "envutil.rb", "colorize.rb", "find_executable.rb"
+download_files "tool/lib" "tool/lib" $files
+
+download_files "tool/lib/minitest" "tool/lib/minitest" @("unit.rb")
+download_files "tool/lib/test"     "tool/lib/test"     @("unit.rb")
+
+$files = "assertions.rb", "core_assertions.rb", "parallel.rb", "testcase.rb"
+download_files "tool/lib/test/unit" "tool/lib/test/unit" $files
+
+# below renames readline.so to readline.no
+$archdir = ruby.exe -e "print RbConfig::CONFIG['archdir']"
+$readline_so = "$archdir/readline"
+
+if (Test-Path -Path "$readline_so.so" -PathType leaf) {
+  Rename-Item -Path "$readline_so.so" -NewName "$readline_so.no"
+}


### PR DESCRIPTION
This PR only affects CI.

1. Rework Windows CI -
  1.1 change script that copies ruby/ruby files from a .bat script to a .ps1 script (PowerShell)
  1.2 rename readline.so file
  1.3 use an 'action' that installs current Rubies, versus the old Rubies on Actions.
  1.4 move master/trunk testing to GitHub Actions ('9.9.x')

2. Allow CI to run in forks on branches other than 'master'

3. Split ci-test and test in Rakefile and workflows

Notes:

4. Windows Rubies 2.5 & 2.6 contain a readline.so file, but do not contain the dll they need to load.

5. Left AppVeyor CI as is.

6. To allow Ruby master to always work, it is versioned as '9.9.x' in the workflow matrix, and installed to the 'C:/Ruby99-x64' folder.  When 2.7.0 release is available, I'll update the 'action'.