### PR TITLE
Cache pasting state in processing a key

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -243,6 +243,7 @@ module Reline
         loop do
           prev_pasting_state = Reline::IOGate.in_pasting?
           read_io(config.keyseq_timeout) { |inputs|
+            line_editor.set_pasting_state(Reline::IOGate.in_pasting?)
             inputs.each { |c|
               line_editor.input_key(c)
               line_editor.rerender
@@ -253,6 +254,7 @@ module Reline
             end
           }
           if prev_pasting_state == true and not Reline::IOGate.in_pasting? and not line_editor.finished?
+            line_editor.set_pasting_state(false)
             prev_pasting_state = false
             line_editor.rerender_all
           end


### PR DESCRIPTION
Because it's too slow.

The rendering time in IRB has been reduced as follows:

```ruby
start = Time.now

def each_top_level_statement
  initialize_input
  catch(:TERM_INPUT) do
    loop do
      begin
        prompt
        unless l = lex
          throw :TERM_INPUT if @line == ''
        else
          @line_no += l.count("\n")
          next if l == "\n"
          @line.concat l
          if @code_block_open or @ltype or @continue or @indent > 0
            next
          end
        end
        if @line != "\n"
          @line.force_encoding(@io.encoding)
          yield @line, @exp_line_no
        end
        break if @io.eof?
        @line = ''
        @exp_line_no = @line_no

        @indent = 0
      rescue TerminateLineInput
        initialize_input
        prompt
      end
    end
  end
end

puts "Duration: #{Time.now - start} seconds"
```

0.22sec -> 0.14sec

This fixes https://github.com/ruby/irb/issues/176.