### PR TITLE
Support mode icon

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -222,7 +222,6 @@ module Reline
       line_editor.auto_indent_proc = auto_indent_proc
       line_editor.dig_perfect_match_proc = dig_perfect_match_proc
       line_editor.pre_input_hook = pre_input_hook
-      line_editor.rerender
 
       unless config.test_mode
         config.read
@@ -231,6 +230,8 @@ module Reline
           config.add_default_key_binding(key, func)
         end
       end
+
+      line_editor.rerender
 
       begin
         loop do

--- a/lib/reline/config.rb
+++ b/lib/reline/config.rb
@@ -35,6 +35,10 @@ class Reline::Config
     show-all-if-ambiguous
     show-all-if-unmodified
     visible-stats
+    show-mode-in-prompt
+    vi-cmd-mode-icon
+    vi-ins-mode-icon
+    emacs-mode-string
   }
   VARIABLE_NAME_SYMBOLS = VARIABLE_NAMES.map { |v| :"#{v.tr(?-, ?_)}" }
   VARIABLE_NAME_SYMBOLS.each do |v|
@@ -52,6 +56,9 @@ class Reline::Config
     @key_actors[:emacs] = Reline::KeyActor::Emacs.new
     @key_actors[:vi_insert] = Reline::KeyActor::ViInsert.new
     @key_actors[:vi_command] = Reline::KeyActor::ViCommand.new
+    @vi_cmd_mode_icon = '(cmd)'
+    @vi_ins_mode_icon = '(ins)'
+    @emacs_mode_string = '@'
     # https://tiswww.case.edu/php/chet/readline/readline.html#IDX25
     @history_size = -1 # unlimited
     @keyseq_timeout = 500
@@ -253,6 +260,21 @@ class Reline::Config
       end
     when 'keyseq-timeout'
       @keyseq_timeout = value.to_i
+    when 'show-mode-in-prompt'
+      case value
+      when 'off'
+        @show_mode_in_prompt = false
+      when 'on'
+        @show_mode_in_prompt = true
+      else
+        @show_mode_in_prompt = false
+      end
+    when 'vi-cmd-mode-string'
+      @vi_cmd_mode_icon = value
+    when 'vi-ins-mode-string'
+      @vi_ins_mode_icon = value
+    when 'emacs-mode-string'
+      @emacs_mode_string = value
     when *VARIABLE_NAMES then
       variable_name = :"@#{name.tr(?-, ?_)}"
       instance_variable_set(variable_name, value.nil? || value == '1' || value == 'on')

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -76,11 +76,35 @@ class Reline::LineEditor
     if @prompt_proc
       prompt_list = @prompt_proc.(buffer)
       prompt_list.map!{ prompt } if @vi_arg or @searching_prompt
+      if @config.show_mode_in_prompt
+        if @config.editing_mode_is?(:vi_command)
+          mode_icon = @config.vi_cmd_mode_icon
+        elsif @config.editing_mode_is?(:vi_insert)
+          mode_icon = @config.vi_ins_mode_icon
+        elsif @config.editing_mode_is?(:emacs)
+          mode_icon = @config.emacs_mode_string
+        else
+          mode_icon = '?'
+        end
+        prompt_list.map!{ |pr| mode_icon + pr }
+      end
       prompt = prompt_list[@line_index]
       prompt_width = calculate_width(prompt, true)
       [prompt, prompt_width, prompt_list]
     else
       prompt_width = calculate_width(prompt, true)
+      if @config.show_mode_in_prompt
+        if @config.editing_mode_is?(:vi_command)
+          mode_icon = @config.vi_cmd_mode_icon
+        elsif @config.editing_mode_is?(:vi_insert)
+          mode_icon = @config.vi_ins_mode_icon
+        elsif @config.editing_mode_is?(:emacs)
+          mode_icon = @config.emacs_mode_string
+        else
+          mode_icon = '?'
+        end
+        prompt = mode_icon + prompt
+      end
       [prompt, prompt_width, nil]
     end
   end

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -81,6 +81,40 @@ begin
         prompt>
       EOC
     end
+
+    def test_mode_icon_emacs
+      File.open(@inputrc_file, 'w') do |f|
+        f.write <<~LINES
+          set show-mode-in-prompt on
+        LINES
+      end
+      start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/bin/multiline_repl})
+      sleep 0.5
+      close
+      assert_screen(<<~EOC)
+        Multiline REPL.
+        @prompt>
+      EOC
+    end
+
+    def test_mode_icon_vi
+      File.open(@inputrc_file, 'w') do |f|
+        f.write <<~LINES
+          set editing-mode vi
+          set show-mode-in-prompt on
+        LINES
+      end
+      start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/bin/multiline_repl})
+      sleep 0.5
+      write(":a\n\C-[k")
+      close
+      assert_screen(<<~EOC)
+        Multiline REPL.
+        (ins)prompt> :a
+        => :a
+        (cmd)prompt> :a
+      EOC
+    end
   end
 rescue LoadError, NameError
   # On Ruby repository, this test suit doesn't run because Ruby repo doesn't


### PR DESCRIPTION
This Pull Request is based on https://github.com/ruby/reline/pull/148 and the author of the commit is @jethrodaniel.

I enhanced the original commit by some points:

- Support "on/off" by `show-mode-in-prompt`
- Use a better way to fix complicated rendering and reading config steps
- Add tests by [yamatanooroti gem](https://rubygems.org/gems/yamatanooroti)
- And other small fixes

Previously, only internal state testing was done, but it wasn't possible to test for prompts because prompts are generated in the final rendering step. I developed yamatanooroti gem to test the rendering steps but it had some bugs, so [yamatanooroti test](https://github.com/ruby/reline/blob/d07601d54e08735c0a4c2ca8080f1d99cb507664/.github/workflows/reline.yml#L110-L111) was failing in CI. I fixed them:

- https://github.com/ruby/reline/pull/151
- https://github.com/ruby/reline/pull/152
- https://github.com/ruby/reline/pull/155

@jethrodaniel Thank you for your great original Pull Request. I'll merge this and release a new version of Reline later.

This closes https://github.com/ruby/reline/pull/148.