### PR TITLE
IRB cause NoMethodError with clrl+L on windows.

### DIFF
--- a/lib/reline/windows.rb
+++ b/lib/reline/windows.rb
@@ -250,15 +250,17 @@ class Reline::Windows
   end
 
   def self.clear_screen
-    coord_screen_top_left = 0
-    written = 0.chr * 4
     csbi = 0.chr * 22
     return if @@GetConsoleScreenBufferInfo.call(@@hConsoleHandle, csbi) == 0
-    con_size = csbi[0, 4].unpack('SS').inject(:*)
+    buffer_width = csbi[0, 2].unpack('S').first
     attributes = csbi[8, 2].unpack('S').first
-    @@FillConsoleOutputCharacter.call(@@hConsoleHandle, 0x20, con_size, coord_screen_top_left, written)
-    @@FillConsoleOutputAttribute.call(@@hConsoleHandle, attributes, con_size, coord_screen_top_left, written)
-    @@SetConsoleCursorPosition.call(@@hConsoleHandle, coord_screen_top_left)
+    window_left, window_top, window_right, window_bottom = *csbi[10,8].unpack('S*')
+    fill_length = buffer_width * (window_bottom - window_top + 1)
+    screen_topleft = window_top * 65536
+    written = 0.chr * 4
+    @@FillConsoleOutputCharacter.call(@@hConsoleHandle, 0x20, fill_length, screen_topleft, written)
+    @@FillConsoleOutputAttribute.call(@@hConsoleHandle, attributes, fill_length, screen_topleft, written)
+    @@SetConsoleCursorPosition.call(@@hConsoleHandle, screen_topleft)
   end
 
   def self.set_screen_size(rows, columns)


### PR DESCRIPTION
I like ctrl+L, but not work with RubyInstaller for Windows 2.7.1-1.
```irb(main):001:0> Traceback (most recent call last):
        31: from ./irb:23:in `<main>'
        30: from ./irb:23:in `load'
        29: from C:/Ruby27-x64/lib/ruby/gems/2.7.0/gems/irb-1.2.3/exe/irb:11:in `<top (required)>'
        28: from C:/Ruby27-x64/lib/ruby/2.7.0/irb.rb:399:in `start'
        27: from C:/Ruby27-x64/lib/ruby/2.7.0/irb.rb:470:in `run'
        26: from C:/Ruby27-x64/lib/ruby/2.7.0/irb.rb:470:in `catch'
        25: from C:/Ruby27-x64/lib/ruby/2.7.0/irb.rb:471:in `block in run'
        24: from C:/Ruby27-x64/lib/ruby/2.7.0/irb.rb:536:in `eval_input'
        23: from C:/Ruby27-x64/lib/ruby/2.7.0/irb/ruby-lex.rb:134:in `each_top_level_statement'
        22: from C:/Ruby27-x64/lib/ruby/2.7.0/irb/ruby-lex.rb:134:in `catch'
        21: from C:/Ruby27-x64/lib/ruby/2.7.0/irb/ruby-lex.rb:135:in `block in each_top_level_statement'
        20: from C:/Ruby27-x64/lib/ruby/2.7.0/irb/ruby-lex.rb:135:in `loop'
        19: from C:/Ruby27-x64/lib/ruby/2.7.0/irb/ruby-lex.rb:138:in `block (2 levels) in each_top_level_statement'
        18: from C:/Ruby27-x64/lib/ruby/2.7.0/irb/ruby-lex.rb:166:in `lex'
        17: from C:/Ruby27-x64/lib/ruby/2.7.0/irb.rb:517:in `block in eval_input'
        16: from C:/Ruby27-x64/lib/ruby/2.7.0/irb.rb:695:in `signal_status'
        15: from C:/Ruby27-x64/lib/ruby/2.7.0/irb.rb:518:in `block (2 levels) in eval_input'
        14: from C:/Ruby27-x64/lib/ruby/2.7.0/irb/input-method.rb:262:in `gets'
        13: from C:/Ruby27-x64/lib/ruby/2.7.0/forwardable.rb:235:in `readmultiline'
        12: from C:/Ruby27-x64/lib/ruby/2.7.0/forwardable.rb:235:in `readmultiline'
        11: from C:/Ruby27-x64/lib/ruby/2.7.0/reline.rb:174:in `readmultiline'
        10: from C:/Ruby27-x64/lib/ruby/2.7.0/reline.rb:236:in `inner_readline'
         9: from C:/Ruby27-x64/lib/ruby/2.7.0/reline.rb:236:in `loop'
         8: from C:/Ruby27-x64/lib/ruby/2.7.0/reline.rb:237:in `block in inner_readline'
         7: from C:/Ruby27-x64/lib/ruby/2.7.0/reline.rb:266:in `read_io'
         6: from C:/Ruby27-x64/lib/ruby/2.7.0/reline.rb:266:in `loop'
         5: from C:/Ruby27-x64/lib/ruby/2.7.0/reline.rb:307:in `block in read_io'
         4: from C:/Ruby27-x64/lib/ruby/2.7.0/reline.rb:238:in `block (2 levels) in inner_readline'
         3: from C:/Ruby27-x64/lib/ruby/2.7.0/reline.rb:238:in `each'
         2: from C:/Ruby27-x64/lib/ruby/2.7.0/reline.rb:240:in `block (3 levels) in inner_readline'
         1: from C:/Ruby27-x64/lib/ruby/2.7.0/reline/line_editor.rb:332:in `rerender'
C:/Ruby27-x64/lib/ruby/2.7.0/reline/windows.rb:253:in `clear_screen': undefined method `write' for Reline::Windows:Class (NoMethodError)
```

commented as `# TODO: Use FillConsoleOutputCharacter and FillConsoleOutputAttribute`, so I try it.
It seems to work for me on command prompt, Windows Terminal, Git Bash(MSYS2 Terminal with winpty).