### PR TITLE
Check the ambiguous char width only on tty

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -466,7 +466,7 @@ module Reline
     end
 
     private def may_req_ambiguous_char_width
-      @ambiguous_width = 2 if Reline::IOGate == Reline::GeneralIO or STDOUT.is_a?(File)
+      @ambiguous_width = 2 if Reline::IOGate == Reline::GeneralIO or !STDOUT.tty?
       return if defined? @ambiguous_width
       Reline::IOGate.move_cursor_column(0)
       begin


### PR DESCRIPTION
It sent the char to check even to non-tty, e.g., pipe.
This causes `unknown command: "\xE2\x96\xBDstart ` warnings on ruby's parallel test on Windows, where non-standard FDs cannot be passed to child processes.