### PR TITLE
Use the standard SPDX ID for license in gemspec

### DIFF
--- a/reline.gemspec
+++ b/reline.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{Alternative GNU Readline or Editline implementation by pure Ruby.}
   spec.description   = %q{Alternative GNU Readline or Editline implementation by pure Ruby.}
   spec.homepage      = 'https://github.com/ruby/reline'
-  spec.license       = 'Ruby License'
+  spec.license       = 'Ruby'
 
   spec.files         = Dir['BSDL', 'COPYING', 'README.md', 'lib/**/*']
   spec.require_paths = ['lib']


### PR DESCRIPTION
It is better to use SPDX ID for license field:

https://guides.rubygems.org/specification-reference/#license=

ref: https://spdx.org/licenses/Ruby.html