### PR TITLE
Remove interrupt avoidance

### DIFF
--- a/lib/reline/ansi.rb
+++ b/lib/reline/ansi.rb
@@ -295,8 +295,6 @@ class Reline::ANSI
 
   def self.prep
     retrieve_keybuffer
-    int_handle = Signal.trap('INT', 'IGNORE')
-    Signal.trap('INT', int_handle)
     nil
   end
 

--- a/test/reline/yamatanooroti/termination_checker.rb
+++ b/test/reline/yamatanooroti/termination_checker.rb
@@ -20,7 +20,7 @@ end
 class AutoIndent < RubyLex
   def initialize
     set_input(self)
-    context = Struct.new(:auto_indent_mode).new(true)
+    context = Struct.new(:auto_indent_mode, :workspace).new(true, nil)
     set_auto_indent(context)
   end
 

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -809,7 +809,7 @@ begin
       EOC
     end
 
-    private def write_inputrc(content)
+    def write_inputrc(content)
       File.open(@inputrc_file, 'w') do |f|
         f.write content
       end


### PR DESCRIPTION
There used to be a process that did not want to be interrupted by SIGINT, so it was trapped, but that process is no longer there.