### PR TITLE
test_yamatanooroti on ruby 2.7 needs irb>=1.3.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,5 @@ group :development do
   is_unix = RUBY_PLATFORM =~ /(aix|darwin|linux|(net|free|open)bsd|cygwin|solaris|irix|hpux)/i
   gem 'vterm', '>= 0.0.5' if is_unix && ENV['WITH_VTERM']
   gem 'yamatanooroti', '>= 0.0.9'
+  gem 'irb', '>= 1.3.6'
 end


### PR DESCRIPTION
ruby 2.7 bundles irb 1.2.6
test/relline/yamatanooroti/termination_checker.rb, RubyLex.ripper_lex_without_warning() needs irb >= 1.3.6