### PR TITLE
Split off set_signal_handler method

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -290,6 +290,7 @@ module Reline
 
       may_req_ambiguous_char_width
       line_editor.reset(prompt, encoding: Reline::IOGate.encoding)
+      line_editor.set_signal_handlers
       if multiline
         line_editor.multiline_on
         if block_given?

--- a/lib/reline/ansi.rb
+++ b/lib/reline/ansi.rb
@@ -345,8 +345,6 @@ class Reline::ANSI
   end
 
   def self.deprep(otio)
-    int_handle = Signal.trap('INT', 'IGNORE')
-    Signal.trap('INT', int_handle)
     Signal.trap('WINCH', @@old_winch_handler) if @@old_winch_handler
   end
 end


### PR DESCRIPTION
In some tests, the `LineEditor#reset` method is always called, but doesn't need to set the signal handlers there, so cuts it out to a separate method.