### PR TITLE
Degenerate the terminal size to [$LINES, $COLUMNS] if it is unknown

### DIFF
--- a/lib/reline/ansi.rb
+++ b/lib/reline/ansi.rb
@@ -50,7 +50,11 @@ class Reline::ANSI
   end
 
   def self.get_screen_size
-    @@input.winsize
+    s = @@input.winsize
+    return s if s[0] > 0 && s[1] > 0
+    s = [ENV["LINES"].to_i, ENV["COLUMNS"].to_i]
+    return s if s[0] > 0 && s[1] > 0
+    [24, 80]
   rescue Errno::ENOTTY
     [24, 80]
   end


### PR DESCRIPTION
This is a workaround for https://github.com/ruby/irb/issues/50