### PR TITLE
Add windows getconsolemode

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -726,7 +726,7 @@ class Reline::LineEditor
       if line.nil?
         if calculate_width(visual_lines[index - 1], true) == Reline::IOGate.get_screen_size.last
           # reaches the end of line
-          if Reline::IOGate.win?
+          if Reline::IOGate.win? and Reline::IOGate.win_legacy_console?
             # A newline is automatically inserted if a character is rendered at
             # eol on command prompt.
           else
@@ -744,7 +744,7 @@ class Reline::LineEditor
         next
       end
       @output.write line
-      if Reline::IOGate.win? and calculate_width(line, true) == Reline::IOGate.get_screen_size.last
+      if Reline::IOGate.win? and Reline::IOGate.win_legacy_console? and calculate_width(line, true) == Reline::IOGate.get_screen_size.last
         # A newline is automatically inserted if a character is rendered at eol on command prompt.
         @rest_height -= 1 if @rest_height > 0
       end

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -725,13 +725,17 @@ class Reline::LineEditor
       Reline::IOGate.move_cursor_column(0)
       if line.nil?
         if calculate_width(visual_lines[index - 1], true) == Reline::IOGate.get_screen_size.last
-          # Reaches the end of line.
-          #
-          # When the cursor is at the end of the line and erases characters
-          # after the cursor, some terminals delete the character at the
-          # cursor position.
-          move_cursor_down(1)
-          Reline::IOGate.move_cursor_column(0)
+          # reaches the end of line
+          if Reline::IOGate.win?
+            # A newline is automatically inserted if a character is rendered at
+            # eol on command prompt.
+          else
+            # When the cursor is at the end of the line and erases characters
+            # after the cursor, some terminals delete the character at the
+            # cursor position.
+            move_cursor_down(1)
+            Reline::IOGate.move_cursor_column(0)
+          end
         else
           Reline::IOGate.erase_after_cursor
           move_cursor_down(1)
@@ -740,6 +744,10 @@ class Reline::LineEditor
         next
       end
       @output.write line
+      if Reline::IOGate.win? and calculate_width(line, true) == Reline::IOGate.get_screen_size.last
+        # A newline is automatically inserted if a character is rendered at eol on command prompt.
+        @rest_height -= 1 if @rest_height > 0
+      end
       @output.flush
       if @first_prompt
         @first_prompt = false

--- a/lib/reline/windows.rb
+++ b/lib/reline/windows.rb
@@ -9,6 +9,10 @@ class Reline::Windows
     true
   end
 
+  def self.win_legacy_console?
+    @@legacy_console
+  end
+
   RAW_KEYSTROKE_CONFIG = {
     [224, 72] => :ed_prev_history, # ↑
     [224, 80] => :ed_next_history, # ↓
@@ -93,6 +97,26 @@ class Reline::Windows
   @@GetFileType = Win32API.new('kernel32', 'GetFileType', ['L'], 'L')
   @@GetFileInformationByHandleEx = Win32API.new('kernel32', 'GetFileInformationByHandleEx', ['L', 'I', 'P', 'L'], 'I')
   @@FillConsoleOutputAttribute = Win32API.new('kernel32', 'FillConsoleOutputAttribute', ['L', 'L', 'L', 'L', 'P'], 'L')
+
+  @@GetConsoleMode = Win32API.new('kernel32', 'GetConsoleMode', ['L', 'P'], 'L')
+  @@SetConsoleMode = Win32API.new('kernel32', 'SetConsoleMode', ['L', 'L'], 'L')
+  ENABLE_VIRTUAL_TERMINAL_PROCESSING = 4
+
+  private_class_method def self.getconsolemode
+    mode = '\000\000\000\000'
+    @@GetConsoleMode.call(@@hConsoleHandle, mode)
+    mode.unpack1('L')
+  end
+
+  private_class_method def self.setconsolemode(mode)
+    @@SetConsoleMode.call(@@hConsoleHandle, mode)
+  end
+
+  @@legacy_console = (getconsolemode() & ENABLE_VIRTUAL_TERMINAL_PROCESSING == 0)
+  #if @@legacy_console
+  #  setconsolemode(getconsolemode() | ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+  #  @@legacy_console = (getconsolemode() & ENABLE_VIRTUAL_TERMINAL_PROCESSING == 0)
+  #end
 
   @@input_buf = []
   @@output_buf = []


### PR DESCRIPTION
This patch solves the problem that `rake test_yamatanooroti` (after `gem install yamatanooroti`) fails the test in Ruby 2.7 on Windows.

Thank you so much, @YO4!

This closes https://github.com/ruby/reline/issues/265.