### PR TITLE
Move the cursor correctly when deleting at eol

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -2395,6 +2395,9 @@ class Reline::LineEditor
       width = Reline::Unicode.get_mbchar_width(mbchar)
       @cursor_max -= width
       if @cursor > 0 and @cursor >= @cursor_max
+        byte_size = Reline::Unicode.get_prev_mbchar_size(@line, @byte_pointer)
+        mbchar = @line.byteslice(@byte_pointer - byte_size, byte_size)
+        width = Reline::Unicode.get_mbchar_width(mbchar)
         @byte_pointer -= byte_size
         @cursor -= width
       end

--- a/test/reline/test_key_actor_vi.rb
+++ b/test/reline/test_key_actor_vi.rb
@@ -1434,4 +1434,22 @@ class Reline::KeyActor::ViInsert::Test < Reline::TestCase
     assert_cursor(4)
     assert_cursor_max(4)
   end
+
+  def test_ed_delete_next_char_at_eol
+    input_keys('"あ"')
+    assert_line('"あ"')
+    assert_byte_pointer_size('"あ"')
+    assert_cursor(4)
+    assert_cursor_max(4)
+    input_keys("\C-[")
+    assert_line('"あ"')
+    assert_byte_pointer_size('"あ')
+    assert_cursor(3)
+    assert_cursor_max(4)
+    input_keys('xa"')
+    assert_line('"あ"')
+    assert_byte_pointer_size('"あ"')
+    assert_cursor(4)
+    assert_cursor_max(4)
+  end
 end


### PR DESCRIPTION
This fixes ruby/reline#246.