### PR TITLE
Fix cursor_pos error: `undefined method `pre_match' for nil:NilClass`

### DIFF
--- a/lib/reline/ansi.rb
+++ b/lib/reline/ansi.rb
@@ -112,10 +112,11 @@ class Reline::ANSI
       @@input.raw do |stdin|
         @@output << "\e[6n"
         @@output.flush
-        while (c = stdin.getc) != 'R'
-          res << c if c
+        while (c = stdin.getc)
+          res << c
+          m = res.match(/\e\[(?<row>\d+);(?<column>\d+)R/)
+          break if m
         end
-        m = res.match(/\e\[(?<row>\d+);(?<column>\d+)/)
         (m.pre_match + m.post_match).chars.reverse_each do |ch|
           stdin.ungetc ch
         end


### PR DESCRIPTION
```txt
/opt/ruby/lib/ruby/2.8.0/reline/ansi.rb:112:in `block in cursor_pos': undefined method `pre_match' for nil:NilClass (NoMethodError)
```

### Reproduce 1:
Type `irb\nRubyVM[tab][tab]` quickly (type R before irb prompt is shown)
```shell
% irb
RubyVM[tab]
```

### Reproduce 2:
Paste long code that includes `R`
`irb(main):001:0> 10.times{RRRRRRRRRRRRRRRRRRRRRR...`
then resize window before paste completes.
