### PR TITLE
Suppress callbacks in pasting

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -235,13 +235,19 @@ module Reline
       line_editor.rerender
 
       begin
+        prev_pasting_state = false
         loop do
+          prev_pasting_state = Reline::IOGate.in_pasting?
           read_io(config.keyseq_timeout) { |inputs|
             inputs.each { |c|
               line_editor.input_key(c)
               line_editor.rerender
             }
           }
+          if prev_pasting_state == true and not Reline::IOGate.in_pasting? and not line_editor.finished?
+            prev_pasting_state = false
+            line_editor.rerender_all
+          end
           break if line_editor.finished?
         end
         Reline::IOGate.move_cursor_column(0)

--- a/lib/reline/ansi.rb
+++ b/lib/reline/ansi.rb
@@ -80,6 +80,22 @@ class Reline::ANSI
     nil
   end
 
+  def self.in_pasting?
+    not Reline::IOGate.empty_buffer?
+  end
+
+  def self.empty_buffer?
+    unless @@buf.empty?
+      return false
+    end
+    rs, = IO.select([@@input], [], [], 0.00001)
+    if rs and rs[0]
+      false
+    else
+      true
+    end
+  end
+
   def self.ungetc(c)
     @@buf.unshift(c)
   end

--- a/lib/reline/general_io.rb
+++ b/lib/reline/general_io.rb
@@ -67,6 +67,10 @@ class Reline::GeneralIO
   def self.set_winch_handler(&handler)
   end
 
+  def self.in_pasting?
+    false
+  end
+
   def self.prep
   end
 

--- a/lib/reline/windows.rb
+++ b/lib/reline/windows.rb
@@ -199,6 +199,20 @@ class Reline::Windows
     @@output_buf.unshift(c)
   end
 
+  def self.in_pasting?
+    not self.empty_buffer?
+  end
+
+  def self.empty_buffer?
+    if not @@input_buf.empty?
+      false
+    elsif @@kbhit.call == 0
+      true
+    else
+      false
+    end
+  end
+
   def self.get_screen_size
     csbi = 0.chr * 22
     @@GetConsoleScreenBufferInfo.call(@@hConsoleHandle, csbi)


### PR DESCRIPTION
IRB uses Reline's 3 dynamic real-time callbacks with calling Ripper; `output_modifier_proc`, `prompt_proc`, and `auto_indent_proc`. These processing times make the paste time too long.

Before:

![before](https://user-images.githubusercontent.com/1404325/96523732-736d8200-12b1-11eb-8714-1d3e6d6afcbf.gif)

Needs 16 seconds to paste the code of ruby/reline#74.

After:

![after](https://user-images.githubusercontent.com/1404325/96525939-402df180-12b7-11eb-9122-441728fc0187.gif)

About 2 seconds.

ref. https://github.com/ruby/irb/issues/43, https://github.com/ruby/reline/pull/184