### PR TITLE
Memoize path of `.inputrc` 

### DIFF
--- a/lib/reline/config.rb
+++ b/lib/reline/config.rb
@@ -119,8 +119,12 @@ class Reline::Config
     return home_rc_path
   end
 
+  private def default_inputrc_path
+    @default_inputrc_path ||= inputrc_path
+  end
+
   def read(file = nil)
-    file ||= inputrc_path
+    file ||= default_inputrc_path
     begin
       if file.respond_to?(:readlines)
         lines = file.readlines


### PR DESCRIPTION
Fix #319.
When `ENV["HOME"] = "foo"` on irb, an exception is raised when retrieving the path of `.inputrc`.
Memoize the path of `.inputrc` and don't get the path after the second time.