### PR TITLE
windows: test_yamatanooroti fix

### DIFF
--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -948,7 +948,7 @@ begin
 
     def test_dialog_with_fullwidth_chars
       ENV['RELINE_TEST_PROMPT'] = '> '
-      start_terminal(30, 5, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --dialog fullwidth,scrollkey,scrollbar}, startup_message: 'Multiline REPL.')
+      start_terminal(20, 5, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --dialog fullwidth,scrollkey,scrollbar}, startup_message: 'Multiline REPL.')
       6.times{ write('j') }
       close
       assert_screen(<<~'EOC')
@@ -965,7 +965,7 @@ begin
 
     def test_dialog_with_fullwidth_chars_split
       ENV['RELINE_TEST_PROMPT'] = '> '
-      start_terminal(30, 6, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --dialog fullwidth,scrollkey,scrollbar}, startup_message: 'Multiline REPL.')
+      start_terminal(20, 6, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --dialog fullwidth,scrollkey,scrollbar}, startup_message: 'Multiline REPL.')
       6.times{ write('j') }
       close
       assert_screen(<<~'EOC')


### PR DESCRIPTION
Because of console geometry, SetConsoleScreenBufferSize() fails in yamatanooroti/windows.rb

SetConsoleScreenBufferSize() fails at too narrow console size (in pixel).
Bigger font resolv this, but screen height limit is other probrem.
1080lines screen needs this patch, 1440lines screen not

With this patch and yamatanootori head,
ruby 3.0.3p157 (2021-11-24 revision 3fb7d2cadc) [x64-mingw32] passed test_yamatanooroti with

```
Finished in 315.1460539 seconds.
------------------------------------------------------------------------------------------------------------------------
76 tests, 74 assertions, 0 failures, 0 errors, 0 pendings, 2 omissions, 0 notifications
100% passed
------------------------------------------------------------------------------------------------------------------------
0.24 tests/s, 0.23 assertions/s
```

but ruby 2.7 yet (probably dialog and windows last column write behavior)