### PR TITLE
Fix reline on OpenBSD

### DIFF
--- a/lib/reline/terminfo.rb
+++ b/lib/reline/terminfo.rb
@@ -40,7 +40,12 @@ module Reline::Terminfo
   #extern 'char *tigetstr(char *capname)'
   @tigetstr = Fiddle::Function.new(curses_dl['tigetstr'], [Fiddle::TYPE_VOIDP], Fiddle::TYPE_VOIDP)
   #extern 'char *tiparm(const char *str, ...)'
-  @tiparm = Fiddle::Function.new(curses_dl['tiparm'], [Fiddle::TYPE_VOIDP, Fiddle::TYPE_VARIADIC], Fiddle::TYPE_VOIDP)
+  @tiparm = begin
+    Fiddle::Function.new(curses_dl['tiparm'], [Fiddle::TYPE_VOIDP, Fiddle::TYPE_VARIADIC], Fiddle::TYPE_VOIDP)
+  rescue
+    # OpenBSD lacks tiparm
+    Fiddle::Function.new(curses_dl['tparm'], [Fiddle::TYPE_VOIDP, Fiddle::TYPE_VARIADIC], Fiddle::TYPE_VOIDP)
+  end
   # TODO: add int tigetflag(char *capname) and int tigetnum(char *capname)
 
   def self.setupterm(term, fildes)


### PR DESCRIPTION
OpenBSD doesn't support tiparm, only tparm.  I'm not sure if the
two are compatible, but this at least this allows me to run irb
on OpenBSD.