### PR TITLE
Workaround libncurses.so as a linker script

### DIFF
--- a/lib/reline/terminfo.rb
+++ b/lib/reline/terminfo.rb
@@ -24,7 +24,8 @@ module Reline::Terminfo
     when /darwin/
       %w[libncursesw.dylib libcursesw.dylib libncurses.dylib libcurses.dylib]
     else
-      %w[libncursesw.so libcursesw.so libncurses.so libcurses.so]
+      %w[libncursesw.so libcursesw.so libncurses.so libcurses.so
+         libncursesw.so.6 libncurses.so.6]
     end
   end
 


### PR DESCRIPTION
This maybe isn't probably isn't the best approach, but it should allow
`Fiddle::Terminfo.curses_dl` to work.  I documented more details about
this in an issue on fiddle: https://github.com/ruby/fiddle/issues/107

It is probably better to deal with it there.  But this workaround is
simpler.

FYI: `reline` itself seems to be working just fine for me _without_
loading ncurses.  But I wanted to be able to use `Reline::Terminfo` for
my own projects. :)