### PR TITLE
Update cursor correctly when just cursor moving

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -471,7 +471,7 @@ class Reline::LineEditor
         calculate_height_by_lines(@buffer_of_lines[0..(@line_index - 1)], prompt_list || prompt)
       end
     first_line_diff = new_first_line_started_from - @first_line_started_from
-    new_cursor, _, new_started_from, _ = calculate_nearest_cursor(@line, @cursor, @started_from, @byte_pointer, false)
+    new_cursor, new_cursor_max, new_started_from, new_byte_pointer = calculate_nearest_cursor(@buffer_of_lines[@line_index], @cursor, @started_from, @byte_pointer, false)
     new_started_from = calculate_height_by_width(prompt_width + new_cursor) - 1
     calculate_scroll_partial_screen(@highest_in_all, new_first_line_started_from + new_started_from)
     @previous_line_index = nil
@@ -485,6 +485,8 @@ class Reline::LineEditor
       @first_line_started_from = new_first_line_started_from
       @started_from = new_started_from
       @cursor = new_cursor
+      @cursor_max = new_cursor_max
+      @byte_pointer = new_byte_pointer
       move_cursor_down(first_line_diff + @started_from)
       Reline::IOGate.move_cursor_column((prompt_width + @cursor) % @screen_size.last)
       false

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -620,6 +620,24 @@ begin
       EOC
     end
 
+    def test_update_cursor_correctly_when_just_cursor_moving
+      start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/bin/multiline_repl}, startup_message: 'Multiline REPL.')
+      puts %W{ruby -I#{@pwd}/lib #{@pwd}/bin/multiline_repl}.inspect
+      write("def hoge\n  01234678")
+      write("\C-p")
+      write("\C-b")
+      write("\C-n")
+      write('5')
+      write("\C-e")
+      write('9')
+      close
+      assert_screen(<<~EOC)
+        Multiline REPL.
+        prompt> def hoge
+        prompt>   0123456789
+      EOC
+    end
+
     private def write_inputrc(content)
       File.open(@inputrc_file, 'w') do |f|
         f.write content


### PR DESCRIPTION
This fixes ruby/reline#236 and ruby/reline#239.