### PR TITLE
Keep operator proc as a local variable in the scope

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -706,12 +706,13 @@ class Reline::LineEditor
         else
           old_waiting_proc = @waiting_proc
           old_waiting_operator_proc = @waiting_operator_proc
+          current_waiting_operator_proc = @waiting_operator_proc
           @waiting_proc = proc { |k|
             old_cursor, old_byte_pointer = @cursor, @byte_pointer
             old_waiting_proc.(k)
             cursor_diff, byte_pointer_diff = @cursor - old_cursor, @byte_pointer - old_byte_pointer
             @cursor, @byte_pointer = old_cursor, old_byte_pointer
-            @waiting_operator_proc.(cursor_diff, byte_pointer_diff)
+            current_waiting_operator_proc.(cursor_diff, byte_pointer_diff)
             @waiting_operator_proc = old_waiting_operator_proc
           }
         end

--- a/test/reline/test_key_actor_vi.rb
+++ b/test/reline/test_key_actor_vi.rb
@@ -1215,6 +1215,19 @@ class Reline::KeyActor::ViInsert::Test < Reline::TestCase
     assert_line('aaa ddd eee')
   end
 
+  def test_vi_delete_meta_with_vi_next_char
+    input_keys("aaa bbb ccc ___ ddd\C-[02w")
+    assert_byte_pointer_size('aaa bbb ')
+    assert_cursor(8)
+    assert_cursor_max(19)
+    assert_line('aaa bbb ccc ___ ddd')
+    input_keys('df_')
+    assert_byte_pointer_size('aaa bbb ')
+    assert_cursor(8)
+    assert_cursor_max(15)
+    assert_line('aaa bbb ___ ddd')
+  end
+
   def test_vi_change_meta
     input_keys("aaa bbb ccc ddd eee\C-[02w")
     assert_byte_pointer_size('aaa bbb ')


### PR DESCRIPTION
The proc variable will be used later so the instance variable will be changes.

This closes https://github.com/ruby/reline/issues/188.