### PR TITLE
Reline::Windows.erase_after_cursor erases attributes too

### DIFF
--- a/lib/reline/windows.rb
+++ b/lib/reline/windows.rb
@@ -258,6 +258,7 @@ class Reline::Windows
     cursor = csbi[4, 4].unpack('L').first
     written = 0.chr * 4
     @@FillConsoleOutputCharacter.call(@@hConsoleHandle, 0x20, get_screen_size.last - cursor_pos.x, cursor, written)
+    @@FillConsoleOutputAttribute.call(@@hConsoleHandle, 0, get_screen_size.last - cursor_pos.x, cursor, written)
   end
 
   def self.scroll_down(val)


### PR DESCRIPTION
ref. https://twitter.com/nagisakaworu17/status/1347802370357354498