### PR TITLE
Fixed an exception occurred when ambiguous width character was passed to `#calculate_width` [Bug #17405]

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -36,7 +36,6 @@ module Reline
     attr_accessor :config
     attr_accessor :key_stroke
     attr_accessor :line_editor
-    attr_writer :ambiguous_width
     attr_accessor :last_incremental_search
     attr_reader :output
 

--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -36,7 +36,7 @@ module Reline
     attr_accessor :config
     attr_accessor :key_stroke
     attr_accessor :line_editor
-    attr_accessor :ambiguous_width
+    attr_writer :ambiguous_width
     attr_accessor :last_incremental_search
     attr_reader :output
 
@@ -356,9 +356,14 @@ module Reline
       end
     end
 
+    def ambiguous_width
+      may_req_ambiguous_char_width unless defined? @ambiguous_width
+      @ambiguous_width
+    end
+
     private def may_req_ambiguous_char_width
       @ambiguous_width = 2 if Reline::IOGate == Reline::GeneralIO or STDOUT.is_a?(File)
-      return if ambiguous_width
+      return if @ambiguous_width
       Reline::IOGate.move_cursor_column(0)
       begin
         output.write "\u{25bd}"

--- a/test/reline/test_unicode.rb
+++ b/test/reline/test_unicode.rb
@@ -9,4 +9,8 @@ class Reline::Unicode::Test < Reline::TestCase
   def test_get_mbchar_width
     assert_equal Reline.ambiguous_width, Reline::Unicode.get_mbchar_width('é')
   end
+
+  def test_ambiguous_width
+    assert_equal 2, Reline::Unicode.calculate_width('√', true)
+  end
 end


### PR DESCRIPTION
Fix : https://bugs.ruby-lang.org/issues/17405

steps to reproduce a bug
`test.rb`
```ruby
require "reline"

p Reline::Unicode.calculate_width("√")
```

```
❯ ruby -v           
ruby 3.0.0rc1 (2020-12-20 master 8680ae9cbd) [x86_64-darwin19]

❯ ruby test.rb
/Users/mi/.rbenv/versions/3.0.0-rc1/lib/ruby/3.0.0/reline/unicode.rb:136:in `+': nil can't be coerced into Integer (TypeError)
	from /Users/mi/.rbenv/versions/3.0.0-rc1/lib/ruby/3.0.0/reline/unicode.rb:136:in `block in calculate_width'
	from /Users/mi/.rbenv/versions/3.0.0-rc1/lib/ruby/3.0.0/reline/unicode.rb:126:in `scan'
	from /Users/mi/.rbenv/versions/3.0.0-rc1/lib/ruby/3.0.0/reline/unicode.rb:126:in `calculate_width'
	from ./reline/test.rb:5:in `<main>'
```

Thanks @osyo-manga 😄 