### PR TITLE
Delete { and ( characters from completer_word_break_characters

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -533,7 +533,7 @@ module Reline
       core.line_editor = Reline::LineEditor.new(core.config, Reline::IOGate.encoding)
 
       core.basic_word_break_characters = " \t\n`><=;|&{("
-      core.completer_word_break_characters = " \t\n`><=;|&{("
+      core.completer_word_break_characters = " \t\n`><=;|&"
       core.basic_quote_characters = '"\''
       core.completer_quote_characters = '"\''
       core.filename_quote_characters = ""

--- a/test/reline/test_reline.rb
+++ b/test/reline/test_reline.rb
@@ -61,7 +61,7 @@ class Reline::Test < Reline::TestCase
   def test_completer_word_break_characters
     completer_word_break_characters = Reline.completer_word_break_characters
 
-    assert_equal(" \t\n`><=;|&{(", Reline.completer_word_break_characters)
+    assert_equal(" \t\n`><=;|&", Reline.completer_word_break_characters)
 
     Reline.completer_word_break_characters = "[".encode(Encoding::ASCII)
     assert_equal("[", Reline.completer_word_break_characters)


### PR DESCRIPTION
Hello guys,

It is an attempt to solve the issue https://github.com/ruby/irb/issues/314.

The { and ( characters are being considered during a regex operation.

https://github.com/ruby/reline/blob/0c7cc7b4354d94d33c277fe3304d50bf989f4c68/lib/reline/line_editor.rb#L1759

It is causing the method retrieve_completion_block generates an unexpected target.

https://github.com/ruby/reline/blob/0c7cc7b4354d94d33c277fe3304d50bf989f4c68/lib/reline/line_editor.rb#L1721

After.

```
"()".
# "()".unicode_normalize!
# "()".to_r
# "()".pretty_print
# "()".encode
# "()".include?

"{}".
# "{}".unicode_normalize!
# "{}".to_r
# "{}".pretty_print
# "{}".encode
# "{}".include?
```

Before.

```
"()".
# "()".Array
# "()".Complex
# "()".CurrentContext
# "()".Float
# "()".Hash

"{}".
# "{}".Array
# "{}".Complex
# "{}".CurrentContext
# "{}".Float
# "{}".Hash
```

Thank you very much.
    