### PR TITLE
Return 1 when char width not found

### DIFF
--- a/lib/reline/unicode.rb
+++ b/lib/reline/unicode.rb
@@ -108,6 +108,7 @@ class Reline::Unicode
     end
     m = mbchar.encode(Encoding::UTF_8).match(MBCharWidthRE)
     case
+    when m.nil? then 1 # TODO should be U+FFFD � REPLACEMENT CHARACTER
     when m[:width_2_1], m[:width_2_2] then 2
     when m[:width_3] then 3
     when m[:width_0] then 0

--- a/test/reline/test_key_actor_emacs.rb
+++ b/test/reline/test_key_actor_emacs.rb
@@ -2280,6 +2280,14 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
     assert_line('  12345')
   end
 
+  def test_input_unknown_char
+    input_keys('͸') # U+0378 (unassigned)
+    assert_line('͸')
+    assert_byte_pointer_size('͸')
+    assert_cursor(1)
+    assert_cursor_max(1)
+  end
+
 =begin # TODO: move KeyStroke instance from Reline to LineEditor
   def test_key_delete
     input_keys('ab')


### PR DESCRIPTION
This fixes ruby/reline#261.