### PR TITLE
Bypass cursor down when a char is rendered at eol on Windows

### DIFF
--- a/lib/reline/ansi.rb
+++ b/lib/reline/ansi.rb
@@ -5,6 +5,10 @@ class Reline::ANSI
     Encoding.default_external
   end
 
+  def self.win?
+    false
+  end
+
   RAW_KEYSTROKE_CONFIG = {
     [27, 91, 65] => :ed_prev_history,     # ↑
     [27, 91, 66] => :ed_next_history,     # ↓

--- a/lib/reline/general_io.rb
+++ b/lib/reline/general_io.rb
@@ -5,6 +5,10 @@ class Reline::GeneralIO
     RUBY_PLATFORM =~ /mswin|mingw/ ? Encoding::UTF_8 : Encoding::default_external
   end
 
+  def self.win?
+    false
+  end
+
   RAW_KEYSTROKE_CONFIG = {}
 
   @@buf = []

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -507,12 +507,20 @@ class Reline::LineEditor
     Reline::IOGate.move_cursor_column(0)
     visual_lines.each_with_index do |line, index|
       if line.nil?
-        Reline::IOGate.erase_after_cursor
-        move_cursor_down(1)
-        Reline::IOGate.move_cursor_column(0)
+        if Reline::IOGate.win? and calculate_width(visual_lines[index - 1], true) == Reline::IOGate.get_screen_size.last
+          # A newline is automatically inserted if a character is rendered at eol on command prompt.
+        else
+          Reline::IOGate.erase_after_cursor
+          move_cursor_down(1)
+          Reline::IOGate.move_cursor_column(0)
+        end
         next
       end
       @output.print line
+      if Reline::IOGate.win? and calculate_width(line, true) == Reline::IOGate.get_screen_size.last
+        # A newline is automatically inserted if a character is rendered at eol on command prompt.
+        @rest_height -= 1 if @rest_height > 0
+      end
       @output.flush
       if @first_prompt
         @first_prompt = false

--- a/lib/reline/windows.rb
+++ b/lib/reline/windows.rb
@@ -5,6 +5,10 @@ class Reline::Windows
     Encoding::UTF_8
   end
 
+  def self.win?
+    true
+  end
+
   RAW_KEYSTROKE_CONFIG = {
     [224, 72] => :ed_prev_history, # ↑
     [224, 80] => :ed_next_history, # ↓


### PR DESCRIPTION
A newline is automatically inserted if a character is rendered at eol on Windows command prompt.

This fixes https://github.com/ruby/reline/issues/110.