### PR TITLE
Disable any implementation-defined special control characters

### DIFF
--- a/lib/reline/ansi.rb
+++ b/lib/reline/ansi.rb
@@ -121,15 +121,11 @@ class Reline::ANSI
     retrieve_keybuffer
     int_handle = Signal.trap('INT', 'IGNORE')
     otio = `stty -g`.chomp
-    setting = ' -echo -icrnl cbreak'
+    setting = ' -echo -icrnl cbreak -ixoff -iexten'
     stty = `stty -a`
     if /-parenb\b/ =~ stty
       setting << ' pass8'
     end
-    if /\bdsusp *=/ =~ stty
-      setting << ' dsusp undef'
-    end
-    setting << ' -ixoff'
     `stty #{setting}`
     Signal.trap('INT', int_handle)
     otio


### PR DESCRIPTION
Including dsusp, lnext, and so on.