### PR TITLE
Add usage for README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,39 @@ This is a screen capture of *IRB improved by Reline*.
 
 Reline is compatible with the API of Ruby's stdlib 'readline', GNU Readline and Editline by pure Ruby implementation.
 
+## Usage
+
+### Single line editing mode
+
+See [bin/example](https://github.com/ruby/reline/blob/master/bin/example)
+
+### Multi-line editing mode
+
+```ruby
+require "reline"
+
+prompt = 'prompt> '
+use_history = true
+
+begin
+  while true
+    text = Reline.readmultiline(prompt, use_history) do |multiline_input|
+      # Accept the input until `end` is entered
+      multiline_input.split.last == "end"
+    end
+
+    puts 'You entered:'
+    puts text
+  end
+# If you want to exit, type Ctrl-C
+rescue Interrupt
+  puts '^C'
+  exit 0
+end
+```
+
+See also: [test/reline/yamatanooroti/multiline_repl](https://github.com/ruby/reline/blob/master/test/reline/yamatanooroti/multiline_repl)
+
 ## License
 
 The gem is available as open source under the terms of the [Ruby License](https://www.ruby-lang.org/en/about/license.txt).

--- a/README.md
+++ b/README.md
@@ -39,6 +39,17 @@ rescue Interrupt
 end
 ```
 
+```bash
+$ ruby example.rb
+prompt> aaa
+prompt> bbb
+prompt> end
+You entered:
+aaa
+bbb
+end
+```
+
 See also: [test/reline/yamatanooroti/multiline_repl](https://github.com/ruby/reline/blob/master/test/reline/yamatanooroti/multiline_repl)
 
 ## License


### PR DESCRIPTION
Added sample code for `Reline.readmultiline`.
In my opinion, Usage would be as short as possible, so it is better to see `test/reline/yamatanooroti/multiline_repl` for details.

If you have any concerns, please let me know. :)

sample code's executable example:

```bash
❯ ruby example.rb
prompt> irb
prompt> reline
prompt> end
You entered:
irb
reline
end
prompt>
^C
```

thanks @osyo-manga 😄 