### PR TITLE
Pass unmodifined lines(that does not include escape sequence) to check_multiline_prompt

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -668,8 +668,10 @@ class Reline::LineEditor
     dialog.set_cursor_pos(cursor_column, @first_line_started_from + @started_from)
     dialog_render_info = dialog.call(@last_key)
     if dialog_render_info.nil? or dialog_render_info.contents.nil? or dialog_render_info.contents.empty?
+      lines = whole_lines
       dialog.lines_backup = {
-        lines: modify_lines(whole_lines),
+        unmodified_lines: lines,
+        lines: modify_lines(lines),
         line_index: @line_index,
         first_line_started_from: @first_line_started_from,
         started_from: @started_from,
@@ -772,8 +774,10 @@ class Reline::LineEditor
     Reline::IOGate.move_cursor_column(cursor_column)
     move_cursor_up(dialog.vertical_offset + dialog.contents.size - 1)
     Reline::IOGate.show_cursor
+    lines = whole_lines
     dialog.lines_backup = {
-      lines: modify_lines(whole_lines),
+      unmodified_lines: lines,
+      lines: modify_lines(lines),
       line_index: @line_index,
       first_line_started_from: @first_line_started_from,
       started_from: @started_from,
@@ -783,7 +787,7 @@ class Reline::LineEditor
 
   private def reset_dialog(dialog, old_dialog)
     return if dialog.lines_backup.nil? or old_dialog.contents.nil?
-    prompt, prompt_width, prompt_list = check_multiline_prompt(dialog.lines_backup[:lines])
+    prompt, prompt_width, prompt_list = check_multiline_prompt(dialog.lines_backup[:unmodified_lines])
     visual_lines = []
     visual_start = nil
     dialog.lines_backup[:lines].each_with_index { |l, i|
@@ -894,7 +898,7 @@ class Reline::LineEditor
   private def clear_each_dialog(dialog)
     dialog.trap_key = nil
     return unless dialog.contents
-    prompt, prompt_width, prompt_list = check_multiline_prompt(dialog.lines_backup[:lines])
+    prompt, prompt_width, prompt_list = check_multiline_prompt(dialog.lines_backup[:unmodified_lines])
     visual_lines = []
     visual_lines_under_dialog = []
     visual_start = nil

--- a/test/reline/yamatanooroti/multiline_repl
+++ b/test/reline/yamatanooroti/multiline_repl
@@ -39,6 +39,19 @@ opt.on('--dynamic-prompt-with-newline') {
     }
   }
 }
+opt.on('--broken-dynamic-prompt-assert-no-escape-sequence') {
+  Reline.prompt_proc = proc { |lines|
+    has_escape_sequence = lines.join.include?("\e")
+    (lines.size + 1).times.map { |i|
+      has_escape_sequence ? 'error>' : '[%04d]> ' % i
+    }
+  }
+}
+opt.on('--color-bold') {
+  Reline.output_modifier_proc = ->(output, complete:){
+    output.gsub(/./) { |c| "\e[1m#{c}\e[0m" }
+  }
+}
 opt.on('--auto-indent') {
   AutoIndent.new
 }

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -460,6 +460,18 @@ begin
       EOC
     end
 
+    def test_no_escape_sequence_passed_to_dynamic_prompt
+      start_terminal(10, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl  --autocomplete --color-bold --broken-dynamic-prompt-assert-no-escape-sequence}, startup_message: 'Multiline REPL.')
+      write("%[ S")
+      write("\n")
+      close
+      assert_screen(<<~EOC)
+        Multiline REPL.
+        [0000]> %[ S
+        [0001]>
+      EOC
+    end
+
     def test_enable_bracketed_paste
       omit if Reline::IOGate.win?
       write_inputrc <<~LINES


### PR DESCRIPTION
In some case, modified lines was passed to auto_indent_proc.

This pullreq will fix some prompt bug in irb.
```
irb(main):002:1* if 1
irb(main):003:1"   %[
irb(main):004:13>   a a a a

# should be 
irb(main):006:1"   a a a a
```
![image](https://user-images.githubusercontent.com/1780201/182479833-550390e5-1f7a-4b9d-9e2f-372f0d4dd54b.gif)

