### PR TITLE
ensure reline's encoding is used when reading inputrc character values

### DIFF
--- a/lib/reline/config.rb
+++ b/lib/reline/config.rb
@@ -291,11 +291,8 @@ class Reline::Config
   end
 
   def retrieve_string(str)
-    if str =~ /\A"(.*)"\z/
-      parse_keyseq($1).map(&:chr).join
-    else
-      parse_keyseq(str).map(&:chr).join
-    end
+    str = $1 if str =~ /\A"(.*)"\z/
+    parse_keyseq(str).map { |c| c.chr(Reline::IOGate.encoding) }.join
   end
 
   def bind_key(key, func_name)

--- a/test/reline/test_config.rb
+++ b/test/reline/test_config.rb
@@ -286,6 +286,16 @@ class Reline::Config::Test < Reline::TestCase
     ENV['INPUTRC'] = inputrc_backup
   end
 
+  def test_inputrc_with_utf
+    @config.read_lines(<<~'LINES'.lines)
+      set editing-mode vi
+      set vi-cmd-mode-string 🍸
+      set vi-ins-mode-string 🍶
+    LINES
+    assert_equal @config.vi_cmd_mode_string, "🍸"
+    assert_equal @config.vi_ins_mode_string, "🍶"
+  end
+
   def test_xdg_config_home
     home_backup = ENV['HOME']
     xdg_config_home_backup = ENV['XDG_CONFIG_HOME']


### PR DESCRIPTION
This change ensures we use `Reline::IOGate`'s `encoding` when converting
characters from their integer values.

This fixes an issue that may occur if you have UTF characters in your
`.inputrc`, but your default encoding isn't set.

For example:

```
> 127864.ord.chr
RangeError: 127864 out of char range
from (pry):1:in `chr'
> Reline::IOGate.encoding
=> #<Encoding:UTF-8>
> 127864.ord.chr(Reline::IOGate.encoding)
=> "🍸"
```