### PR TITLE
DRAFT - Fix Various Home / End key binding issues

### DIFF
--- a/lib/reline/ansi.rb
+++ b/lib/reline/ansi.rb
@@ -60,8 +60,22 @@ class Reline::ANSI
       config.add_default_key_binding_by_keymap(:emacs, key, func)
     end
   end
+  
+  @@input = STDIN
+  def self.input=(val)
+    @@input = val
+  end
 
+  @@output = STDOUT
+  def self.output=(val)
+    @@output = val
+  end
   def self.set_default_key_bindings_terminfo(config)
+    begin
+      @@output.write Reline::Terminfo.tigetstr('smkx')
+    rescue Reline::Terminfo::TerminfoError
+      # capname is undefined
+    end
     key_bindings = CAPNAME_KEY_BINDINGS.map do |capname, key_binding|
       begin
         key_code = Reline::Terminfo.tigetstr(capname)

--- a/lib/reline/ansi.rb
+++ b/lib/reline/ansi.rb
@@ -15,6 +15,7 @@ class Reline::ANSI
     'cud' => :ed_next_history,
     'cuf' => :ed_next_char,
     'cub' => :ed_prev_char,
+    'kdch1' => :key_delete 
   }
 
   if Reline::Terminfo.enabled?

--- a/lib/reline/ansi.rb
+++ b/lib/reline/ansi.rb
@@ -70,12 +70,26 @@ class Reline::ANSI
   def self.output=(val)
     @@output = val
   end
+
   def self.set_default_key_bindings_terminfo(config)
+    
+    # put terminal in tx mode so that
+    # keys match terminfo's bindings
     begin
       @@output.write Reline::Terminfo.tigetstr('smkx')
     rescue Reline::Terminfo::TerminfoError
       # capname is undefined
     end
+    
+    # return terminal to rx mode
+    at_exit do
+      begin
+        @@output.write Reline::Terminfo.tigetstr('rmkx')
+      rescue Reline::Terminfo::TerminfoError
+        # capname is undefined
+      end
+    end
+    
     key_bindings = CAPNAME_KEY_BINDINGS.map do |capname, key_binding|
       begin
         key_code = Reline::Terminfo.tigetstr(capname)

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -37,6 +37,7 @@ class Reline::LineEditor
     vi_end_big_word
     vi_repeat_next_char
     vi_repeat_prev_char
+    key_delete
   }
 
   module CompletionState

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -37,7 +37,6 @@ class Reline::LineEditor
     vi_end_big_word
     vi_repeat_next_char
     vi_repeat_prev_char
-    key_delete
   }
 
   module CompletionState


### PR DESCRIPTION
After playing around with various keybinding issues affecting MacOS, iTerm2, and other ncurses loading terminal emulators, I stumbled upon references to switching the terminal mode so that key bindings align with the output of terminfo (infocmp) for kend and khome. Basically, until the terminal emulator has been set to 'smkx' ("keypad-transmit" mode) home/end keys send normal mode bindings which use a different style escape sequences. This code slots in at the setup phase before we use the ncurses based libraries to gather the keybindings.

If you want to test the intended functionality here prior to pulling try running the following

`tput smkx && irb`

if you want to see what the raw chars look like in various mode

`tput smkx && read` will let you see the raw escape code of keypad-transmit mode

Some terminals and shells will reset after program exit, but some do not, so to return to receive mode:

`tput rmkx`

---
Note this is my first PR in this project and I didn't see any submission guidelines... so please let me know what changes would be required.

Note 2 ... MacOS's Terminal.app has a variation of home/end key bindings and prefers shift+home and shift+end but these map to kend and khome rather than kEND and kHOM