### PR TITLE
Rescue if tigetstr(capname) cannot be obtained

### DIFF
--- a/lib/reline/ansi.rb
+++ b/lib/reline/ansi.rb
@@ -73,7 +73,7 @@ class Reline::ANSI
         else
           [ key_code.bytes, key_binding ]
         end
-      rescue TerminfoError
+      rescue Reline::Terminfo::TerminfoError
         # capname is undefined
       end
     end.compact.to_h
@@ -300,7 +300,7 @@ class Reline::ANSI
     if Reline::Terminfo.enabled?
       begin
         @@output.write Reline::Terminfo.tigetstr('civis')
-      rescue TerminfoError
+      rescue Reline::Terminfo::TerminfoError
         # civis is undefined
       end
     else
@@ -312,7 +312,7 @@ class Reline::ANSI
     if Reline::Terminfo.enabled?
       begin
         @@output.write Reline::Terminfo.tigetstr('cnorm')
-      rescue TerminfoError
+      rescue Reline::Terminfo::TerminfoError
         # cnorm is undefined
       end
     else


### PR DESCRIPTION
fix https://github.com/ruby/reline/issues/384

If `$TERM` is `vt102`, there are no `kend`, `khome`, `civis`, or `cnorm` in capabilities.
`TerminfoError` is raised in `Reline::Terminfo.tigetstr(capname)`, so it is rescued if it does not exist.