### PR TITLE
Ignore non-absolute XDG_CONFIG_HOME

### DIFF
--- a/lib/reline/config.rb
+++ b/lib/reline/config.rb
@@ -94,14 +94,15 @@ class Reline::Config
     home_rc_path = File.expand_path('~/.inputrc')
     return home_rc_path if File.exist?(home_rc_path)
 
-    case ENV['XDG_CONFIG_HOME']
+    case path = ENV['XDG_CONFIG_HOME']
     when nil, ''
-      path = File.expand_path('~/.config/readline/inputrc')
-      return path if File.exist?(path)
     else
-      path = File.expand_path("#{ENV['XDG_CONFIG_HOME']}/readline/inputrc")
-      return path if File.exist?(path)
+      path = File.join(path, 'readline/inputrc')
+      return path if File.exist?(path) and path == File.expand_path(path)
     end
+
+    path = File.expand_path('~/.config/readline/inputrc')
+    return path if File.exist?(path)
 
     return home_rc_path
   end

--- a/test/reline/test_config.rb
+++ b/test/reline/test_config.rb
@@ -213,6 +213,7 @@ class Reline::Config::Test < Reline::TestCase
     assert_nothing_raised do
       @config.read
     end
+  ensure
     ENV['INPUTRC'] = inputrc_backup
   end
 
@@ -221,6 +222,7 @@ class Reline::Config::Test < Reline::TestCase
     expected = "#{@tmpdir}/abcde"
     ENV['INPUTRC'] = expected
     assert_equal expected, @config.inputrc_path
+  ensure
     ENV['INPUTRC'] = inputrc_backup
   end
 
@@ -234,6 +236,7 @@ class Reline::Config::Test < Reline::TestCase
     ENV['HOME'] = @tmpdir
     ENV['XDG_CONFIG_HOME'] = xdg_config_home
     assert_equal expected, @config.inputrc_path
+  ensure
     FileUtils.rm(expected)
     ENV['XDG_CONFIG_HOME'] = xdg_config_home_backup
     ENV['HOME'] = home_backup
@@ -248,6 +251,28 @@ class Reline::Config::Test < Reline::TestCase
     FileUtils.mkdir_p(File.dirname(expected))
     FileUtils.touch(expected)
     assert_equal expected, @config.inputrc_path
+  ensure
+    FileUtils.rm(expected)
+    ENV['XDG_CONFIG_HOME'] = xdg_config_home_backup
+    ENV['HOME'] = home_backup
+  end
+
+  def test_relative_xdg_config_home
+    home_backup = ENV['HOME']
+    xdg_config_home_backup = ENV['XDG_CONFIG_HOME']
+    ENV['HOME'] = @tmpdir
+    expected = File.expand_path('~/.config/readline/inputrc')
+    FileUtils.mkdir_p(File.dirname(expected))
+    FileUtils.touch(expected)
+    result = Dir.chdir(@tmpdir) do
+      xdg_config_home = ".config/example_dir"
+      ENV['XDG_CONFIG_HOME'] = xdg_config_home
+      inputrc = "#{xdg_config_home}/readline/inputrc"
+      FileUtils.mkdir_p(File.dirname(inputrc))
+      FileUtils.touch(inputrc)
+      @config.inputrc_path
+    end
+    assert_equal expected, result
     FileUtils.rm(expected)
     ENV['XDG_CONFIG_HOME'] = xdg_config_home_backup
     ENV['HOME'] = home_backup


### PR DESCRIPTION
https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
> All paths set in these environment variables must be absolute.  If an implementation encounters a relative path in any of these variables it should consider the path invalid and ignore it.