### PR TITLE
Use #bytesize for vi_replace_char

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -2478,7 +2478,7 @@ class Reline::LineEditor
         byte_size = Reline::Unicode.get_next_mbchar_size(@line, @byte_pointer)
         before = @line.byteslice(0, @byte_pointer)
         remaining_point = @byte_pointer + byte_size
-        after = @line.byteslice(remaining_point, @line.size - remaining_point)
+        after = @line.byteslice(remaining_point, @line.bytesize - remaining_point)
         @line = before + k.chr + after
         @cursor_max = calculate_width(@line)
         @waiting_proc = nil
@@ -2489,7 +2489,7 @@ class Reline::LineEditor
         end
         before = @line.byteslice(0, @byte_pointer)
         remaining_point = @byte_pointer + byte_size
-        after = @line.byteslice(remaining_point, @line.size - remaining_point)
+        after = @line.byteslice(remaining_point, @line.bytesize - remaining_point)
         replaced = k.chr * arg
         @line = before + replaced + after
         @byte_pointer += replaced.bytesize

--- a/test/reline/test_key_actor_vi.rb
+++ b/test/reline/test_key_actor_vi.rb
@@ -615,6 +615,24 @@ class Reline::KeyActor::ViInsert::Test < Reline::TestCase
     assert_cursor_max(6)
   end
 
+  def test_vi_replace_char_with_mbchar
+    input_keys("あいうえお\C-[0l")
+    assert_line('あいうえお')
+    assert_byte_pointer_size('あ')
+    assert_cursor(2)
+    assert_cursor_max(10)
+    input_keys('rx')
+    assert_line('あxうえお')
+    assert_byte_pointer_size('あ')
+    assert_cursor(2)
+    assert_cursor_max(9)
+    input_keys('l2ry')
+    assert_line('あxyyお')
+    assert_byte_pointer_size('あxyy')
+    assert_cursor(5)
+    assert_cursor_max(7)
+  end
+
   def test_vi_next_char
     input_keys("abcdef\C-[0")
     assert_line('abcdef')


### PR DESCRIPTION
This closes ruby/reline#228.