### PR TITLE
Fix crash to input `é`

### DIFF
--- a/lib/reline/unicode.rb
+++ b/lib/reline/unicode.rb
@@ -89,6 +89,9 @@ class Reline::Unicode
     | #{ EastAsianWidth::TYPE_NA }
     | #{ EastAsianWidth::TYPE_N }
     )
+  | (?<ambiguous_width>
+      #{EastAsianWidth::TYPE_A}
+    )
   /x
 
   def self.get_mbchar_width(mbchar)
@@ -98,6 +101,7 @@ class Reline::Unicode
     when m[:width_3] then 3
     when m[:width_0] then 0
     when m[:width_1] then 1
+    when m[:ambiguous_width] then Reline.ambiguous_width
     else
       nil
     end

--- a/test/reline/test_unicode.rb
+++ b/test/reline/test_unicode.rb
@@ -1,0 +1,12 @@
+require_relative 'helper'
+require "reline/unicode"
+
+class Reline::Unicode::Test < Reline::TestCase
+  def setup
+    Reline.send(:test_mode)
+  end
+
+  def test_get_mbchar_width
+    assert_equal Reline.ambiguous_width, Reline::Unicode.get_mbchar_width('é')
+  end
+end


### PR DESCRIPTION
Fix #174.
This is because [`Reline.ambiguous_width` case was removed here](https://github.com/ruby/reline/commit/e36f6c070784b972955f490f71d3af9df125b8f5#diff-a29767a3bb4f901d7224743024c7734d625b5b2c3e62a892140d93c27866e218L84). (Thanks @ima1zumi :)
