### PR TITLE
Use omit instead of skip

### DIFF
--- a/test/reline/test_reline.rb
+++ b/test/reline/test_reline.rb
@@ -137,7 +137,7 @@ class Reline::Test < Reline::TestCase
   end
 
   def test_completion_proc
-    skip unless Reline.completion_proc == nil
+    omit unless Reline.completion_proc == nil
     # Another test can set Reline.completion_proc
 
     # assert_equal(nil, Reline.completion_proc)

--- a/test/reline/test_terminfo.rb
+++ b/test/reline/test_terminfo.rb
@@ -9,24 +9,24 @@ class Reline::Terminfo::Test < Reline::TestCase
   def test_tigetstr
     assert Reline::Terminfo.tigetstr('khome')
   rescue Reline::Terminfo::TerminfoError => e
-    skip e.message
+    omit e.message
   end
 
   def test_tiparm
     assert Reline::Terminfo.tigetstr('khome').tiparm
   rescue Reline::Terminfo::TerminfoError => e
-    skip e.message
+    omit e.message
   end
 
   def test_tigetstr_with_param
     assert Reline::Terminfo.tigetstr('cuu').include?('%p1%d')
   rescue Reline::Terminfo::TerminfoError => e
-    skip e.message
+    omit e.message
   end
 
   def test_tiparm_with_param
     assert Reline::Terminfo.tigetstr('cuu').tiparm(4649).include?('4649')
   rescue Reline::Terminfo::TerminfoError => e
-    skip e.message
+    omit e.message
   end
 end if Reline::Terminfo.enabled?


### PR DESCRIPTION
`skip` is minitest methods. I hope to migrate it to `omit` provided by `test-unit`