### PR TITLE
Avoid tripping over nil prompt

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -124,6 +124,7 @@ class Reline::LineEditor
         @prompt_cache_time = Time.now.to_f
       end
       prompt_list.map!{ prompt } if @vi_arg or @searching_prompt
+      prompt_list = [prompt] if prompt_list.empty?
       mode_string = check_mode_string
       prompt_list = prompt_list.map{ |pr| mode_string + pr } if mode_string
       prompt = prompt_list[@line_index]


### PR DESCRIPTION
Starting irb and type dollar `$` causes a crash.

The cause is that `prompt` is nil, because `prompt_list` is empty. 

I'm offering this fix. There is no test coverage, for which I apologise. I'd be happy to collaborate with someone who knows the repo better.
