### PR TITLE
Use default background color to erase on Windows

### DIFF
--- a/lib/reline/windows.rb
+++ b/lib/reline/windows.rb
@@ -325,10 +325,11 @@ class Reline::Windows
   def self.erase_after_cursor
     csbi = 0.chr * 24
     @@GetConsoleScreenBufferInfo.call(@@hConsoleHandle, csbi)
+    attributes = csbi[8, 2].unpack1('S')
     cursor = csbi[4, 4].unpack1('L')
     written = 0.chr * 4
     @@FillConsoleOutputCharacter.call(@@hConsoleHandle, 0x20, get_screen_size.last - cursor_pos.x, cursor, written)
-    @@FillConsoleOutputAttribute.call(@@hConsoleHandle, 0, get_screen_size.last - cursor_pos.x, cursor, written)
+    @@FillConsoleOutputAttribute.call(@@hConsoleHandle, attributes, get_screen_size.last - cursor_pos.x, cursor, written)
   end
 
   def self.scroll_down(val)


### PR DESCRIPTION
This fixes https://github.com/ruby/irb/issues/260.