### PR TITLE
Handle ed_search_{prev,next}_history in multiline correctly

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -1732,7 +1732,7 @@ class Reline::LineEditor
       @buffer_of_lines = Reline::HISTORY[@history_pointer].split("\n")
       @buffer_of_lines = [String.new(encoding: @encoding)] if @buffer_of_lines.empty?
       @line_index = line_no
-      @line = @buffer_of_lines.last
+      @line = @buffer_of_lines[@line_index]
       @rerender_all = true
     else
       @line = Reline::HISTORY[@history_pointer]
@@ -1780,7 +1780,7 @@ class Reline::LineEditor
         @line_index = line_no
       end
       @buffer_of_lines = [String.new(encoding: @encoding)] if @buffer_of_lines.empty?
-      @line = @buffer_of_lines.last
+      @line = @buffer_of_lines[@line_index]
       @rerender_all = true
     else
       if @history_pointer.nil? and substr.empty?

--- a/test/reline/helper.rb
+++ b/test/reline/helper.rb
@@ -96,4 +96,18 @@ class Reline::TestCase < Test::Unit::TestCase
   def assert_cursor_max(expected)
     assert_equal(expected, @line_editor.instance_variable_get(:@cursor_max))
   end
+
+  def assert_line_index(expected)
+    assert_equal(expected, @line_editor.instance_variable_get(:@line_index))
+  end
+
+  def assert_whole_lines(expected)
+    previous_line_index = @line_editor.instance_variable_get(:@previous_line_index)
+    if previous_line_index
+      lines = @line_editor.whole_lines(index: previous_line_index)
+    else
+      lines = @line_editor.whole_lines
+    end
+    assert_equal(expected, lines)
+  end
 end

--- a/test/reline/test_key_actor_emacs.rb
+++ b/test/reline/test_key_actor_emacs.rb
@@ -2233,6 +2233,53 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
     assert_line('def hoge')
   end
 
+  def test_ed_search_prev_next_history_in_multibyte
+    Reline::HISTORY.concat([
+      "def hoge\n  67890\n  12345\nend", # old
+      "def aiu\n  0xDEADBEEF\nend",
+      "def foo\n  12345\nend" # new
+    ])
+    @line_editor.multiline_on
+    input_keys('  123')
+    # The ed_search_prev_history doesn't have default binding
+    @line_editor.__send__(:ed_search_prev_history, "\C-p".ord)
+    assert_whole_lines(['def foo', '  12345', 'end'])
+    assert_line_index(1)
+    assert_whole_lines(['def foo', '  12345', 'end'])
+    assert_byte_pointer_size('  123')
+    assert_cursor(5)
+    assert_cursor_max(7)
+    assert_line('  12345')
+    @line_editor.__send__(:ed_search_prev_history, "\C-p".ord)
+    assert_line_index(2)
+    assert_whole_lines(['def hoge', '  67890', '  12345', 'end'])
+    assert_byte_pointer_size('  123')
+    assert_cursor(5)
+    assert_cursor_max(7)
+    assert_line('  12345')
+    @line_editor.__send__(:ed_search_prev_history, "\C-p".ord)
+    assert_line_index(2)
+    assert_whole_lines(['def hoge', '  67890', '  12345', 'end'])
+    assert_byte_pointer_size('  123')
+    assert_cursor(5)
+    assert_cursor_max(7)
+    assert_line('  12345')
+    @line_editor.__send__(:ed_search_next_history, "\C-n".ord)
+    assert_line_index(1)
+    assert_whole_lines(['def foo', '  12345', 'end'])
+    assert_byte_pointer_size('  123')
+    assert_cursor(5)
+    assert_cursor_max(7)
+    assert_line('  12345')
+    @line_editor.__send__(:ed_search_next_history, "\C-n".ord)
+    assert_line_index(1)
+    assert_whole_lines(['def foo', '  12345', 'end'])
+    assert_byte_pointer_size('  123')
+    assert_cursor(5)
+    assert_cursor_max(7)
+    assert_line('  12345')
+  end
+
 =begin # TODO: move KeyStroke instance from Reline to LineEditor
   def test_key_delete
     input_keys('ab')


### PR DESCRIPTION
The current line was being handled incorrectly when displaying the hit history, so it has been fixed to be correct.