### PR TITLE
Remove loose operation in Dialog#render_each_dialog

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -760,7 +760,6 @@ class Reline::LineEditor
           @output.write @full_block
         elsif dialog.scrollbar_pos <= (i * 2) and (i * 2) < (dialog.scrollbar_pos + bar_height)
           @output.write @upper_half_block
-          str += ''
         elsif dialog.scrollbar_pos <= (i * 2 + 1) and (i * 2) < (dialog.scrollbar_pos + bar_height)
           @output.write @lower_half_block
         else


### PR DESCRIPTION
The variable ``str`` is not used after this point, making the string operation ``str += ''`` unnecessary.