### PR TITLE
[WIP] Use latest gem-bundler

### DIFF
--- a/.github/workflows/reline.yml
+++ b/.github/workflows/reline.yml
@@ -106,6 +106,8 @@ jobs:
           sed -i -e 's/^PREFIX=.*$/PREFIX=\/usr/g' Makefile
           make
           sudo make install
+      - name: Install latest bundler
+        run:  gem install bundler
       - name: Install dependencies
         run:  WITH_VTERM=1 bundle install
       - name: Install latest irb

--- a/.github/workflows/reline.yml
+++ b/.github/workflows/reline.yml
@@ -106,8 +106,6 @@ jobs:
           sed -i -e 's/^PREFIX=.*$/PREFIX=\/usr/g' Makefile
           make
           sudo make install
-      - name: Install latest bundler
-        run:  gem install bundler
       - name: Install dependencies
         run:  WITH_VTERM=1 bundle install
       - name: Install latest irb

--- a/.github/workflows/reline.yml
+++ b/.github/workflows/reline.yml
@@ -112,5 +112,7 @@ jobs:
         run:  WITH_VTERM=1 bundle install
       - name: Install latest irb
         run:  gem install irb -f --pre
+      - name: debug output
+        run:  echo "exit" | ruby ./test/reline/yamatanooroti/multiline_repl
       - name: rake test_yamatanooroti
         run:  rake test_yamatanooroti


### PR DESCRIPTION
`rake test_yamatanooroti` fails when the `multiline_repl` script gives the following warning

```shell
$ ruby ./test/reline/yamatanooroti/multiline_repl
Warning: the running version of Bundler (2.2.15) is older than the version that created the lockfile (2.3.7). We suggest you to upgrade to the version that created the lockfile by running `gem install bundler:2.3.7`.
Multiline REPL.
prompt>
```