### PR TITLE
Fix reline on Solaris

### DIFF
--- a/lib/reline/terminfo.rb
+++ b/lib/reline/terminfo.rb
@@ -92,9 +92,9 @@ module Reline::Terminfo
   end
 
   def self.setupterm(term, fildes)
-    errret_int = String.new("\x00" * 8, encoding: 'ASCII-8BIT')
+    errret_int = Fiddle::Pointer.malloc(Fiddle::SIZEOF_INT)
     ret = @setupterm.(term, fildes, errret_int)
-    errret = errret_int.unpack1('i')
+    errret = errret_int[0, Fiddle::SIZEOF_INT].unpack1('i')
     case ret
     when 0 # OK
       0


### PR DESCRIPTION
Solaris requires that the pointer errret_int is alined to an integer,
however, with VWA, strings are no longer aligned to an integer, so use a
Fiddle::Pointer with a malloc'd region instead.