### PR TITLE
Add Ruby 3.0 to list of versions in CI workflow

### DIFF
--- a/.github/workflows/reline.yml
+++ b/.github/workflows/reline.yml
@@ -99,9 +99,9 @@ jobs:
       - name: Install libvterm
         run: |
           sudo apt install -y libtool-bin
-          wget http://www.leonerd.org.uk/code/libvterm/libvterm-0.1.3.tar.gz
-          tar xvzf libvterm-0.1.3.tar.gz
-          cd libvterm-0.1.3
+          wget http://www.leonerd.org.uk/code/libvterm/libvterm-0.1.4.tar.gz
+          tar xvzf libvterm-0.1.4.tar.gz
+          cd libvterm-0.1.4
           sed -i -e 's/^PREFIX=.*$/PREFIX=\/usr/g' Makefile
           make
           sudo make install

--- a/.github/workflows/reline.yml
+++ b/.github/workflows/reline.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        ruby: [ 2.7, 2.6, 2.5 ]
+        ruby: [ '3.0', 2.7, 2.6, 2.5 ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby
@@ -87,7 +87,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        ruby: [ 2.7, 2.6 ]
+        ruby: [ '3.0', 2.7, 2.6 ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby


### PR DESCRIPTION
Adds Ruby 3.0 to the versions which are explicitly tested against in the CI workflow.

I noticed that the `reline` job has more versions listed than the `vterm-yamatanooroti` one. The latter is missing ruby 2.5. I am not sure if that is intentional or not but I made this PR with the intention of making the smallest change possible and so left everything else as it is.

Closes #237