### PR TITLE
improve windows paste speed

### DIFF
--- a/lib/reline/windows.rb
+++ b/lib/reline/windows.rb
@@ -237,23 +237,27 @@ class Reline::Windows
       Reline.core.line_editor.resize
       next if @@WaitForSingleObject.(@@hConsoleInputHandle, 100) != 0 # max 0.1 sec
       next if @@GetNumberOfConsoleInputEvents.(@@hConsoleInputHandle, num_of_events) == 0 or num_of_events.unpack1('L') == 0
-      input_record = 0.chr * 18
+      input_records = 0.chr * 20 * 80
       read_event = 0.chr * 4
-      if @@ReadConsoleInputW.(@@hConsoleInputHandle, input_record, 1, read_event) != 0
-        event = input_record[0, 2].unpack1('s*')
-        case event
-        when WINDOW_BUFFER_SIZE_EVENT
-          @@winch_handler.()
-        when KEY_EVENT
-          key_down = input_record[4, 4].unpack1('l*')
-          repeat_count = input_record[8, 2].unpack1('s*')
-          virtual_key_code = input_record[10, 2].unpack1('s*')
-          virtual_scan_code = input_record[12, 2].unpack1('s*')
-          char_code = input_record[14, 2].unpack1('S*')
-          control_key_state = input_record[16, 2].unpack1('S*')
-          is_key_down = key_down.zero? ? false : true
-          if is_key_down
-            process_key_event(repeat_count, virtual_key_code, virtual_scan_code, char_code, control_key_state)
+      if @@ReadConsoleInputW.(@@hConsoleInputHandle, input_records, 80, read_event) != 0
+        read_events = read_event.unpack1('L')
+        0.upto(read_events) do |idx|
+          input_record = input_records[idx * 20, 20]
+          event = input_record[0, 2].unpack1('s*')
+          case event
+          when WINDOW_BUFFER_SIZE_EVENT
+            @@winch_handler.()
+          when KEY_EVENT
+            key_down = input_record[4, 4].unpack1('l*')
+            repeat_count = input_record[8, 2].unpack1('s*')
+            virtual_key_code = input_record[10, 2].unpack1('s*')
+            virtual_scan_code = input_record[12, 2].unpack1('s*')
+            char_code = input_record[14, 2].unpack1('S*')
+            control_key_state = input_record[16, 2].unpack1('S*')
+            is_key_down = key_down.zero? ? false : true
+            if is_key_down
+              process_key_event(repeat_count, virtual_key_code, virtual_scan_code, char_code, control_key_state)
+            end
           end
         end
       end

--- a/lib/reline/windows.rb
+++ b/lib/reline/windows.rb
@@ -274,7 +274,7 @@ class Reline::Windows
   end
 
   def self.empty_buffer?
-    if not @@input_buf.empty?
+    if not @@output_buf.empty?
       false
     elsif @@kbhit.call == 0
       true


### PR DESCRIPTION
Reline::Windows.in_pasting not working, this patch resolve it.
paste #74 code between 
```
t = Time.now
# #74
p (Time.now - t) * 1000
```
shows 2700msec -> 410msec.
074e407c62e6615c577e77fdf9328d41367015fb and eb3ef7af98ed44df7170d3247410a400725d08a9 both required.
Either one patch works less/none.

ref. #186