### PR TITLE
Improve pasting long text

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -261,6 +261,7 @@ class Reline::LineEditor
 
   private def insert_new_line(cursor_line, next_line)
     @line = cursor_line
+    next_line ||= next_line.to_s
     @buffer_of_lines.insert(@line_index + 1, String.new(next_line, encoding: @encoding))
     @previous_line_index = @line_index
     @line_index += 1

--- a/lib/reline/unicode.rb
+++ b/lib/reline/unicode.rb
@@ -100,6 +100,8 @@ class Reline::Unicode
   /x
 
   def self.get_mbchar_width(mbchar)
+    return 1 if mbchar == ""
+
     ord = mbchar.ord
     if (0x00 <= ord and ord <= 0x1F)
       return 2


### PR DESCRIPTION
I was trying to paste this long piece of text and play around new reline using Ruby 3.0.0 (reline 0.2.0) on macOS. Steps to reproduce:

```
irb
(type the following)
q = <<~Q
(enter)
(paste the following)
query {
  organization(slug: "test") {
    pipelines(last: 10) {
      edges {
        node {
          id
          name
          builds(createdAtFrom: "2020-01-01") {
            count
          }
          metrics {
            edges {
              node {
                label
                value
              }
            }
          }
        }
      }
    }
  }
}
```

irb crashed and `exit(1)` with various scenarios

- [x] When I pasted it, hit <kbd>enter</kbd> -> Fixed by 58e7f3e

  <details>
  <summary>Backtrace</summary>

  ```
  ➜  ~ irb
  irb(main):001:0" q=<<~Q
  irb(main):002:0" query {
  irb(main):003:0"   organization(slug: "test") {
  irb(main):004:0"     pipelines(last: 10) {
  irb(main):005:0"       edges {
  irb(main):006:0"         node {
  irb(main):007:0"           id
  irb(main):008:0"           name
  irb(main):009:0"           builds(createdAtFrom: "2020-01-01") {
  irb(main):010:0"             count
  irb(main):011:0"           }
  irb(main):012:0"           metrics {
  irb(main):013:0"             edges {
  irb(main):014:0"               node {
  irb(main):015:0"                 label
  irb(main):016:0"                 value
  irb(main):017:0"               }
  irb(main):018:0"             }
  irb(main):019:0"           }
  irb(main):020:0"         }
  irb(main):021:0"       }
  irb(main):022:0"     }
  irb(main):023:0"   }
  irb(main):024:0" } /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline/line_editor.rb:264:in `initialize': no implicit conversion of nil into String (TypeError)
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline/line_editor.rb:264:in `new'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline/line_editor.rb:264:in `insert_new_line'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline/line_editor.rb:1330:in `key_newline'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline/line_editor.rb:1900:in `ed_newline'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline/line_editor.rb:951:in `call'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline/line_editor.rb:951:in `wrap_method_call'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline/line_editor.rb:998:in `block in process_key'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline/line_editor.rb:922:in `run_for_operators'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline/line_editor.rb:997:in `process_key'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline/line_editor.rb:1032:in `normal_char'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline/line_editor.rb:1078:in `input_key'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline.rb:247:in `block (3 levels) in inner_readline'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline.rb:246:in `each'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline.rb:246:in `block (2 levels) in inner_readline'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline.rb:330:in `block in read_io'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline.rb:284:in `loop'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline.rb:284:in `read_io'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline.rb:245:in `block in inner_readline'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline.rb:243:in `loop'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline.rb:243:in `inner_readline'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline.rb:175:in `readmultiline'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/forwardable.rb:238:in `readmultiline'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/forwardable.rb:238:in `readmultiline'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb/input-method.rb:302:in `gets'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb.rb:519:in `block (2 levels) in eval_input'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb.rb:721:in `signal_status'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb.rb:518:in `block in eval_input'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb/ruby-lex.rb:202:in `lex'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb/ruby-lex.rb:174:in `block (2 levels) in each_top_level_statement'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb/ruby-lex.rb:171:in `loop'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb/ruby-lex.rb:171:in `block in each_top_level_statement'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb/ruby-lex.rb:170:in `catch'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb/ruby-lex.rb:170:in `each_top_level_statement'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb.rb:537:in `eval_input'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb.rb:472:in `block in run'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb.rb:471:in `catch'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb.rb:471:in `run'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb.rb:400:in `start'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/gems/3.0.0/gems/irb-1.3.0/exe/irb:11:in `<top (required)>'
    from /Users/hhh/.gem/ruby/3.0.0/bin/irb:23:in `load'
    from /Users/hhh/.gem/ruby/3.0.0/bin/irb:23:in `<main>'
  ```
  </details>

- [x] When I pasted it, use <kbd>←</kbd> or <kbd>→</kbd> arrow keys (<kbd>↑</kbd> or <kbd>↓</kbd> work fine) -> Fixed by 34d253d

  <details>
  <summary>Backtrace</summary>

  ```
  ➜  ~ irb
  irb(main):001:0" q=<<~Q
  irb(main):002:0" query {
  irb(main):003:0"   organization(slug: "test") {
  irb(main):004:0"     pipelines(last: 10) {
  irb(main):005:0"       edges {
  irb(main):006:0"         node {
  irb(main):007:0"           id
  irb(main):008:0"           name
  irb(main):009:0"           builds(createdAtFrom: "2020-01-01") {
  irb(main):010:0"             count
  irb(main):011:0"           }
  irb(main):012:0"           metrics {
  irb(main):013:0"             edges {
  irb(main):014:0"               node {
  irb(main):015:0"                 label
  irb(main):016:0"                 value
  irb(main):017:0"               }
  irb(main):018:0"             }
  irb(main):019:0"           }
  irb(main):020:0"         }
  irb(main):021:0"       }
  irb(main):022:0"     }
  irb(main):023:0"   }
  irb(main):024:0" } /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline/unicode.rb:105:in `ord': empty string (ArgumentError)
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline/unicode.rb:105:in `get_mbchar_width'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline/line_editor.rb:1438:in `ed_prev_char'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline/line_editor.rb:952:in `call'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline/line_editor.rb:952:in `wrap_method_call'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline/line_editor.rb:969:in `process_key'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline/line_editor.rb:1077:in `input_key'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline.rb:247:in `block (3 levels) in inner_readline'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline.rb:246:in `each'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline.rb:246:in `block (2 levels) in inner_readline'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline.rb:298:in `block in read_io'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline.rb:284:in `loop'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline.rb:284:in `read_io'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline.rb:245:in `block in inner_readline'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline.rb:243:in `loop'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline.rb:243:in `inner_readline'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline.rb:175:in `readmultiline'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/forwardable.rb:238:in `readmultiline'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/forwardable.rb:238:in `readmultiline'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb/input-method.rb:302:in `gets'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb.rb:519:in `block (2 levels) in eval_input'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb.rb:721:in `signal_status'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb.rb:518:in `block in eval_input'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb/ruby-lex.rb:202:in `lex'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb/ruby-lex.rb:174:in `block (2 levels) in each_top_level_statement'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb/ruby-lex.rb:171:in `loop'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb/ruby-lex.rb:171:in `block in each_top_level_statement'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb/ruby-lex.rb:170:in `catch'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb/ruby-lex.rb:170:in `each_top_level_statement'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb.rb:537:in `eval_input'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb.rb:472:in `block in run'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb.rb:471:in `catch'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb.rb:471:in `run'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb.rb:400:in `start'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/gems/3.0.0/gems/irb-1.3.0/exe/irb:11:in `<top (required)>'
    from /Users/hhh/.gem/ruby/3.0.0/bin/irb:23:in `load'
    from /Users/hhh/.gem/ruby/3.0.0/bin/irb:23:in `<main>'
  ```
  </details>

- [ ] When I pasted it, use <kbd>← Backspace</kbd>

  The problem with this is that pasted text added an extra space which the line is just `"}"` (irb 024 below), so the calculation went wrong.

  <img width="660" alt="スクリーンショット 2020-12-30 11 08 12" src="https://user-images.githubusercontent.com/1000669/103325476-5d3d2880-4a8f-11eb-80c1-dff2863d0c04.png">


  <details>
  <summary>Backtrace</summary>

  ```
  ➜  ~ irb
  irb(main):001:0" q=<<~Q
  irb(main):002:0" query {
  irb(main):003:0"   organization(slug: "test") {
  irb(main):004:0"     pipelines(last: 10) {
  irb(main):005:0"       edges {
  irb(main):006:0"         node {
  irb(main):007:0"           id
  irb(main):008:0"           name
  irb(main):009:0"           builds(createdAtFrom: "2020-01-01") {
  irb(main):010:0"             count
  irb(main):011:0"           }
  irb(main):012:0"           metrics {
  irb(main):013:0"             edges {
  irb(main):014:0"               node {
  irb(main):015:0"                 label
  irb(main):016:0"                 value
  irb(main):017:0"               }
  irb(main):018:0"             }
  irb(main):019:0"           }
  irb(main):020:0"         }
  irb(main):021:0"       }
  irb(main):022:0"     }
  irb(main):023:0"   }
  irb(main):024:0" } /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline/line_editor.rb:1303:in `byteslice!': no implicit conversion of nil into String (TypeError)
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline/line_editor.rb:1932:in `em_delete_prev_char'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline/line_editor.rb:952:in `call'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline/line_editor.rb:952:in `wrap_method_call'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline/line_editor.rb:999:in `block in process_key'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline/line_editor.rb:923:in `run_for_operators'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline/line_editor.rb:998:in `process_key'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline/line_editor.rb:1033:in `normal_char'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline/line_editor.rb:1079:in `input_key'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline.rb:247:in `block (3 levels) in inner_readline'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline.rb:246:in `each'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline.rb:246:in `block (2 levels) in inner_readline'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline.rb:330:in `block in read_io'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline.rb:284:in `loop'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline.rb:284:in `read_io'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline.rb:245:in `block in inner_readline'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline.rb:243:in `loop'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline.rb:243:in `inner_readline'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/reline.rb:175:in `readmultiline'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/forwardable.rb:238:in `readmultiline'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/forwardable.rb:238:in `readmultiline'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb/input-method.rb:302:in `gets'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb.rb:519:in `block (2 levels) in eval_input'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb.rb:721:in `signal_status'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb.rb:518:in `block in eval_input'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb/ruby-lex.rb:202:in `lex'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb/ruby-lex.rb:174:in `block (2 levels) in each_top_level_statement'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb/ruby-lex.rb:171:in `loop'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb/ruby-lex.rb:171:in `block in each_top_level_statement'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb/ruby-lex.rb:170:in `catch'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb/ruby-lex.rb:170:in `each_top_level_statement'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb.rb:537:in `eval_input'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb.rb:472:in `block in run'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb.rb:471:in `catch'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb.rb:471:in `run'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/3.0.0/irb.rb:400:in `start'
    from /Users/hhh/.rubies/3.0.0/lib/ruby/gems/3.0.0/gems/irb-1.3.0/exe/irb:11:in `<top (required)>'
    from /Users/hhh/.gem/ruby/3.0.0/bin/irb:23:in `load'
    from /Users/hhh/.gem/ruby/3.0.0/bin/irb:23:in `<main>'
  ```
  </details>


I would love some tips on improving these and adding tests for these.   Thanks.

Feel free to push changes to this branch if you want.