### PR TITLE
The AltGr behaves exactly the same as Ctrl+Alt

### DIFF
--- a/lib/reline/windows.rb
+++ b/lib/reline/windows.rb
@@ -95,7 +95,7 @@ class Reline::Windows
   end
 
   VK_RETURN = 0x0D
-  VK_MENU = 0x12
+  VK_MENU = 0x12 # ALT key
   VK_LMENU = 0xA4
   VK_CONTROL = 0x11
   VK_SHIFT = 0x10

--- a/lib/reline/windows.rb
+++ b/lib/reline/windows.rb
@@ -249,7 +249,7 @@ class Reline::Windows
     # no char, only control keys
     return if key.char_code == 0 and key.control_keys.any?
 
-    @@output_buf.push("\e".ord) if key.control_keys.include?(:ALT)
+    @@output_buf.push("\e".ord) if key.control_keys.include?(:ALT) and !key.control_keys.include?(:CTRL)
 
     @@output_buf.concat(key.char.bytes)
   end


### PR DESCRIPTION
On European keyboards.

This fixes https://github.com/ruby/irb/issues/331.

ref.
- https://devblogs.microsoft.com/oldnewthing/20040329-00/?p=40003
- https://docs.microsoft.com/en-us/windows/terminal/customize-settings/profile-advanced
