### PR TITLE
Use IO#raw to read one byte

### DIFF
--- a/reline.gemspec
+++ b/reline.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = Gem::Requirement.new('>= 2.5')
 
+  spec.add_dependency 'io-console', '~> 0.5'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'test-unit'


### PR DESCRIPTION
Use `IO#raw` to read a byte in raw mode, instead of calling `stty` command.