### PR TITLE
Character merging may increase the character width

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -2030,6 +2030,7 @@ class Reline::LineEditor
     @byte_pointer += bytesize
     last_mbchar = @line.byteslice((@byte_pointer - bytesize - last_byte_size), last_byte_size)
     if last_byte_size != 0 and (last_mbchar + str).grapheme_clusters.size == 1
+      # combined char
       width = 0
     end
     @cursor += width

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -2029,9 +2029,16 @@ class Reline::LineEditor
     last_byte_size = Reline::Unicode.get_prev_mbchar_size(@line, @byte_pointer)
     @byte_pointer += bytesize
     last_mbchar = @line.byteslice((@byte_pointer - bytesize - last_byte_size), last_byte_size)
-    if last_byte_size != 0 and (last_mbchar + str).grapheme_clusters.size == 1
+    combined_char = last_mbchar + str
+    if last_byte_size != 0 and combined_char.grapheme_clusters.size == 1
       # combined char
-      width = 0
+      last_mbchar_width = Reline::Unicode.get_mbchar_width(last_mbchar)
+      combined_char_width = Reline::Unicode.get_mbchar_width(combined_char)
+      if combined_char_width > last_mbchar_width
+        width = combined_char_width - last_mbchar_width
+      else
+        width = 0
+      end
     end
     @cursor += width
     @cursor_max += width

--- a/test/reline/test_key_actor_emacs.rb
+++ b/test/reline/test_key_actor_emacs.rb
@@ -2306,6 +2306,22 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
     assert_line('abcd')
   end
 
+  def test_halfwidth_kana_width_dakuten
+    input_keys('ｶﾞｷﾞｹﾞｺﾞ')
+    assert_byte_pointer_size('ｶﾞｷﾞｹﾞｺﾞ')
+    assert_cursor(8)
+    assert_cursor_max(8)
+    input_keys("\C-b\C-b", false)
+    assert_byte_pointer_size('ｶﾞｷﾞ')
+    assert_cursor(4)
+    assert_cursor_max(8)
+    input_keys('ｸﾞ', false)
+    assert_byte_pointer_size('ｶﾞｷﾞｸﾞ')
+    assert_cursor(6)
+    assert_cursor_max(10)
+    assert_line('ｶﾞｷﾞｸﾞｹﾞｺﾞ')
+  end
+
   def test_input_unknown_char
     input_keys('͸') # U+0378 (unassigned)
     assert_line('͸')


### PR DESCRIPTION
When a halfwidth character is followed by a halfwidth dakuten or a halfwidth handakuten character, it should be treated as a single grapheme. So, even if the number of graphemes doesn't change owing to character merging, the character width may increase.

This fixes https://github.com/ruby/reline/issues/405.