### PR TITLE
Stop using chomp option of lines method

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -538,7 +538,7 @@ class Reline::LineEditor
     return before if before.nil? || before.empty?
 
     if after = @output_modifier_proc&.call("#{before.join("\n")}\n", complete: finished?)
-      after.lines("\n", chomp: true)
+      after.lines("\n").map { |l| l.chomp('') }
     else
       before
     end


### PR DESCRIPTION
Workaround for https://github.com/ruby/reline/issues/165.