### PR TITLE
The config file must accept any character encoding

### DIFF
--- a/lib/reline/config.rb
+++ b/lib/reline/config.rb
@@ -157,6 +157,9 @@ class Reline::Config
   end
 
   def read_lines(lines, file = nil)
+    if lines.first.encoding != Reline.encoding_system_needs
+      lines = lines.map { |l| l.encode(Reline.encoding_system_needs) }
+    end
     conditions = [@skip_section, @if_stack]
     @skip_section = nil
     @if_stack = []
@@ -292,7 +295,7 @@ class Reline::Config
 
   def retrieve_string(str)
     str = $1 if str =~ /\A"(.*)"\z/
-    parse_keyseq(str).map { |c| c.chr(Reline::IOGate.encoding) }.join
+    parse_keyseq(str).map { |c| c.chr(Reline.encoding_system_needs) }.join
   end
 
   def bind_key(key, func_name)

--- a/lib/reline/general_io.rb
+++ b/lib/reline/general_io.rb
@@ -1,12 +1,19 @@
 require 'timeout'
 
 class Reline::GeneralIO
-  def self.reset
+  def self.reset(encoding: nil)
     @@pasting = false
+    @@encoding = encoding
   end
 
   def self.encoding
-    RUBY_PLATFORM =~ /mswin|mingw/ ? Encoding::UTF_8 : Encoding::default_external
+    if @@encoding
+      @@encoding
+    elsif RUBY_PLATFORM =~ /mswin|mingw/
+      Encoding::UTF_8
+    else
+      Encoding::default_external
+    end
   end
 
   def self.win?

--- a/test/reline/helper.rb
+++ b/test/reline/helper.rb
@@ -7,7 +7,8 @@ module Reline
     def test_mode
         remove_const('IOGate') if const_defined?('IOGate')
         const_set('IOGate', Reline::GeneralIO)
-        Reline::GeneralIO.reset
+        encoding = (RELINE_TEST_ENCODING rescue nil)
+        Reline::GeneralIO.reset(encoding: encoding)
         send(:core).config.instance_variable_set(:@test_mode, true)
         send(:core).config.reset
     end

--- a/test/reline/test_config.rb
+++ b/test/reline/test_config.rb
@@ -286,14 +286,25 @@ class Reline::Config::Test < Reline::TestCase
     ENV['INPUTRC'] = inputrc_backup
   end
 
-  def test_inputrc_with_utf
+  def test_inputrc_with_utf8
+    # This file is encoded by UTF-8 so this heredoc string is also UTF-8.
     @config.read_lines(<<~'LINES'.lines)
       set editing-mode vi
       set vi-cmd-mode-string 🍸
       set vi-ins-mode-string 🍶
     LINES
-    assert_equal @config.vi_cmd_mode_string, "🍸"
-    assert_equal @config.vi_ins_mode_string, "🍶"
+    assert_equal '🍸', @config.vi_cmd_mode_string
+    assert_equal '🍶', @config.vi_ins_mode_string
+  end
+
+  def test_inputrc_with_eucjp
+    @config.read_lines(<<~"LINES".encode(Encoding::EUC_JP).lines)
+      set editing-mode vi
+      set vi-cmd-mode-string ｫｬｯ
+      set vi-ins-mode-string 能
+    LINES
+    assert_equal 'ｫｬｯ'.encode(Reline.encoding_system_needs), @config.vi_cmd_mode_string
+    assert_equal '能'.encode(Reline.encoding_system_needs), @config.vi_ins_mode_string
   end
 
   def test_xdg_config_home

--- a/test/reline/test_history.rb
+++ b/test/reline/test_history.rb
@@ -292,7 +292,9 @@ class Reline::History::Test < Reline::TestCase
   end
 
   def get_default_internal_encoding
-    if RUBY_PLATFORM =~ /mswin|mingw/
+    if encoding = (RELINE_TEST_ENCODING rescue nil)
+      encoding
+    elsif RUBY_PLATFORM =~ /mswin|mingw/
       Encoding.default_internal || Encoding::UTF_8
     else
       Encoding.default_internal || Encoding.find("locale")

--- a/test/reline/test_reline.rb
+++ b/test/reline/test_reline.rb
@@ -314,6 +314,12 @@ class Reline::Test < Reline::TestCase
   end
 
   def get_reline_encoding
-    RUBY_PLATFORM =~ /mswin|mingw/ ? Encoding::UTF_8 : Encoding::default_external
+    if encoding = (RELINE_TEST_ENCODING rescue nil)
+      encoding
+    elsif RUBY_PLATFORM =~ /mswin|mingw/
+      Encoding::UTF_8
+    else
+      Encoding::default_external
+    end
   end
 end


### PR DESCRIPTION
In Japan, so many programmers used EUC-JP to write text files that contain Japanese. Many .inputrc files which contain EUC-JP are still being copied and used. This commit supports the whole encoding of what user set including UTF-8.

ref. https://github.com/ruby/reline/pull/280