### PR TITLE
Backspace and C-h should be unassigned on vi command mode

### DIFF
--- a/lib/reline/key_actor/vi_command.rb
+++ b/lib/reline/key_actor/vi_command.rb
@@ -17,7 +17,7 @@ class Reline::KeyActor::ViCommand < Reline::KeyActor::Base
     #   7 ^G
     :ed_unassigned,
     #   8 ^H
-    :ed_delete_prev_char,
+    :ed_unassigned,
     #   9 ^I
     :ed_unassigned,
     #  10 ^J
@@ -255,7 +255,7 @@ class Reline::KeyActor::ViCommand < Reline::KeyActor::Base
     # 126 ~
     :vi_change_case,
     # 127 ^?
-    :ed_delete_prev_char,
+    :ed_unassigned,
     # 128 M-^@
     :ed_unassigned,
     # 129 M-^A


### PR DESCRIPTION
This closes https://github.com/ruby/reline/issues/192.