### PR TITLE
Use UTF-8 only for width calc, rest uses original encoding

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -344,8 +344,9 @@ class Reline::LineEditor
     else
     end_of_line_cursor = new_cursor_max
     end
-    line_to_calc.encode(Encoding::UTF_8).grapheme_clusters.each do |gc|
-      mbchar_width = Reline::Unicode.get_mbchar_width(gc)
+    line_to_calc.grapheme_clusters.each do |gc|
+      mbchar = gc.encode(Encoding::UTF_8)
+      mbchar_width = Reline::Unicode.get_mbchar_width(mbchar)
       now = new_cursor + mbchar_width
       if now > end_of_line_cursor or now > cursor
         break


### PR DESCRIPTION
I confirmed that libvterm supports only which are UTF-8, US ASCII, UK, and DEC graphics by reading source code, so can't test this patch by yamatanoorogi gem through vterm gem for now.

This fixes ruby/irb#190.