### PR TITLE
Simplify SIGWINCH handler to avoid aborting when resizing.

### DIFF
--- a/lib/reline/ansi.rb
+++ b/lib/reline/ansi.rb
@@ -131,8 +131,8 @@ class Reline::ANSI
     unless @@buf.empty?
       return @@buf.shift
     end
-    until c = @@input.raw(intr: true, &:getbyte)
-      sleep 0.1
+    until c = @@input.raw(intr: true) { select([@@input], [], [], 0.1) && @@input.getbyte }
+      Reline.core.line_editor.resize
     end
     (c == 0x16 && @@input.raw(min: 0, tim: 0, &:getbyte)) || c
   rescue Errno::EIO


### PR DESCRIPTION
The current SIGWINCH handler is too large, so it causes Segmentation fault or ThreadError when resizing.

Fix https://github.com/ruby/irb/issues/282