### PR TITLE
Execute compress_meta_key if convert_meta is on

### DIFF
--- a/lib/reline/config.rb
+++ b/lib/reline/config.rb
@@ -67,6 +67,7 @@ class Reline::Config
     @keyseq_timeout = 500
     @test_mode = false
     @autocompletion = false
+    @convert_meta = true if seven_bit_encoding?(Reline::IOGate.encoding)
   end
 
   def reset
@@ -386,5 +387,9 @@ class Reline::Config
       ret << key_notation_to_code($&)
     end
     ret
+  end
+
+  private def seven_bit_encoding?(encoding)
+    encoding == Encoding::US_ASCII
   end
 end

--- a/lib/reline/key_stroke.rb
+++ b/lib/reline/key_stroke.rb
@@ -4,6 +4,7 @@ class Reline::KeyStroke
   end
 
   def compress_meta_key(ary)
+    return ary unless @config.convert_meta
     ary.inject([]) { |result, key|
       if result.size > 0 and result.last == "\e".ord
         result[result.size - 1] = Reline::Key.new(key, key | 0b10000000, true)

--- a/test/reline/test_config.rb
+++ b/test/reline/test_config.rb
@@ -11,12 +11,14 @@ class Reline::Config::Test < Reline::TestCase
       Dir.mkdir(@tmpdir)
     end
     Dir.chdir(@tmpdir)
+    Reline.test_mode
     @config = Reline::Config.new
   end
 
   def teardown
     Dir.chdir(@pwd)
     FileUtils.rm_rf(@tmpdir)
+    Reline.test_reset
     @config.reset
   end
 
@@ -79,6 +81,22 @@ class Reline::Config::Test < Reline::TestCase
     LINES
 
     assert_equal '(Emacs)', @config.instance_variable_get(:@emacs_mode_string)
+  end
+
+  def test_encoding_is_ascii
+    @config.reset
+    Reline::IOGate.reset(encoding: Encoding::US_ASCII)
+    @config = Reline::Config.new
+
+    assert_equal true, @config.convert_meta
+  end
+
+  def test_encoding_is_not_ascii
+    @config.reset
+    Reline::IOGate.reset(encoding: Encoding::UTF_8)
+    @config = Reline::Config.new
+
+    assert_equal nil, @config.convert_meta
   end
 
   def test_comment_line

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -739,6 +739,16 @@ begin
       EOC
     end
 
+    def test_not_meta_key
+      start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
+      write("おだんご") # "だ" in UTF-8 contains "\xA0"
+      close
+      assert_screen(<<~EOC)
+        Multiline REPL.
+        prompt> おだんご
+      EOC
+    end
+
     def test_force_enter
       start_terminal(30, 120, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write("def hoge\nend\C-p\C-e")


### PR DESCRIPTION
fix #357

When using 8-bit characters, it is better not to use `compress_meta_key`.
I believe not to use `compress_meta_key` unless `set convert-meta on` is written in the `.inputrc`.

The following is a quote from tmtm's comments.

> The behavior of this compress_meta_key method is similar to the behavior of convert-meta=on in readline, but readline turns off convert-meta if the locale contains 8bit characters.

> In readline(3):

> convert-meta (On)
> If set to On, readline will convert characters with the eighth
> bit set to an ASCII key sequence by stripping the eighth bit and
> prefixing it with an escape character (in effect, using escape
> as the meta prefix). The default is On, but readline will set
> it to Off if the locale contains eight-bit characters.

Co-authored-by: TOMITA Masahiro <tommy@tmtm.org>