### PR TITLE
Use Ubuntu 16.04 on GitHub Actions

### DIFF
--- a/.github/workflows/ubuntu-rvm-with-irb.yml
+++ b/.github/workflows/ubuntu-rvm-with-irb.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
     strategy:
       matrix:
         ruby: [ 'ruby-head' ]

--- a/.github/workflows/ubuntu-rvm-with-readline.yml
+++ b/.github/workflows/ubuntu-rvm-with-readline.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
     strategy:
       matrix:
         ruby: [ 'ruby-head' ]

--- a/.github/workflows/ubuntu-rvm.yml
+++ b/.github/workflows/ubuntu-rvm.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
     strategy:
       matrix:
         ruby: [ 'ruby-head' ]


### PR DESCRIPTION
GitHub Actions uses RVM binary packages of Travis CI. The packages don't contain ruby-head on Ubuntu 18.04 (ubuntu-latest). Therefore, change the container to Ubuntu 16.04 as a workaround.