### PR TITLE
Rename dialog_pointer_* to dialog_highlight_*

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -53,12 +53,12 @@ module Reline
     :dialog_default_fg_color,
     :dialog_default_fg_color_sequence,
     :dialog_default_fg_color=,
-    :dialog_pointer_bg_color,
-    :dialog_pointer_bg_color_sequence,
-    :dialog_pointer_bg_color=,
-    :dialog_pointer_fg_color,
-    :dialog_pointer_fg_color_sequence,
-    :dialog_pointer_fg_color=
+    :dialog_highlight_bg_color,
+    :dialog_highlight_bg_color_sequence,
+    :dialog_highlight_bg_color=,
+    :dialog_highlight_fg_color,
+    :dialog_highlight_fg_color_sequence,
+    :dialog_highlight_fg_color=
   ]
 
   class Core
@@ -273,9 +273,9 @@ module Reline
         scrollbar: true,
         height: 15,
         bg_color: config.dialog_default_bg_color_sequence,
-        pointer_bg_color: config.dialog_pointer_bg_color_sequence,
+        pointer_bg_color: config.dialog_highlight_bg_color_sequence,
         fg_color: config.dialog_default_fg_color_sequence,
-        pointer_fg_color: config.dialog_pointer_fg_color_sequence
+        pointer_fg_color: config.dialog_highlight_fg_color_sequence
       )
     }
     Reline::DEFAULT_DIALOG_CONTEXT = Array.new
@@ -586,8 +586,8 @@ module Reline
       core.add_dialog_proc(:autocomplete, Reline::DEFAULT_DIALOG_PROC_AUTOCOMPLETE, Reline::DEFAULT_DIALOG_CONTEXT)
       core.dialog_default_bg_color = :cyan
       core.dialog_default_fg_color = :white
-      core.dialog_pointer_bg_color = :magenta
-      core.dialog_pointer_fg_color = :white
+      core.dialog_highlight_bg_color = :magenta
+      core.dialog_highlight_fg_color = :white
     }
   end
 

--- a/lib/reline/config.rb
+++ b/lib/reline/config.rb
@@ -48,8 +48,8 @@ class Reline::Config
   attr_accessor :autocompletion
   attr_reader :dialog_default_bg_color_sequence,
     :dialog_default_fg_color_sequence,
-    :dialog_pointer_bg_color_sequence,
-    :dialog_pointer_fg_color_sequence
+    :dialog_highlight_bg_color_sequence,
+    :dialog_highlight_fg_color_sequence
 
   def initialize
     @additional_key_bindings = {} # from inputrc
@@ -76,9 +76,9 @@ class Reline::Config
     @autocompletion = false
     @convert_meta = true if seven_bit_encoding?(Reline::IOGate.encoding)
     @dialog_default_bg_color_sequence = nil
-    @dialog_pointer_bg_color_sequence = nil
+    @dialog_highlight_bg_color_sequence = nil
     @dialog_default_fg_color_sequence = nil
-    @dialog_pointer_fg_color_sequence = nil
+    @dialog_highlight_fg_color_sequence = nil
   end
 
   def reset
@@ -112,12 +112,12 @@ class Reline::Config
     @dialog_default_fg_color_sequence = dialog_color_to_code(:fg, color)
   end
 
-  def dialog_pointer_bg_color=(color)
-    @dialog_pointer_bg_color_sequence = dialog_color_to_code(:bg, color)
+  def dialog_highlight_bg_color=(color)
+    @dialog_highlight_bg_color_sequence = dialog_color_to_code(:bg, color)
   end
 
-  def dialog_pointer_fg_color=(color)
-    @dialog_pointer_fg_color_sequence = dialog_color_to_code(:fg, color)
+  def dialog_highlight_fg_color=(color)
+    @dialog_highlight_fg_color_sequence = dialog_color_to_code(:fg, color)
   end
 
   def dialog_default_bg_color
@@ -128,12 +128,12 @@ class Reline::Config
     dialog_code_to_color(:fg, @dialog_default_fg_color_sequence)
   end
 
-  def dialog_pointer_bg_color
-    dialog_code_to_color(:bg, @dialog_pointer_bg_color_sequence)
+  def dialog_highlight_bg_color
+    dialog_code_to_color(:bg, @dialog_highlight_bg_color_sequence)
   end
 
-  def dialog_pointer_fg_color
-    dialog_code_to_color(:fg, @dialog_pointer_fg_color_sequence)
+  def dialog_highlight_fg_color
+    dialog_code_to_color(:fg, @dialog_highlight_fg_color_sequence)
   end
 
   COLORS = [
@@ -399,10 +399,10 @@ class Reline::Config
       self.dialog_default_bg_color = value
     when 'dialog-default-fg-color'
       self.dialog_default_fg_color = value
-    when 'dialog-pointer-bg-color'
-      self.dialog_pointer_bg_color = value
-    when 'dialog-pointer-fg-color'
-      self.dialog_pointer_fg_color = value
+    when 'dialog-highlight-bg-color'
+      self.dialog_highlight_bg_color = value
+    when 'dialog-highlight-fg-color'
+      self.dialog_highlight_fg_color = value
     when *VARIABLE_NAMES then
       variable_name = :"@#{name.tr(?-, ?_)}"
       instance_variable_set(variable_name, value.nil? || value == '1' || value == 'on')

--- a/test/reline/test_config.rb
+++ b/test/reline/test_config.rb
@@ -412,15 +412,15 @@ class Reline::Config::Test < Reline::TestCase
   def test_dialog_configurations
     @config.read_lines(<<~LINES.lines)
       set dialog-default-bg-color white
-      set dialog-pointer-bg-color black
+      set dialog-highlight-bg-color black
       set dialog-default-fg-color cyan
-      set dialog-pointer-fg-color magenta
+      set dialog-highlight-fg-color magenta
     LINES
 
     assert_equal :white, @config.dialog_default_bg_color
-    assert_equal :black, @config.dialog_pointer_bg_color
+    assert_equal :black, @config.dialog_highlight_bg_color
     assert_equal :cyan, @config.dialog_default_fg_color
-    assert_equal :magenta, @config.dialog_pointer_fg_color
+    assert_equal :magenta, @config.dialog_highlight_fg_color
   end
 end
 

--- a/test/reline/test_reline.rb
+++ b/test/reline/test_reline.rb
@@ -50,8 +50,8 @@ class Reline::Test < Reline::TestCase
     # defaults
     assert_equal(:cyan, Reline.dialog_default_bg_color)
     assert_equal(:white, Reline.dialog_default_fg_color)
-    assert_equal(:magenta, Reline.dialog_pointer_bg_color)
-    assert_equal(:white, Reline.dialog_pointer_fg_color)
+    assert_equal(:magenta, Reline.dialog_highlight_bg_color)
+    assert_equal(:white, Reline.dialog_highlight_fg_color)
 
     Reline.dialog_default_bg_color = :black
     assert_equal(:black, Reline.dialog_default_bg_color)
@@ -61,17 +61,17 @@ class Reline::Test < Reline::TestCase
     assert_equal(:white, Reline.dialog_default_fg_color)
     assert_equal(37, Reline.dialog_default_fg_color_sequence)
 
-    Reline.dialog_pointer_bg_color = :white
-    assert_equal(:white, Reline.dialog_pointer_bg_color)
-    assert_equal(47, Reline.dialog_pointer_bg_color_sequence)
+    Reline.dialog_highlight_bg_color = :white
+    assert_equal(:white, Reline.dialog_highlight_bg_color)
+    assert_equal(47, Reline.dialog_highlight_bg_color_sequence)
 
-    Reline.dialog_pointer_fg_color = :black
-    assert_equal(:black, Reline.dialog_pointer_fg_color)
-    assert_equal(30, Reline.dialog_pointer_fg_color_sequence)
+    Reline.dialog_highlight_fg_color = :black
+    assert_equal(:black, Reline.dialog_highlight_fg_color)
+    assert_equal(30, Reline.dialog_highlight_fg_color_sequence)
 
     # test value validation
     assert_raise(ArgumentError) do
-      Reline.dialog_pointer_fg_color = :foo
+      Reline.dialog_highlight_fg_color = :foo
     end
   end
 


### PR DESCRIPTION
"Pointer" is not what we usually use to describe a selected item.

"Highlight" is a more common word for the scenario so we should use it instead.