### PR TITLE
Check Errno::EIO

### DIFF
--- a/bin/multiline_repl
+++ b/bin/multiline_repl
@@ -37,4 +37,8 @@ rescue Interrupt
 ensure
   `stty #{stty_save}` if stty_save
 end
-puts
+begin
+  puts
+rescue Errno::EIO
+  # Maybe the I/O has been closed.
+end

--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -243,6 +243,8 @@ module Reline
           break if line_editor.finished?
         end
         Reline::IOGate.move_cursor_column(0)
+      rescue Errno::EIO
+        # Maybe the I/O has been closed.
       rescue StandardError => e
         line_editor.finalize
         Reline::IOGate.deprep(otio)

--- a/lib/reline/ansi.rb
+++ b/lib/reline/ansi.rb
@@ -67,6 +67,9 @@ class Reline::ANSI
     end
     c = @@input.raw(intr: true, &:getbyte)
     (c == 0x16 && @@input.raw(min: 0, tim: 0, &:getbyte)) || c
+  rescue Errno::EIO
+    # Maybe the I/O has been closed.
+    nil
   end
 
   def self.ungetc(c)


### PR DESCRIPTION
Catch `Errno::EIO` what will be occurred if the console terminates I/O before Reline finishes rendering.