### PR TITLE
Fix test input_keys to handle "hankaku" characters correctly on Windows

### DIFF
--- a/test/reline/helper.rb
+++ b/test/reline/helper.rb
@@ -77,6 +77,13 @@ class Reline::TestCase < Test::Unit::TestCase
     end
   end
 
+  def input_raw_keys(input, convert = true)
+    input = convert_str(input) if convert
+    input.bytes.each do |b|
+      @line_editor.input_key(Reline::Key.new(b, b, false))
+    end
+  end
+
   def assert_line(expected)
     expected = convert_str(expected)
     assert_equal(expected, @line_editor.line)

--- a/test/reline/test_key_actor_emacs.rb
+++ b/test/reline/test_key_actor_emacs.rb
@@ -2307,7 +2307,7 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
   end
 
   def test_halfwidth_kana_width_dakuten
-    input_keys('ｶﾞｷﾞｹﾞｺﾞ')
+    input_raw_keys('ｶﾞｷﾞｹﾞｺﾞ')
     assert_byte_pointer_size('ｶﾞｷﾞｹﾞｺﾞ')
     assert_cursor(8)
     assert_cursor_max(8)
@@ -2315,7 +2315,7 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
     assert_byte_pointer_size('ｶﾞｷﾞ')
     assert_cursor(4)
     assert_cursor_max(8)
-    input_keys('ｸﾞ', false)
+    input_raw_keys('ｸﾞ', false)
     assert_byte_pointer_size('ｶﾞｷﾞｸﾞ')
     assert_cursor(6)
     assert_cursor_max(10)


### PR DESCRIPTION
The method "input_keys" in test/reline/helper.rb handles a single-byte
and 8-bit charater as an input with the meta key.
However, "test_halfwidth_kana_width_dakuten" in test/reline/test_key_actor_emacs.rb
uses a string that contains "hankaku" characters.
A "hankaku" character is not with the meta key, but it is a single-byte
and 8-bit character on Windows-31J encoding, which confused "input_keys"
method. This caused the following error.

https://ci.appveyor.com/project/ruby/ruby/builds/41997092/job/ejm77qxgvnlpdwvg
```
  1) Failure:
Reline::KeyActor::Emacs::Test#test_halfwidth_kana_width_dakuten [C:/projects/ruby/test/reline/test_key_actor_emacs.rb:2311]:
<"\xB6\xDE\xB7\xDE\xB9\xDE\xBA\xDE" (#<Encoding:Windows-31J>)> expected but was
<"\e^\e^\e^\e:\e^" (#<Encoding:Windows-31J>)> in <Terminal #<Encoding:Windows-31J>>
.
<8> expected but was
<10>.
Finished tests in 1045.472722s, 19.3922 tests/s, 2609.4320 assertions/s.
```

This change introduces "input_raw_keys" that does not convert a
single-byte and 8-bit character to "with the meta key", and use it in
the test in question.