### PR TITLE
Fix support for emacs-ctlx and emacs-meta keymaps

### DIFF
--- a/lib/reline/config.rb
+++ b/lib/reline/config.rb
@@ -55,6 +55,7 @@ class Reline::Config
     @if_stack = nil
     @editing_mode_label = :emacs
     @keymap_label = :emacs
+    @keymap_prefix = []
     @key_actors = {}
     @key_actors[:emacs] = Reline::KeyActor::Emacs.new
     @key_actors[:vi_insert] = Reline::KeyActor::ViInsert.new
@@ -221,7 +222,7 @@ class Reline::Config
         key, func_name = $1, $2
         keystroke, func = bind_key(key, func_name)
         next unless keystroke
-        @additional_key_bindings[@keymap_label][keystroke] = func
+        @additional_key_bindings[@keymap_label][@keymap_prefix + keystroke] = func
       end
     end
     unless @if_stack.empty?
@@ -292,18 +293,29 @@ class Reline::Config
       when 'emacs'
         @editing_mode_label = :emacs
         @keymap_label = :emacs
+        @keymap_prefix = []
       when 'vi'
         @editing_mode_label = :vi_insert
         @keymap_label = :vi_insert
+        @keymap_prefix = []
       end
     when 'keymap'
       case value
-      when 'emacs', 'emacs-standard', 'emacs-meta', 'emacs-ctlx'
+      when 'emacs', 'emacs-standard'
         @keymap_label = :emacs
+        @keymap_prefix = []
+      when 'emacs-ctlx'
+        @keymap_label = :emacs
+        @keymap_prefix = [?\C-x.ord]
+      when 'emacs-meta'
+        @keymap_label = :emacs
+        @keymap_prefix = [?\e.ord]
       when 'vi', 'vi-move', 'vi-command'
         @keymap_label = :vi_command
+        @keymap_prefix = []
       when 'vi-insert'
         @keymap_label = :vi_insert
+        @keymap_prefix = []
       end
     when 'keyseq-timeout'
       @keyseq_timeout = value.to_i

--- a/test/reline/test_config.rb
+++ b/test/reline/test_config.rb
@@ -274,6 +274,28 @@ class Reline::Config::Test < Reline::TestCase
     assert_equal expected, @config.key_bindings
   end
 
+  def test_additional_key_bindings_for_auxiliary_emacs_keymaps
+    @config.read_lines(<<~'LINES'.lines)
+      set keymap emacs
+      "ab": "AB"
+      set keymap emacs-standard
+      "cd": "CD"
+      set keymap emacs-ctlx
+      "ef": "EF"
+      set keymap emacs-meta
+      "gh": "GH"
+      set editing-mode emacs # keymap changes to be emacs
+    LINES
+
+    expected = {
+      'ab'.bytes => 'AB'.bytes,
+      'cd'.bytes => 'CD'.bytes,
+      "\C-xef".bytes => 'EF'.bytes,
+      "\egh".bytes => 'GH'.bytes,
+    }
+    assert_equal expected, @config.key_bindings
+  end
+
   def test_history_size
     @config.read_lines(<<~LINES.lines)
       set history-size 5000


### PR DESCRIPTION
The existing implementation, given the below .inputrc, erroneously creates a `C-v` key binding:

	set keymap emacs-ctlx
	"\C-v": "[C-x C-v was pressed]"

This fixes it to instead create a `C-x C-v` keybinding.