### PR TITLE
Support isearch-terminators

### DIFF
--- a/lib/reline/config.rb
+++ b/lib/reline/config.rb
@@ -38,6 +38,7 @@ class Reline::Config
     vi-ins-mode-icon
     emacs-mode-string
     enable-bracketed-paste
+    isearch-terminators
   }
   VARIABLE_NAME_SYMBOLS = VARIABLE_NAMES.map { |v| :"#{v.tr(?-, ?_)}" }
   VARIABLE_NAME_SYMBOLS.each do |v|
@@ -238,7 +239,7 @@ class Reline::Config
     when 'completion-query-items'
       @completion_query_items = value.to_i
     when 'isearch-terminators'
-      @isearch_terminators = instance_eval(value)
+      @isearch_terminators = retrieve_string(value)
     when 'editing-mode'
       case value
       when 'emacs'

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -1593,9 +1593,11 @@ class Reline::LineEditor
     searcher = generate_searcher
     searcher.resume(key)
     @searching_prompt = "(reverse-i-search)`': "
+    termination_keys = ["\C-j".ord]
+    termination_keys.concat(@config.isearch_terminators&.chars&.map(&:ord)) if @config.isearch_terminators
     @waiting_proc = ->(k) {
       case k
-      when "\C-j".ord
+      when *termination_keys
         if @history_pointer
           buffer = Reline::HISTORY[@history_pointer]
         else

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -1614,6 +1614,8 @@ class Reline::LineEditor
         @waiting_proc = nil
         @cursor_max = calculate_width(@line)
         @cursor = @byte_pointer = 0
+        @rerender_all = true
+        @cached_prompt_list = nil
         searcher.resume(-1)
       when "\C-g".ord
         if @is_multiline
@@ -1657,6 +1659,8 @@ class Reline::LineEditor
           @waiting_proc = nil
           @cursor_max = calculate_width(@line)
           @cursor = @byte_pointer = 0
+          @rerender_all = true
+          @cached_prompt_list = nil
           searcher.resume(-1)
         end
       end

--- a/test/reline/test_key_actor_emacs.rb
+++ b/test/reline/test_key_actor_emacs.rb
@@ -1894,6 +1894,36 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
     assert_cursor_max(0)
   end
 
+  def test_search_history_with_isearch_terminator
+    @config.read_lines(<<~LINES.split(/(?<=\n)/))
+      set isearch-terminators "XYZ"
+    LINES
+    Reline::HISTORY.concat([
+      '1235', # old
+      '12aa',
+      '1234' # new
+    ])
+    assert_line('')
+    assert_byte_pointer_size('')
+    assert_cursor(0)
+    assert_cursor_max(0)
+    input_keys("\C-r12a")
+    assert_line('12aa')
+    assert_byte_pointer_size('')
+    assert_cursor(0)
+    assert_cursor_max(0) # doesn't determine yet
+    input_keys('Y')
+    assert_line('12aa')
+    assert_byte_pointer_size('')
+    assert_cursor(0)
+    assert_cursor_max(4)
+    input_keys('x')
+    assert_line('x12aa')
+    assert_byte_pointer_size('x')
+    assert_cursor(1)
+    assert_cursor_max(5)
+  end
+
   def test_em_set_mark_and_em_exchange_mark
     input_keys('aaa bbb ccc ddd')
     assert_byte_pointer_size('aaa bbb ccc ddd')

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -399,6 +399,17 @@ begin
       EOC
     end
 
+    def test_multiline_incremental_search_finish
+      start_terminal(6, 25, %W{ruby -I#{@pwd}/lib #{@pwd}/bin/multiline_repl}, startup_message: 'Multiline REPL.')
+      write("def a\n  8\nend\ndef b\n  3\nend\C-r8\C-j")
+      close
+      assert_screen(<<~EOC)
+        prompt> def a
+        prompt>   8
+        prompt> end
+      EOC
+    end
+
     def test_binding_for_vi_movement_mode
       write_inputrc <<~LINES
         set editing-mode vi


### PR DESCRIPTION
This closes https://github.com/ruby/reline/issues/81.