### PR TITLE
Fix failed test

### DIFF
--- a/test/reline/test_key_actor_emacs.rb
+++ b/test/reline/test_key_actor_emacs.rb
@@ -2140,65 +2140,65 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
   end
 
   # Unicode emoji test
-  if Reline::IOGate.encoding == Encoding::UTF_8
-    def test_ed_insert_for_include_zwj_emoji
-      # U+1F468 U+200D U+1F469 U+200D U+1F467 U+200D U+1F466 is family: man, woman, girl, boy "👨‍👩‍👧‍👦"
-      input_keys("\u{1F468}") # U+1F468 is man "👨"
-      assert_line("\u{1F468}")
-      assert_byte_pointer_size("\u{1F468}")
-      assert_cursor(2)
-      assert_cursor_max(2)
-      input_keys("\u200D") # U+200D is ZERO WIDTH JOINER
-      assert_line("\u{1F468 200D}")
-      assert_byte_pointer_size("\u{1F468 200D}")
-      assert_cursor(2)
-      assert_cursor_max(2)
-      input_keys("\u{1F469}") # U+1F469 is woman "👩"
-      assert_line("\u{1F468 200D 1F469}")
-      assert_byte_pointer_size("\u{1F468 200D 1F469}")
-      assert_cursor(2)
-      assert_cursor_max(2)
-      input_keys("\u200D") # U+200D is ZERO WIDTH JOINER
-      assert_line("\u{1F468 200D 1F469 200D}")
-      assert_byte_pointer_size("\u{1F468 200D 1F469 200D}")
-      assert_cursor(2)
-      assert_cursor_max(2)
-      input_keys("\u{1F467}") # U+1F467 is girl "👧"
-      assert_line("\u{1F468 200D 1F469 200D 1F467}")
-      assert_byte_pointer_size("\u{1F468 200D 1F469 200D 1F467}")
-      assert_cursor(2)
-      assert_cursor_max(2)
-      input_keys("\u200D") # U+200D is ZERO WIDTH JOINER
-      assert_line("\u{1F468 200D 1F469 200D 1F467 200D}")
-      assert_byte_pointer_size("\u{1F468 200D 1F469 200D 1F467 200D}")
-      assert_cursor(2)
-      assert_cursor_max(2)
-      input_keys("\u{1F466}") # U+1F466 is boy "👦"
-      assert_line("\u{1F468 200D 1F469 200D 1F467 200D 1F466}")
-      assert_byte_pointer_size("\u{1F468 200D 1F469 200D 1F467 200D 1F466}")
-      assert_cursor(2)
-      assert_cursor_max(2)
-      # U+1F468 U+200D U+1F469 U+200D U+1F467 U+200D U+1F466 is family: man, woman, girl, boy "👨‍👩‍👧‍👦"
-      input_keys("\u{1F468 200D 1F469 200D 1F467 200D 1F466}")
-      assert_line("\u{1F468 200D 1F469 200D 1F467 200D 1F466 1F468 200D 1F469 200D 1F467 200D 1F466}")
-      assert_byte_pointer_size("\u{1F468 200D 1F469 200D 1F467 200D 1F466 1F468 200D 1F469 200D 1F467 200D 1F466}")
-      assert_cursor(4)
-      assert_cursor_max(4)
-    end
+  def test_ed_insert_for_include_zwj_emoji
+    return if Reline::IOGate.encoding != Encoding::UTF_8
+    # U+1F468 U+200D U+1F469 U+200D U+1F467 U+200D U+1F466 is family: man, woman, girl, boy "👨‍👩‍👧‍👦"
+    input_keys("\u{1F468}") # U+1F468 is man "👨"
+    assert_line("\u{1F468}")
+    assert_byte_pointer_size("\u{1F468}")
+    assert_cursor(2)
+    assert_cursor_max(2)
+    input_keys("\u200D") # U+200D is ZERO WIDTH JOINER
+    assert_line("\u{1F468 200D}")
+    assert_byte_pointer_size("\u{1F468 200D}")
+    assert_cursor(2)
+    assert_cursor_max(2)
+    input_keys("\u{1F469}") # U+1F469 is woman "👩"
+    assert_line("\u{1F468 200D 1F469}")
+    assert_byte_pointer_size("\u{1F468 200D 1F469}")
+    assert_cursor(2)
+    assert_cursor_max(2)
+    input_keys("\u200D") # U+200D is ZERO WIDTH JOINER
+    assert_line("\u{1F468 200D 1F469 200D}")
+    assert_byte_pointer_size("\u{1F468 200D 1F469 200D}")
+    assert_cursor(2)
+    assert_cursor_max(2)
+    input_keys("\u{1F467}") # U+1F467 is girl "👧"
+    assert_line("\u{1F468 200D 1F469 200D 1F467}")
+    assert_byte_pointer_size("\u{1F468 200D 1F469 200D 1F467}")
+    assert_cursor(2)
+    assert_cursor_max(2)
+    input_keys("\u200D") # U+200D is ZERO WIDTH JOINER
+    assert_line("\u{1F468 200D 1F469 200D 1F467 200D}")
+    assert_byte_pointer_size("\u{1F468 200D 1F469 200D 1F467 200D}")
+    assert_cursor(2)
+    assert_cursor_max(2)
+    input_keys("\u{1F466}") # U+1F466 is boy "👦"
+    assert_line("\u{1F468 200D 1F469 200D 1F467 200D 1F466}")
+    assert_byte_pointer_size("\u{1F468 200D 1F469 200D 1F467 200D 1F466}")
+    assert_cursor(2)
+    assert_cursor_max(2)
+    # U+1F468 U+200D U+1F469 U+200D U+1F467 U+200D U+1F466 is family: man, woman, girl, boy "👨‍👩‍👧‍👦"
+    input_keys("\u{1F468 200D 1F469 200D 1F467 200D 1F466}")
+    assert_line("\u{1F468 200D 1F469 200D 1F467 200D 1F466 1F468 200D 1F469 200D 1F467 200D 1F466}")
+    assert_byte_pointer_size("\u{1F468 200D 1F469 200D 1F467 200D 1F466 1F468 200D 1F469 200D 1F467 200D 1F466}")
+    assert_cursor(4)
+    assert_cursor_max(4)
+  end
 
-    def test_ed_insert_for_include_valiation_selector
-      # U+0030 U+FE00 is DIGIT ZERO + VARIATION SELECTOR-1 "0︀"
-      input_keys("\u0030") # U+0030 is DIGIT ZERO
-      assert_line("\u0030")
-      assert_byte_pointer_size("\u0030")
-      assert_cursor(1)
-      assert_cursor_max(1)
-      input_keys("\uFE00") # U+FE00 is VARIATION SELECTOR-1
-      assert_line("\u{0030 FE00}")
-      assert_byte_pointer_size("\u{0030 FE00}")
-      assert_cursor(1)
-      assert_cursor_max(1)
-    end
+  def test_ed_insert_for_include_valiation_selector
+    return if Reline::IOGate.encoding != Encoding::UTF_8
+    # U+0030 U+FE00 is DIGIT ZERO + VARIATION SELECTOR-1 "0︀"
+    input_keys("\u0030") # U+0030 is DIGIT ZERO
+    assert_line("\u0030")
+    assert_byte_pointer_size("\u0030")
+    assert_cursor(1)
+    assert_cursor_max(1)
+    input_keys("\uFE00") # U+FE00 is VARIATION SELECTOR-1
+    assert_line("\u{0030 FE00}")
+    assert_byte_pointer_size("\u{0030 FE00}")
+    assert_cursor(1)
+    assert_cursor_max(1)
   end
 
   def test_em_yank_pop


### PR DESCRIPTION
For ruby/ruby repository's  AppVeyor CI (Windows environment), `Reline::IOGate.encoding` will be changed from `UTF-8` to `Windows-31J` after the test is run.
So, when `test/reline/test_key_actor_emacs.rb` is loaded, `Reline::IOGate.encoding == Encoding::UTF_8` will be `true`,
but at the time of test execution, `Reline::IOGate.encoding` is `Windows-31J`.
For this reason, I changed the test method to check `Reline::IOGate.encoding` in the test method.