### PR TITLE
Moved development dependencies to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,12 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in reline.gemspec
 gemspec
+
+group :development do
+  gem 'bundler'
+  gem 'rake'
+  gem 'test-unit'
+  is_unix = RUBY_PLATFORM =~ /(aix|darwin|linux|(net|free|open)bsd|cygwin|solaris|irix|hpux)/i
+  gem 'vterm', '>= 0.0.5' if is_unix && ENV['WITH_VTERM']
+  gem 'yamatanooroti', '>= 0.0.6'
+end

--- a/reline.gemspec
+++ b/reline.gemspec
@@ -20,10 +20,4 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = Gem::Requirement.new('>= 2.5')
 
   spec.add_dependency 'io-console', '~> 0.5'
-  spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'test-unit'
-  is_unix = RUBY_PLATFORM =~ /(aix|darwin|linux|(net|free|open)bsd|cygwin|solaris|irix|hpux)/i
-  spec.add_development_dependency 'vterm', '>= 0.0.5' if is_unix && ENV['WITH_VTERM']
-  spec.add_development_dependency 'yamatanooroti', '>= 0.0.6'
 end


### PR DESCRIPTION
As expressions in a gemspec file are evaluated at the build time, but not the run time, the conditional in the gemspec will not work as intended.