### PR TITLE
Discard prompt cache by changing mode icon

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -68,6 +68,26 @@ class Reline::LineEditor
     end
   end
 
+  private def check_mode_icon
+    mode_icon = nil
+    if @config.show_mode_in_prompt
+      if @config.editing_mode_is?(:vi_command)
+        mode_icon = @config.vi_cmd_mode_icon
+      elsif @config.editing_mode_is?(:vi_insert)
+        mode_icon = @config.vi_ins_mode_icon
+      elsif @config.editing_mode_is?(:emacs)
+        mode_icon = @config.emacs_mode_string
+      else
+        mode_icon = '?'
+      end
+    end
+    if mode_icon != @prev_mode_icon
+      @rerender_all = true
+    end
+    @prev_mode_icon = mode_icon
+    mode_icon
+  end
+
   private def check_multiline_prompt(buffer, prompt)
     if @vi_arg
       prompt = "(arg: #{@vi_arg}) "
@@ -78,7 +98,11 @@ class Reline::LineEditor
     else
       prompt = @prompt
     end
-    return [prompt, calculate_width(prompt, true), [prompt] * buffer.size] if simplified_rendering?
+    if simplified_rendering?
+      mode_icon = check_mode_icon
+      prompt = mode_icon + prompt if mode_icon
+      return [prompt, calculate_width(prompt, true), [prompt] * buffer.size]
+    end
     if @prompt_proc
       use_cached_prompt_list = false
       if @cached_prompt_list
@@ -95,35 +119,15 @@ class Reline::LineEditor
         @prompt_cache_time = Time.now.to_f
       end
       prompt_list.map!{ prompt } if @vi_arg or @searching_prompt
-      if @config.show_mode_in_prompt
-        if @config.editing_mode_is?(:vi_command)
-          mode_icon = @config.vi_cmd_mode_icon
-        elsif @config.editing_mode_is?(:vi_insert)
-          mode_icon = @config.vi_ins_mode_icon
-        elsif @config.editing_mode_is?(:emacs)
-          mode_icon = @config.emacs_mode_string
-        else
-          mode_icon = '?'
-        end
-        prompt_list.map!{ |pr| mode_icon + pr }
-      end
+      mode_icon = check_mode_icon
+      prompt_list = prompt_list.map{ |pr| mode_icon + pr } if mode_icon
       prompt = prompt_list[@line_index]
       prompt_width = calculate_width(prompt, true)
       [prompt, prompt_width, prompt_list]
     else
+      mode_icon = check_mode_icon
+      prompt = mode_icon + prompt if mode_icon
       prompt_width = calculate_width(prompt, true)
-      if @config.show_mode_in_prompt
-        if @config.editing_mode_is?(:vi_command)
-          mode_icon = @config.vi_cmd_mode_icon
-        elsif @config.editing_mode_is?(:vi_insert)
-          mode_icon = @config.vi_ins_mode_icon
-        elsif @config.editing_mode_is?(:emacs)
-          mode_icon = @config.emacs_mode_string
-        else
-          mode_icon = '?'
-        end
-        prompt = mode_icon + prompt
-      end
       [prompt, prompt_width, nil]
     end
   end
@@ -213,6 +217,7 @@ class Reline::LineEditor
     @eof = false
     @continuous_insertion_buffer = String.new(encoding: @encoding)
     @scroll_partial_screen = nil
+    @prev_mode_icon = nil
     reset_line
   end
 

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -224,6 +224,20 @@ begin
       EOC
     end
 
+    def test_mode_icon_vi_changing
+      write_inputrc <<~LINES
+        set editing-mode vi
+        set show-mode-in-prompt on
+      LINES
+      start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/bin/multiline_repl}, startup_message: 'Multiline REPL.')
+      write(":a\C-[ab\C-[ac\C-h\C-h\C-h\C-h:a")
+      close
+      assert_screen(<<~EOC)
+        Multiline REPL.
+        (ins)prompt> :a
+      EOC
+    end
+
     def test_prompt_with_escape_sequence
       ENV['RELINE_TEST_PROMPT'] = "\1\e[30m\2prompt> \1\e[m\2"
       start_terminal(5, 20, %W{ruby -I#{@pwd}/lib #{@pwd}/bin/multiline_repl}, startup_message: 'Multiline REPL.')


### PR DESCRIPTION
This fixes https://github.com/ruby/reline/issues/226.