### PR TITLE
Re-calc the scroll pos when the content in dialog is shortened

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -671,6 +671,9 @@ class Reline::LineEditor
       end
       dialog.contents = dialog.contents[dialog.scroll_top, height]
     end
+    if dialog.contents and dialog.scroll_top >= dialog.contents.size
+      dialog.scroll_top = dialog.contents.size - height
+    end
     if dialog_render_info.scrollbar and dialog_render_info.contents.size > height
       bar_max_height = height * 2
       moving_distance = (dialog_render_info.contents.size - height) * 2

--- a/test/reline/yamatanooroti/multiline_repl
+++ b/test/reline/yamatanooroti/multiline_repl
@@ -115,6 +115,13 @@ opt.on('--autocomplete-long') {
     }.select{ |c| c.start_with?(target) }
   }
 }
+opt.on('--autocomplete-super-long') {
+  Reline.autocompletion = true
+  Reline.completion_proc = lambda { |target, preposing = nil, postposing = nil|
+    c = 'A'
+    2000.times.map{ s = "Str_#{c}"; c.succ!; s }.select{ |c| c.start_with?(target) }
+  }
+}
 opt.parse!(ARGV)
 
 begin

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -1057,6 +1057,33 @@ begin
       EOC
     end
 
+    def test_autocomplete_super_long_and_backspace
+      start_terminal(20, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --autocomplete-super-long}, startup_message: 'Multiline REPL.')
+      shift_tab = [27, 91, 90]
+      write('S' + shift_tab.map(&:chr).join)
+      write("\C-h")
+      close
+      assert_screen(<<~'EOC')
+        Multiline REPL.
+        prompt> Str_BX
+                Str_BX
+                Str_BXA
+                Str_BXB
+                Str_BXC
+                Str_BXD
+                Str_BXE
+                Str_BXF
+                Str_BXG
+                Str_BXH
+                Str_BXI
+                Str_BXJ
+                Str_BXK
+                Str_BXL
+                Str_BXM
+                Str_BXN
+      EOC
+    end
+
     def test_dialog_callback_returns_nil
       start_terminal(20, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --dialog nil}, startup_message: 'Multiline REPL.')
       write('a')


### PR DESCRIPTION
This fixes https://github.com/ruby/reline/issues/342 and https://github.com/ruby/reline/issues/349.