### PR TITLE
windows fix scroll

### DIFF
--- a/lib/reline/windows.rb
+++ b/lib/reline/windows.rb
@@ -386,7 +386,7 @@ class Reline::Windows
   def self.scroll_down(val)
     return if val < 0
     return unless csbi = get_console_screen_buffer_info
-    buffer_width, x, y, buffer_lines, attributes, window_left, window_top, window_bottom = csbi.unpack('ssssSssx2s')
+    buffer_width, buffer_lines, x, y, attributes, window_left, window_top, window_bottom = csbi.unpack('ssssSssx2s')
     screen_height = window_bottom - window_top + 1
     val = screen_height if val > screen_height
 


### PR DESCRIPTION
Sorry, my patch b61bc43374931dcc2a92325b7a661d7d30fb459d break scrolling.

In Windows Terminal, scrolling shows strange behavior(cursor jumping).
In cmd.exe, this comes in last line of screen buffer. 
I missed this because of using cmd.exe with long screen buffer.