### PR TITLE
Use prerelease version of irb on CI

### DIFF
--- a/.github/workflows/reline.yml
+++ b/.github/workflows/reline.yml
@@ -109,6 +109,6 @@ jobs:
       - name: Install dependencies
         run:  WITH_VTERM=1 bundle install
       - name: Install latest irb
-        run:  gem install irb -f
+        run:  gem install irb -f --pre
       - name: rake test_yamatanooroti
         run:  rake test_yamatanooroti


### PR DESCRIPTION
Added `--pre` because `gem install irb -f` can't install the prerelease version of irb.