### PR TITLE
Prefer wait_readable for fiber scheduler.

### DIFF
--- a/lib/reline/ansi.rb
+++ b/lib/reline/ansi.rb
@@ -147,7 +147,7 @@ class Reline::ANSI
     unless @@buf.empty?
       return @@buf.shift
     end
-    until c = @@input.raw(intr: true) { select([@@input], [], [], 0.1) && @@input.getbyte }
+    until c = @@input.raw(intr: true) { @@input.wait_readable(0.1) && @@input.getbyte }
       Reline.core.line_editor.resize
     end
     (c == 0x16 && @@input.raw(min: 0, tim: 0, &:getbyte)) || c

--- a/lib/reline/general_io.rb
+++ b/lib/reline/general_io.rb
@@ -1,4 +1,5 @@
 require 'timeout'
+require 'io/wait'
 
 class Reline::GeneralIO
   def self.reset(encoding: nil)
@@ -36,7 +37,7 @@ class Reline::GeneralIO
     end
     c = nil
     loop do
-      result = select([@@input], [], [], 0.1)
+      result = @@input.wait_readable(0.1)
       next if result.nil?
       c = @@input.read(1)
       break


### PR DESCRIPTION
The fiber scheduler does not handle `IO#select` and for one IO there is no point to use it. Using `IO#wait_readable` is the preferred approach as it works both with and without the fiber scheduler.