### PR TITLE
Use unix_line_discard when Ctrl-u is entered

### DIFF
--- a/lib/reline/key_actor/emacs.rb
+++ b/lib/reline/key_actor/emacs.rb
@@ -43,7 +43,7 @@ class Reline::KeyActor::Emacs < Reline::KeyActor::Base
     #  20 ^T
     :ed_transpose_chars,
     #  21 ^U
-    :ed_kill_line,
+    :unix_line_discard,
     #  22 ^V
     :ed_quoted_insert,
     #  23 ^W

--- a/test/reline/test_key_actor_emacs.rb
+++ b/test/reline/test_key_actor_emacs.rb
@@ -2329,4 +2329,26 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
     assert_cursor(1)
     assert_cursor_max(1)
   end
+
+  def test_unix_line_discard
+    input_keys("\C-u", false)
+    assert_byte_pointer_size('')
+    assert_cursor(0)
+    assert_cursor_max(0)
+    assert_line('')
+    input_keys('abc')
+    assert_byte_pointer_size('abc')
+    assert_cursor(3)
+    assert_cursor_max(3)
+    input_keys("\C-b\C-u", false)
+    assert_byte_pointer_size('')
+    assert_cursor(0)
+    assert_cursor_max(1)
+    assert_line('c')
+    input_keys("\C-f\C-u", false)
+    assert_byte_pointer_size('')
+    assert_cursor(0)
+    assert_cursor_max(0)
+    assert_line('')
+  end
 end


### PR DESCRIPTION
fix https://github.com/ruby/reline/issues/415

The kill-line was called when C-u was entered, so it is now called unix-line-discard.

In readline(3):

> unix-line-discard (C-u)
>               Kill backward from point to the beginning of the line.
>               The killed text is saved on the kill-ring.