### PR TITLE
Remove unnecessary variables, `lower_space`

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -706,19 +706,18 @@ class Reline::LineEditor
       dialog.scrollbar_pos = nil
     end
     upper_space = @first_line_started_from - @started_from
-    lower_space = @highest_in_all - @first_line_started_from - @started_from - 1
     dialog.column = dialog_render_info.pos.x
     dialog.width += @block_elem_width if dialog.scrollbar_pos
     diff = (dialog.column + dialog.width) - (@screen_size.last)
     if diff > 0
       dialog.column -= diff
     end
-    if (lower_space + @rest_height - dialog_render_info.pos.y) >= height
+    if (@rest_height - dialog_render_info.pos.y) >= height
       dialog.vertical_offset = dialog_render_info.pos.y + 1
     elsif upper_space >= height
       dialog.vertical_offset = dialog_render_info.pos.y - height
     else
-      if (lower_space + @rest_height - dialog_render_info.pos.y) < height
+      if (@rest_height - dialog_render_info.pos.y) < height
         scroll_down(height + dialog_render_info.pos.y)
         move_cursor_up(height + dialog_render_info.pos.y)
       end

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -1197,6 +1197,26 @@ begin
       EOC
     end
 
+    def test_bottom
+      start_terminal(10, 40, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --autocomplete}, startup_message: 'Multiline REPL.')
+      write("\n\n\n\n\n\n")
+      write("def hoge\n\n\n\n\n\n\nend\C-p\C-p\C-p\C-e")
+      write("  S")
+      close
+      assert_screen(<<~'EOC')
+        prompt> def hoge
+        prompt>
+        prompt>
+        prompt>
+        prompt>   S
+        prompt>   String
+        prompt>   Struct
+        prompt> enSymbol
+                  ScriptError
+                  Signal
+      EOC
+    end
+
     def write_inputrc(content)
       File.open(@inputrc_file, 'w') do |f|
         f.write content


### PR DESCRIPTION
The number of lines below the cursor position was known by `@rest_height` alone, but the problem was caused by adding `lower_space`. Remove `lower_space` as it is unnecessary.

This fixes https://github.com/ruby/reline/issues/391.