### PR TITLE
Fix history_size behaviours

### DIFF
--- a/lib/reline/config.rb
+++ b/lib/reline/config.rb
@@ -52,7 +52,7 @@ class Reline::Config
     @key_actors[:emacs] = Reline::KeyActor::Emacs.new
     @key_actors[:vi_insert] = Reline::KeyActor::ViInsert.new
     @key_actors[:vi_command] = Reline::KeyActor::ViCommand.new
-    @history_size = 500
+    @history_size = -1 # unlimited
     @keyseq_timeout = 500
     @test_mode = false
   end

--- a/lib/reline/history.rb
+++ b/lib/reline/history.rb
@@ -29,6 +29,8 @@ class Reline::History < Array
   end
 
   def push(*val)
+    # If history_size is zero, all histories are dropped.
+    return self if @config.history_size.zero?
     diff = size + val.size - @config.history_size
     if diff > 0
       if diff <= size
@@ -43,6 +45,8 @@ class Reline::History < Array
   end
 
   def <<(val)
+    # If history_size is zero, all histories are dropped.
+    return self if @config.history_size.zero?
     shift if size + 1 > @config.history_size
     super(String.new(val, encoding: Reline.encoding_system_needs))
   end

--- a/lib/reline/history.rb
+++ b/lib/reline/history.rb
@@ -31,29 +31,45 @@ class Reline::History < Array
   def push(*val)
     # If history_size is zero, all histories are dropped.
     return self if @config.history_size.zero?
-    diff = size + val.size - @config.history_size
-    if diff > 0
-      if diff <= size
-        shift(diff)
-      else
-        diff -= size
-        clear
-        val.shift(diff)
+    # If history_size is negative, history size is unlimited.
+    if @config.history_size.positive?
+      diff = size + val.size - @config.history_size
+      if diff > 0
+        if diff <= size
+          shift(diff)
+        else
+          diff -= size
+          clear
+          val.shift(diff)
+        end
       end
     end
-    super(*(val.map{ |v| String.new(v, encoding: Reline.encoding_system_needs) }))
+    super(*(val.map{ |v|
+      String.new(v, encoding: Reline.encoding_system_needs)
+    }))
   end
 
   def <<(val)
     # If history_size is zero, all histories are dropped.
     return self if @config.history_size.zero?
-    shift if size + 1 > @config.history_size
+    # If history_size is negative, history size is unlimited.
+    if @config.history_size.positive?
+      shift if size + 1 > @config.history_size
+    end
     super(String.new(val, encoding: Reline.encoding_system_needs))
   end
 
   private def check_index(index)
     index += size if index < 0
-    raise RangeError.new("index=<#{index}>") if index < -@config.history_size or @config.history_size < index
+    if index < -2147483648 or 2147483647 < index
+      raise RangeError.new("integer #{index} too big to convert to `int'")
+    end
+    # If history_size is negative, history size is unlimited.
+    if @config.history_size.positive?
+      if index < -@config.history_size or @config.history_size < index
+        raise RangeError.new("index=<#{index}>")
+      end
+    end
     raise IndexError.new("index=<#{index}>") if index < 0 or size <= index
     index
   end

--- a/test/reline/test_history.rb
+++ b/test/reline/test_history.rb
@@ -242,6 +242,16 @@ class Reline::History::Test < Reline::TestCase
     end
   end
 
+  def test_history_size_zero
+    history = history_new(history_size: 0)
+    assert_equal 0, history.size
+    history << 'aa'
+    history << 'bb'
+    assert_equal 0, history.size
+    history.push(*%w{aa bb cc})
+    assert_equal 0, history.size
+  end
+
   private
 
   def history_new(history_size: 10)

--- a/test/reline/test_history.rb
+++ b/test/reline/test_history.rb
@@ -252,6 +252,16 @@ class Reline::History::Test < Reline::TestCase
     assert_equal 0, history.size
   end
 
+  def test_history_size_negative_unlimited
+    history = history_new(history_size: -1)
+    assert_equal 0, history.size
+    history << 'aa'
+    history << 'bb'
+    assert_equal 2, history.size
+    history.push(*%w{aa bb cc})
+    assert_equal 5, history.size
+  end
+
   private
 
   def history_new(history_size: 10)


### PR DESCRIPTION
* Added new items to history are dropped if history_size is zero
* Negative history_size means unlimited
* Unlimited is default

This fixes https://github.com/ruby/reline/issues/138.