### PR TITLE
Fix GitHub Actions

### DIFF
--- a/.github/workflows/reline.yml
+++ b/.github/workflows/reline.yml
@@ -24,25 +24,21 @@ jobs:
 
   readline:
     name: >-
-      readline ${{ matrix.cfg.ruby }}  ${{ matrix.cfg.os }}
-    runs-on: ${{ matrix.cfg.os }}
+      readline ${{ matrix.ruby }}  ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         include:
-          - ruby: head
-            os: ubuntu-latest
-          - ruby: head
-            os: macos-latest
-          - ruby: mingw
-            os: windows-latest
-          - ruby: mswin
-            os: windows-latest
+          - { ruby: head,  os: ubuntu-latest  }
+          - { ruby: head,  os: macos-latest   }
+          - { ruby: mingw, os: windows-latest }
+          - { ruby: mswin, os: windows-latest }
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.cfg.ruby }}
+          ruby-version: ${{ matrix.ruby }}
       - name: Install dependencies
         run:  bundle install
       - name: Download test readline


### PR DESCRIPTION
The 'readline' jobs weren't running.  if one views a run thru the ['Actions'](https://github.com/ruby/reline/actions) tab, you'll see the jobs won't run because the runner is confused as to the OS...

Note:

The '-latest' suffix for the OS designation may change what version it refers to.  I've changed a few repos to using just the numeric suffix, so `ubuntu-latest` would become `ubuntu-20.04`.