### PR TITLE
Remove gem dependency on io-console

### DIFF
--- a/reline.gemspec
+++ b/reline.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = Gem::Requirement.new('>= 2.5')
 
-  spec.add_dependency 'io-console', '~> 0.5'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'test-unit'


### PR DESCRIPTION
* It's not needed, io/console is part of the standard library.
* Adding this dependency currently prevents to install the gem on JRuby
  and TruffleRuby. It works without this gem dependency.
* Fixes #124 and #95.