### PR TITLE
Cope with frozen-string-literal

### DIFF
--- a/lib/reline/ansi.rb
+++ b/lib/reline/ansi.rb
@@ -81,7 +81,7 @@ class Reline::ANSI
 
   def self.cursor_pos
     begin
-      res = ''
+      res = String.new
       m = nil
       @@input.raw do |stdin|
         @@output << "\e[6n"

--- a/lib/reline/ansi.rb
+++ b/lib/reline/ansi.rb
@@ -81,7 +81,7 @@ class Reline::ANSI
 
   def self.cursor_pos
     begin
-      res = String.new
+      res = +''
       m = nil
       @@input.raw do |stdin|
         @@output << "\e[6n"


### PR DESCRIPTION
When running irb 1.2.1 (2019-12-24) with frozen-string-literal enabled, it crashes in reline with `can't modify frozen String (FrozenError)`

Steps to reproduce: 

`RUBYOPT="--enable-frozen-string-literal" irb`