### PR TITLE
Ignore global constants when checking if Fiddle::VERSION exists

### DIFF
--- a/lib/reline/terminfo.rb
+++ b/lib/reline/terminfo.rb
@@ -35,7 +35,7 @@ module Reline::Terminfo
       # Gem module isn't defined in test-all of the Ruby repository, and
       # Fiddle in Ruby 3.0.0 or later supports Fiddle::TYPE_VARIADIC.
       fiddle_supports_variadic = true
-    elsif Fiddle.const_defined?(:VERSION) and Gem::Version.create(Fiddle::VERSION) >= Gem::Version.create('1.0.1')
+    elsif Fiddle.const_defined?(:VERSION,false) and Gem::Version.create(Fiddle::VERSION) >= Gem::Version.create('1.0.1')
       # Fiddle::TYPE_VARIADIC is supported from Fiddle 1.0.1.
       fiddle_supports_variadic = true
     else


### PR DESCRIPTION
If a top-level `VERSION` constant exists, or if a module containing a `VERSION` constant is included into the top-level scope, then `Fiddle.const_defined?(:VERSION)` will erroneously return true when `RUBY_VERSION < '3.0.0'`.