### PR TITLE
support vim insert and command mode indicators

### DIFF
--- a/lib/reline/config.rb
+++ b/lib/reline/config.rb
@@ -35,6 +35,9 @@ class Reline::Config
     show-all-if-ambiguous
     show-all-if-unmodified
     visible-stats
+    show-mode-in-prompt
+    vi_cmd_mode_icon
+    vi_ins_mode_icon
   }
   VARIABLE_NAME_SYMBOLS = VARIABLE_NAMES.map { |v| :"#{v.tr(?-, ?_)}" }
   VARIABLE_NAME_SYMBOLS.each do |v|
@@ -247,6 +250,10 @@ class Reline::Config
       end
     when 'keyseq-timeout'
       @keyseq_timeout = value.to_i
+    when 'vi-cmd-mode-string'
+      @vi_cmd_mode_icon = value
+    when 'vi-ins-mode-string'
+      @vi_ins_mode_icon = value
     when *VARIABLE_NAMES then
       variable_name = :"@#{name.tr(?-, ?_)}"
       instance_variable_set(variable_name, value.nil? || value == '1' || value == 'on')

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -74,7 +74,7 @@ class Reline::LineEditor
       prompt = @prompt
     end
     if @prompt_proc
-      prompt_list = @prompt_proc.(buffer)
+      prompt_list = @prompt_proc.(buffer, @prompt, @config)
       prompt_list.map!{ prompt } if @vi_arg or @searching_prompt
       prompt = prompt_list[@line_index]
       prompt_width = calculate_width(prompt, true)


### PR DESCRIPTION
Support vi insert and command mode indicators

This is enabled when in vi-mode and readline config contains

```
set show-mode-in-prompt on
```

The default value is `off`.

The indicators are configured with

- `vi-cmd-mode-string`, defaults to `(cmd)`
- `vi-ins-mode-string`, defaults to `(ins)`

**note**: This breaks the existing behavior of `Reline.prompt_proc` in vi-mode

    Reline.prompt_proc = lambda {}

    => ArgumentError: wrong number of arguments (given 3, expected 0)

The required form is now

    Reline.prompt_proc = lambda { |buffer, prompt, config| ... }

Example

```
$ bundle exec bin/multiline_repl
Multiline REPL.
(ins) prompt> def foo
(ins) prompt>   :bar
(ins) prompt> end
=> :foo
(cmd) prompt>       #  `(ins)` is present here until  `escape` is pressed
```

a sample `.inputrc`

```
set editing-mode vi
set vi-cmd-mode-string 🍸
set vi-ins-mode-string 🍶
set show-mode-in-prompt on
```

## concerns/todo

- I'm not sure how `Reline.prompt_proc` is meant to be used, even after looking at the [tests](https://github.com/ruby/reline/blob/23c67fb7b36bc6baee7863aef1b06c77f6942b98/test/reline/test_reline.rb#L136-L173). It's likely I missed something, and/or that this functionality has been added in the wrong place.
- The config is now being read earlier than before - this was because otherwise, the config would not be loaded for the initial prompt.
- [ ] add tests  - not sure how best to add tests for this