### PR TITLE
Fix indent when type "[\n" or "{\n" in irb

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -1717,17 +1717,18 @@ class Reline::LineEditor
       new_lines = whole_lines
     end
     new_indent = @auto_indent_proc.(new_lines, @line_index, @byte_pointer, @check_new_auto_indent)
-    new_indent = @cursor_max if new_indent&.> @cursor_max
     if new_indent&.>= 0
       md = new_lines[@line_index].match(/\A */)
       prev_indent = md[0].count(' ')
       if @check_new_auto_indent
-        @buffer_of_lines[@line_index] = ' ' * new_indent + @buffer_of_lines[@line_index].lstrip
+        line = @buffer_of_lines[@line_index] = ' ' * new_indent + @buffer_of_lines[@line_index].lstrip
         @cursor = new_indent
+        @cursor_max = calculate_width(line)
         @byte_pointer = new_indent
       else
         @line = ' ' * new_indent + @line.lstrip
         @cursor += new_indent - prev_indent
+        @cursor_max = calculate_width(@line)
         @byte_pointer += new_indent - prev_indent
       end
     end

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -1333,6 +1333,18 @@ begin
       EOC
     end
 
+    def test_bracket_newline_indent
+      start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --auto-indent}, startup_message: 'Multiline REPL.')
+      write("[\n")
+      write("1")
+      close
+      assert_screen(<<~EOC)
+        Multiline REPL.
+        prompt> [
+        prompt>   1
+      EOC
+    end
+
     def write_inputrc(content)
       File.open(@inputrc_file, 'w') do |f|
         f.write content


### PR DESCRIPTION
fixed theses indent

```
# type `[\n1,\n2,` in irb
irb(main):001:1* [
irb(main):002:1*  1, # expect 1 and 2 on the same column
irb(main):003:1*   2,
```

```
# type `{\nx: 1,\ny:` in irb
irb(main):001:0> {
irb(main):002:1*  x: 1, # expect x: and y: on the same column
irb(main):003:1>   y:
```

```ruby
require 'reline'
Reline.auto_indent_proc = proc { _1.size <= 1 ? 0 : 5 }
Reline.readmultiline('#>') { false }

# type `ab\nc\nd\ne\nf`
#>ab
#>   c
#>    d
#>     e
#>     f

# expected result
#>ab
#>     c
#>     d
#>     e
#>     f
```

## Changes

new_indent can be larget than previous line. deleted the codition
```ruby
new_indent = @cursor_max if new_indent&.> @cursor_max
```

recalculate `@cursor_max`
```ruby
# Works without this code. Maybe no effect.
@cursor_max = calculate_width(line)
# Without this code, @cursor_max will be re-calculated in `def rerender_added_newline`.

# Works without this code.
@cursor_max = calculate_width(@line)
# But without this code, after typing "if 1\n    end\n", process_auto_indent is called with:
# new_lines == ["if false", "end"]
# @cursor_max == 9 (I think 3 is expected)
```
