### PR TITLE
Windows cmd: Don't type anything when pressing ALT keys alone

### DIFF
--- a/lib/reline/windows.rb
+++ b/lib/reline/windows.rb
@@ -190,9 +190,6 @@ class Reline::Windows
       # It's treated as Meta+Space on Windows.
       @@output_buf.push("\e".ord)
       @@output_buf.push(char_code)
-    elsif control_key_state.anybits?(LEFT_ALT_PRESSED | RIGHT_ALT_PRESSED)
-      @@output_buf.push("\e".ord)
-      @@output_buf.concat(char.bytes)
     elsif control_key_state.anybits?(ENHANCED_KEY)
       case virtual_key_code # Emulate getwch() key sequences.
       when VK_END

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -775,6 +775,19 @@ begin
       EOC
     end
 
+    def test_brackets
+      omit unless Reline::IOGate.win?
+      start_terminal(20, 50, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
+      write("\x80\M-[\x80\M-{\x80\M-}\x80\M-]\n")
+      close
+      assert_screen(<<~EOC)
+        Multiline REPL.
+        prompt> [{}]
+        => [{}]
+        prompt>
+      EOC
+    end
+
     def test_with_newline
       omit if Reline::IOGate.win?
       cmd = %Q{ruby -e 'print(%Q{abc def \\e\\r})' | ruby -I#{@pwd}/lib -rreline -e 'p Reline.readline(%{> })'}


### PR DESCRIPTION
Fixes #298

The test fails on Ubuntu, so that it's omitted on non-Windows. Obviously the meta key handling is different there.
