### PR TITLE
Suppress crashing when broken information comes from callbacks

### DIFF
--- a/bin/multiline_repl
+++ b/bin/multiline_repl
@@ -22,6 +22,14 @@ opt.on('--dynamic-prompt') {
     }
   }
 }
+opt.on('--broken-dynamic-prompt') {
+  Reline.prompt_proc = proc { |lines|
+    range = lines.size > 1 ? (0..(lines.size - 2)) : (0..0)
+    lines[range].each_with_index.map { |l, i|
+      '[%04d]> ' % i
+    }
+  }
+}
 opt.on('--auto-indent') {
   AutoIndent.new
 }

--- a/bin/multiline_repl
+++ b/bin/multiline_repl
@@ -22,6 +22,9 @@ opt.on('--dynamic-prompt') {
     }
   }
 }
+opt.on('--auto-indent') {
+  AutoIndent.new
+}
 opt.parse!(ARGV)
 
 begin

--- a/bin/termination_checker.rb
+++ b/bin/termination_checker.rb
@@ -16,3 +16,15 @@ class TerminationChecker < RubyLex
     end
   end
 end
+
+class AutoIndent < RubyLex
+  def initialize
+    set_input(self)
+    context = Struct.new(:auto_indent_mode).new(true)
+    set_auto_indent(context)
+  end
+
+  def auto_indent(&block)
+    Reline.auto_indent_proc = block
+  end
+end

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -1131,6 +1131,7 @@ class Reline::LineEditor
       new_lines = whole_lines
     end
     new_indent = @auto_indent_proc.(new_lines, @line_index, @byte_pointer, @check_new_auto_indent)
+    new_indent = @cursor_max if new_indent&.> @cursor_max
     if new_indent&.>= 0
       md = new_lines[@line_index].match(/\A */)
       prev_indent = md[0].count(' ')

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -112,6 +112,7 @@ class Reline::LineEditor
           use_cached_prompt_list = true
         end
       end
+      use_cached_prompt_list = false if @rerender_all
       if use_cached_prompt_list
         prompt_list = @cached_prompt_list
       else
@@ -123,6 +124,12 @@ class Reline::LineEditor
       prompt_list = prompt_list.map{ |pr| mode_string + pr } if mode_string
       prompt = prompt_list[@line_index]
       prompt = prompt_list[0] if prompt.nil?
+      prompt = prompt_list.last if prompt.nil?
+      if buffer.size > prompt_list.size
+        (buffer.size - prompt_list.size).times do
+          prompt_list << prompt_list.last
+        end
+      end
       prompt_width = calculate_width(prompt, true)
       [prompt, prompt_width, prompt_list]
     else

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -1339,7 +1339,7 @@ class Reline::LineEditor
       cursor_line = @line.byteslice(0, @byte_pointer)
       insert_new_line(cursor_line, next_line)
       @cursor = 0
-      @check_new_auto_indent = true
+      @check_new_auto_indent = true unless Reline::IOGate.in_pasting?
     end
   end
 

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -637,6 +637,20 @@ begin
       EOC
     end
 
+    def test_suppress_auto_indent_just_after_pasted
+      start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/bin/multiline_repl --auto-indent}, startup_message: 'Multiline REPL.')
+      write("def hoge\n  [[\n      3]]\ned")
+      write("\C-bn")
+      close
+      assert_screen(<<~EOC)
+        Multiline REPL.
+        prompt> def hoge
+        prompt>   [[
+        prompt>       3]]
+        prompt> end
+      EOC
+    end
+
     private def write_inputrc(content)
       File.open(@inputrc_file, 'w') do |f|
         f.write content

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -450,6 +450,18 @@ begin
       EOC
     end
 
+    def test_broken_prompt_list
+      start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/bin/multiline_repl --broken-dynamic-prompt}, startup_message: 'Multiline REPL.')
+      write("def hoge\n  3\nend")
+      close
+      assert_screen(<<~EOC)
+        Multiline REPL.
+        [0000]> def hoge
+        [0001]>   3
+        [0001]> end
+      EOC
+    end
+
     def test_enable_bracketed_paste
       omit if Reline::IOGate.win?
       write_inputrc <<~LINES

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -663,6 +663,21 @@ begin
       EOC
     end
 
+    def test_suppress_auto_indent_for_adding_newlines_in_pasting
+      start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/bin/multiline_repl --auto-indent}, startup_message: 'Multiline REPL.')
+      write("<<~Q\n")
+      write("{\n  #\n}")
+      write("#")
+      close
+      assert_screen(<<~EOC)
+        Multiline REPL.
+        prompt> <<~Q
+        prompt> {
+        prompt>   #
+        prompt> }#
+      EOC
+    end
+
     private def write_inputrc(content)
       File.open(@inputrc_file, 'w') do |f|
         f.write content


### PR DESCRIPTION
ref. https://github.com/ruby/reline/pull/242