### PR TITLE
Always set default key bindings in lists

### DIFF
--- a/lib/reline/ansi.rb
+++ b/lib/reline/ansi.rb
@@ -30,10 +30,9 @@ class Reline::ANSI
   end
 
   def self.set_default_key_bindings(config)
+    set_default_key_bindings_comprehensive_list(config)
     if Reline::Terminfo.enabled?
       set_default_key_bindings_terminfo(config)
-    else
-      set_default_key_bindings_comprehensive_list(config)
     end
     {
       # extended entries of terminfo


### PR DESCRIPTION
The default key combinations of many terminal emulators did not match the information in `terminfo`. To maintain compatibility, the key bindings in the comprehensive list should always be set by default.

This cloud fixes ruby/irb#330 home/end/delete key bindings in some cases.