### PR TITLE
Rerender whole buffer when arg editing is finished

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -1401,7 +1401,10 @@ class Reline::LineEditor
       end
       @waiting_operator_proc = nil
       @waiting_operator_vi_arg = nil
-      @vi_arg = nil
+      if @vi_arg
+        @rerender_all = true
+        @vi_arg = nil
+      end
     else
       block.(false)
     end
@@ -1452,7 +1455,10 @@ class Reline::LineEditor
         wrap_method_call(method_symbol, method_obj, key) if method_obj
       end
       @kill_ring.process
-      @vi_arg = nil
+      if @vi_arg
+        @rerender_al = true
+        @vi_arg = nil
+      end
     elsif @vi_arg
       if key.chr =~ /[0-9]/
         ed_argument_digit(key)
@@ -1469,7 +1475,10 @@ class Reline::LineEditor
           ed_insert(key) unless @config.editing_mode_is?(:vi_command)
         end
         @kill_ring.process
-        @vi_arg = nil
+        if @vi_arg
+          @rerender_all = true
+          @vi_arg = nil
+        end
       end
     elsif @waiting_proc
       @waiting_proc.(key)

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -1067,6 +1067,17 @@ begin
       EOC
     end
 
+    def test_rerender_argument_prompt_after_pasting
+      start_terminal(20, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
+      write('abcdef')
+      write("\M-3\C-h")
+      close
+      assert_screen(<<~'EOC')
+        Multiline REPL.
+        prompt> abc
+      EOC
+    end
+
     def write_inputrc(content)
       File.open(@inputrc_file, 'w') do |f|
         f.write content


### PR DESCRIPTION
When just after pasting, should rerender prompt if an argument is provided.