### PR TITLE
Load correct version.rb from gemspec

### DIFF
--- a/reline.gemspec
+++ b/reline.gemspec
@@ -1,7 +1,9 @@
 
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'reline/version'
+begin
+  require_relative 'lib/reline/version'
+rescue LoadError
+  require_relative 'version'
+end
 
 Gem::Specification.new do |spec|
   spec.name          = 'reline'


### PR DESCRIPTION
When merged to ruby/ruby, reline.gemspec file is located under lib/reline, as the same as reline/version.rb.
That is the latter path relative from the former differs from the ruby/reline case, and the reline/version.rb in the default load path will be loaded.
Try `require_relative` not to load unexpected files.