### PR TITLE
Exhibit the correct recommendations in IRB autocomplete for strings

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -1824,12 +1824,12 @@ class Reline::LineEditor
   end
 
   private def string_slice?(line_pos)
-    line_scan = Ripper::Lexer.new(@line).scan
+    line_scan = Ripper::Lexer.lex(@line)
     counter = 0
     line_scan.each do |elem|
-      counter += elem.tok.length
+      counter += elem[2].length
       if line_pos < counter
-        if [:on_tstring_beg, :on_embexpr_beg, :on_tstring_content, :on_embexpr_end, :on_tstring_end].include? elem.event
+        if [:on_tstring_beg, :on_embexpr_beg, :on_tstring_content, :on_embexpr_end, :on_tstring_end].include? elem[1]
           return true
         end
         break

--- a/test/reline/test_string_processing.rb
+++ b/test/reline/test_string_processing.rb
@@ -78,4 +78,41 @@ class Reline::LineEditor::StringProcessingTest < Reline::TestCase
     })
     @line_editor.__send__(:call_completion_proc)
   end
+
+  def test_completion_proc_parenthesis
+    # IRB has some specific settings
+    Reline.completer_quote_characters = ""
+
+    buf = ["\"()\"", "()"]
+
+    @line_editor.instance_variable_set(:@is_multiline, true)
+    @line_editor.instance_variable_set(:@buffer_of_lines, buf)
+    @line_editor.instance_variable_set(:@line, buf[0])
+    @line_editor.instance_variable_set(:@byte_pointer, 4)
+    @line_editor.instance_variable_set(:@cursor, 4)
+    @line_editor.instance_variable_set(:@cursor_max, 4)
+    @line_editor.instance_variable_set(:@line_index, 0)
+    @line_editor.instance_variable_set(:@completion_proc, proc { |target, pre, post|
+      assert_equal("\"()\"", target)
+      assert_equal("", pre)
+      assert_equal("\n" + "()", post)
+    })
+    @line_editor.__send__(:call_completion_proc)
+
+    # the target for () returns ) because of completer_word_break_characters
+    # it likely needs improvements
+    @line_editor.instance_variable_set(:@is_multiline, true)
+    @line_editor.instance_variable_set(:@buffer_of_lines, buf)
+    @line_editor.instance_variable_set(:@line, buf[1])
+    @line_editor.instance_variable_set(:@byte_pointer, 2)
+    @line_editor.instance_variable_set(:@cursor, 2)
+    @line_editor.instance_variable_set(:@cursor_max, 2)
+    @line_editor.instance_variable_set(:@line_index, 1)
+    @line_editor.instance_variable_set(:@completion_proc, proc { |target, pre, post|
+      assert_equal(")", target)
+      assert_equal("\"()\"\n" + "(", pre)
+      assert_equal("", post)
+    })
+    @line_editor.__send__(:call_completion_proc)
+  end
 end


### PR DESCRIPTION
This is an attempt to fix the issue https://github.com/ruby/irb/issues/314.

Instead of changing completer_word_break_characters like I tried here https://github.com/ruby/reline/pull/400 now this is checking if slice is part of a string.

The while method looks to be ignoring the previous characters relatively to slice when it is searching for the target.

https://github.com/ruby/reline/blob/3f6ea9226898f95c54ff65ebbea0e3a82a4a79e4/lib/reline/line_editor.rb#L1747

Debug the code printing slice.

```
while i < @byte_pointer do
  slice = @line.byteslice(i, @byte_pointer - i)
  puts
  p "slice #{slice}
```

Type "0 + 1" in IRB to visualize slice values.

```
3.0.3 :001 > "0 + 1"
"slice \"0 + 1"

"slice 0 + 1"

"slice  + 1"

"slice + 1"

"slice  1"

"slice 1" 
```

It is actually getting the string to the right of the last successful match using `$'` without considering its type.

https://github.com/ruby/reline/blob/3f6ea9226898f95c54ff65ebbea0e3a82a4a79e4/lib/reline/line_editor.rb#L1767-L1771

The current branch is analyzing if slice is a string before getting `$'`.

After.

```
"()".
# "()".unicode_normalize!
# "()".to_r
# "()".pretty_print
# "()".encode
# "()".include?

"{}".
# "{}".unicode_normalize!
# "{}".to_r
# "{}".pretty_print
# "{}".encode
# "{}".include?

"(#{0})".
# "(#{0})".unicode_normalize!
# "(#{0})".to_r
# "(#{0})".pretty_print
# "(#{0})".encode
# "(#{0})".include?
```

Before.

```
"()".
# )".Array
# )".Complex
# )".CurrentContext
# )".Float
# )".Hash

"{}".
# }".Array
# }".Complex
# }".CurrentContext
# }".Float
# }".Hash

"(#{0})".
# 0})".Array
# 0})".Complex
# 0})".CurrentContext
# 0})".Float
# 0})".Hash
```