### PR TITLE
Support dumb terminal

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -601,24 +601,21 @@ module Reline
 end
 
 require 'reline/general_io'
-if RbConfig::CONFIG['host_os'] =~ /mswin|msys|mingw|cygwin|bccwin|wince|emc/
-  require 'reline/windows'
-  if Reline::Windows.msys_tty?
-    Reline::IOGate = if ENV['TERM'] == 'dumb'
-      Reline::GeneralIO
-    else
-      require 'reline/ansi'
-      Reline::ANSI
-    end
+io = Reline::GeneralIO
+unless ENV['TERM'] == 'dumb'
+  case RbConfig::CONFIG['host_os']
+  when /mswin|msys|mingw|cygwin|bccwin|wince|emc/
+    require 'reline/windows'
+    tty = (io = Reline::Windows).msys_tty?
   else
-    Reline::IOGate = Reline::Windows
-  end
-else
-  Reline::IOGate = if $stdout.isatty
-    require 'reline/ansi'
-    Reline::ANSI
-  else
-    Reline::GeneralIO
+    tty = $stdout.tty?
   end
 end
+Reline::IOGate = if tty
+  require 'reline/ansi'
+  Reline::ANSI
+else
+  io
+end
+
 Reline::HISTORY = Reline::History.new(Reline.core.config)

--- a/test/reline/test_reline.rb
+++ b/test/reline/test_reline.rb
@@ -397,6 +397,12 @@ class Reline::Test < Reline::TestCase
     # TODO in Reline::Core
   end
 
+  def test_dumb_terminal
+    lib = File.expand_path("../../lib", __dir__)
+    out = IO.popen([{"TERM"=>"dumb"}, "ruby", "-I#{lib}", "-rreline", "-e", "p Reline::IOGate"], &:read)
+    assert_equal("Reline::GeneralIO", out.chomp)
+  end
+
   def get_reline_encoding
     if encoding = Reline::IOGate.encoding
       encoding


### PR DESCRIPTION
The "dumb" terminal is considered only on MSys tty now.
However, the `TERM` feature has been used on many Unix-like systems for decades, not MSys specific.