### PR TITLE
Gemfile: Drop unused github git_source alias

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,5 @@
 source 'https://rubygems.org'
 
-git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
-
-# Specify your gem's dependencies in reline.gemspec
 gemspec
 
 group :development do


### PR DESCRIPTION
Remove generated comment.

The github git_source exists that way in Bundler 2, so it is available if we want to use it later.