### PR TITLE
Unimplemented vi command should be no-op

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -770,7 +770,7 @@ class Reline::LineEditor
         elsif method_obj
           wrap_method_call(method_symbol, method_obj, key)
         else
-          ed_insert(key)
+          ed_insert(key) unless @config.editing_mode_is?(:vi_command)
         end
         @kill_ring.process
         @vi_arg = nil
@@ -788,7 +788,7 @@ class Reline::LineEditor
       end
       @kill_ring.process
     else
-      ed_insert(key)
+      ed_insert(key) unless @config.editing_mode_is?(:vi_command)
     end
   end
 

--- a/test/reline/test_key_actor_vi.rb
+++ b/test/reline/test_key_actor_vi.rb
@@ -1237,4 +1237,17 @@ class Reline::KeyActor::ViInsert::Test < Reline::TestCase
     assert_cursor_max(16)
     assert_line('aaa bbb  ddd eee')
   end
+
+  def test_unimplemented_vi_command_should_be_no_op
+    input_keys("abc\C-[h")
+    assert_byte_pointer_size('a')
+    assert_cursor(1)
+    assert_cursor_max(3)
+    assert_line('abc')
+    input_keys('@')
+    assert_byte_pointer_size('a')
+    assert_cursor(1)
+    assert_cursor_max(3)
+    assert_line('abc')
+  end
 end


### PR DESCRIPTION
This closes https://github.com/ruby/reline/issues/191.