### PR TITLE
Preserve the input buffer across cursor_pos

### DIFF
--- a/lib/reline/ansi.rb
+++ b/lib/reline/ansi.rb
@@ -60,14 +60,18 @@ class Reline::ANSI
   def self.cursor_pos
     begin
       res = ''
+      m = nil
       @@input.raw do |stdin|
         @@output << "\e[6n"
         @@output.flush
         while (c = stdin.getc) != 'R'
           res << c if c
         end
+        m = res.match(/\e\[(?<row>\d+);(?<column>\d+)/)
+        (m.pre_match + m.post_match).chars.reverse_each do |ch|
+          stdin.ungetc ch
+        end
       end
-      m = res.match(/(?<row>\d+);(?<column>\d+)/)
       column = m[:column].to_i - 1
       row = m[:row].to_i - 1
     rescue Errno::ENOTTY


### PR DESCRIPTION
The old version of cursor_pos discards the input buffer, which made IRB
ignore the input immediately after IRB is invoked.

This change keeps the input before cursor_pos by using ungetc.