### PR TITLE
Implement vi_kill_line_prev

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -2539,6 +2539,7 @@ class Reline::LineEditor
     end
   end
   alias_method :kill_line, :em_kill_line
+  alias_method :vi_kill_line_prev, :em_kill_line
 
   private def em_delete(key)
     if (not @is_multiline and @line.empty?) or (@is_multiline and @line.empty? and @buffer_of_lines.size == 1)


### PR DESCRIPTION
This operation is mentioned and bound to `^U` in both `vi_command.rb`
and `vi_insert.rb`, but there is no definition of it.

Both Vi and Emacs use the same keystroke to do the same behavior, so
I've chosen to use `alias_method` to make the implementation small,
rather than duplicating the method and re-implementing it.