### PR TITLE
Only show dialogs if default external encoding is UTF-8

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -624,6 +624,7 @@ class Reline::LineEditor
 
   DIALOG_HEIGHT = 20
   private def render_dialog(cursor_column)
+    return unless Encoding.default_external == Encoding::UTF_8
     @dialogs.each do |dialog|
       render_each_dialog(dialog, cursor_column)
     end


### PR DESCRIPTION
Without this patch, irb crashes in my environment (stock OpenBSD/amd64) when trying to display a dialog:

```
$ run_irb
irb(main):001:0> p
                 pwws                           /home/jeremy/tmp/reline/lib/reline/line_editor.rb:731:in `write': U+2588 from UTF-8 to US-ASCII (Encoding::UndefinedConversionError)
        from /home/jeremy/tmp/reline/lib/reline/line_editor.rb:731:in `block in render_each_dialog'
        from /home/jeremy/tmp/reline/lib/reline/line_editor.rb:715:in `each'
        from /home/jeremy/tmp/reline/lib/reline/line_editor.rb:715:in `each_with_index'
        from /home/jeremy/tmp/reline/lib/reline/line_editor.rb:715:in `render_each_dialog'
        from /home/jeremy/tmp/reline/lib/reline/line_editor.rb:628:in `block in render_dialog'
        from /home/jeremy/tmp/reline/lib/reline/line_editor.rb:627:in `each'
        from /home/jeremy/tmp/reline/lib/reline/line_editor.rb:627:in `render_dialog'
        from /home/jeremy/tmp/reline/lib/reline/line_editor.rb:491:in `rerender'
        from /home/jeremy/tmp/reline/lib/reline.rb:325:in `block (3 levels) in inner_readline'
        from /home/jeremy/tmp/reline/lib/reline.rb:323:in `each'
        from /home/jeremy/tmp/reline/lib/reline.rb:323:in `block (2 levels) in inner_readline'
        from /home/jeremy/tmp/reline/lib/reline.rb:393:in `block in read_io'
        from /home/jeremy/tmp/reline/lib/reline.rb:363:in `loop'
        from /home/jeremy/tmp/reline/lib/reline.rb:363:in `read_io'
        from /home/jeremy/tmp/reline/lib/reline.rb:321:in `block in inner_readline'
        from /home/jeremy/tmp/reline/lib/reline.rb:319:in `loop'
        from /home/jeremy/tmp/reline/lib/reline.rb:319:in `inner_readline'
        from /home/jeremy/tmp/reline/lib/reline.rb:249:in `readmultiline'
        from /home/jeremy/tmp/ruby/lib/forwardable.rb:238:in `readmultiline'
        from /home/jeremy/tmp/ruby/lib/forwardable.rb:238:in `readmultiline'
        from /home/jeremy/tmp/irb/lib/irb/input-method.rb:388:in `gets'
        from /home/jeremy/tmp/irb/lib/irb.rb:538:in `block (2 levels) in eval_input'
        from /home/jeremy/tmp/irb/lib/irb.rb:769:in `signal_status'
        from /home/jeremy/tmp/irb/lib/irb.rb:537:in `block in eval_input'
        from /home/jeremy/tmp/irb/lib/irb/ruby-lex.rb:282:in `lex'
        from /home/jeremy/tmp/irb/lib/irb/ruby-lex.rb:251:in `block (2 levels) in each_top_level_statement'
        from /home/jeremy/tmp/irb/lib/irb/ruby-lex.rb:248:in `loop'
        from /home/jeremy/tmp/irb/lib/irb/ruby-lex.rb:248:in `block in each_top_level_statement'
        from /home/jeremy/tmp/irb/lib/irb/ruby-lex.rb:247:in `catch'
        from /home/jeremy/tmp/irb/lib/irb/ruby-lex.rb:247:in `each_top_level_statement'
        from /home/jeremy/tmp/irb/lib/irb.rb:556:in `eval_input'
        from /home/jeremy/tmp/irb/lib/irb.rb:490:in `block in run'
        from /home/jeremy/tmp/irb/lib/irb.rb:489:in `catch'
        from /home/jeremy/tmp/irb/lib/irb.rb:489:in `run'
        from /home/jeremy/tmp/irb/lib/irb.rb:418:in `start'
        from /home/jeremy/tmp/irb/exe/irb:11:in `<main>'
```

A simple way to fix this is to avoid showing dialogs if the default external encoding is not UTF-8, which this pull request does.  However, I'm not sure if that is the best way.