### PR TITLE
Fix dialog deleting fullwidth characters

### DIFF
--- a/lib/reline/unicode.rb
+++ b/lib/reline/unicode.rb
@@ -205,8 +205,10 @@ class Reline::Unicode
       case
       when gc[NON_PRINTING_START_INDEX]
         in_zero_width = true
+        chunk << NON_PRINTING_START
       when gc[NON_PRINTING_END_INDEX]
         in_zero_width = false
+        chunk << NON_PRINTING_END
       when gc[CSI_REGEXP_INDEX]
         chunk << gc[CSI_REGEXP_INDEX]
       when gc[OSC_REGEXP_INDEX]

--- a/test/reline/test_unicode.rb
+++ b/test/reline/test_unicode.rb
@@ -19,7 +19,21 @@ class Reline::Unicode::Test < Reline::TestCase
   end
 
   def test_take_range
-    assert_equal 'cdef', Reline::Unicode.take_range('abcdefghi', 2, 4)
-    assert_equal 'いう', Reline::Unicode.take_range('あいうえお', 2, 4)
+    assert_equal ['cdef', 2, 4], Reline::Unicode.take_range('abcdefghi', 2, 4)
+    assert_equal ['cdef', 2, 4], Reline::Unicode.take_range('abcdefghi', 2, 4, padding: true)
+    assert_equal ['cdef', 2, 4], Reline::Unicode.take_range('abcdefghi', 2, 4, cover_begin: true)
+    assert_equal ['cdef', 2, 4], Reline::Unicode.take_range('abcdefghi', 2, 4, cover_end: true)
+    assert_equal ['いう', 2, 4], Reline::Unicode.take_range('あいうえお', 2, 4)
+    assert_equal ['いう', 2, 4], Reline::Unicode.take_range('あいうえお', 2, 4, padding: true)
+    assert_equal ['いう', 2, 4], Reline::Unicode.take_range('あいうえお', 2, 4, cover_begin: true)
+    assert_equal ['いう', 2, 4], Reline::Unicode.take_range('あいうえお', 2, 4, cover_end: true)
+    assert_equal ['う', 4, 2], Reline::Unicode.take_range('あいうえお', 3, 4)
+    assert_equal [' う ', 3, 4], Reline::Unicode.take_range('あいうえお', 3, 4, padding: true)
+    assert_equal ['いう', 2, 4], Reline::Unicode.take_range('あいうえお', 3, 4, cover_begin: true)
+    assert_equal ['うえ', 4, 4], Reline::Unicode.take_range('あいうえお', 3, 4, cover_end: true)
+    assert_equal ['いう ', 2, 5], Reline::Unicode.take_range('あいうえお', 3, 4, cover_begin: true, padding: true)
+    assert_equal [' うえ', 3, 5], Reline::Unicode.take_range('あいうえお', 3, 4, cover_end: true, padding: true)
+    assert_equal [' うえお   ', 3, 10], Reline::Unicode.take_range('あいうえお', 3, 10, padding: true)
+    assert_equal ["\e[31mc\1ABC\2d\e[0mef", 2, 4], Reline::Unicode.take_range("\e[31mabc\1ABC\2d\e[0mefghi", 2, 4)
   end
 end

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -1031,6 +1031,22 @@ begin
       EOC
     end
 
+    def test_autocomplete_rerender_fullwidth_under_dialog
+      start_terminal(20, 40, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --autocomplete}, startup_message: 'Multiline REPL.')
+      write("def hoge\n\n  あいうえおかきくけこab\n  aあいうえおかきくけこb\n  abあいうえおかきくけこ\C-p\C-p\C-p  ")
+      write('S')
+      write('t')
+      close
+      assert_screen(<<~'EOC')
+        Multiline REPL.
+        prompt> def hoge
+        prompt>   St
+        prompt>   Stringえおかきくけこab
+        prompt>   Struct えおかきくけこb
+        prompt>   abあいうえおかきくけこ
+      EOC
+    end
+
     def test_autocomplete_long_with_scrollbar
       start_terminal(20, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --autocomplete-long}, startup_message: 'Multiline REPL.')
       write('S')


### PR DESCRIPTION
Reline's dialog will delete fullwidth characters and fails to restore it in reset_dialog. This pull request fixes this.

![dialog_on_fullwidth](https://user-images.githubusercontent.com/1780201/192744199-77e58459-e651-4656-b9f0-adf0f4a72588.gif)





In reset_dialog, what we want for `Reline::Unicode.take_range('一二三', 1, 4)` could be
- `一二三` string covers range, needed for rerender bottom, rerender top in reset_dialog
- `二三` rerender right in reset_dialog
- `一二` render left in reset_dialog
- `二` string inside range
- `▫️二▫️` string inside range with padding


### Changes

#### take_range will also return position(col and width)
`take_range('一二三', 1, 4) #=> ['二', 2, 2]`
need to determine where to render the string.
`二` should be rendered at `col: 2, width: 2`, not at `col: 1, width: 4`

#### add an option cover_begin, cover_end to take_range
`take_range('一二三', 1, 4, cover_begin: true) #=> ['一二', 0, 4]` for render left
`take_range('一二三', 1, 4, cover_end: true) #=> ['二三', 2, 4]` for render right

#### add an option padding to take_range
Delete `padding_space_with_escape_sequences` that only adds spaces at the end of the string.
take_range will properly add spaces around the string.
`take_range('一二三', 1, 4, padding: true) #=> ['▫️二▫️', 1, 4]`
`take_range('一二三', 1, 8, padding: true) #=> ['▫️二三▫️▫️▫️', 1, 8]`

#### Refactored reset_dialog
To make the main change easier, I reduced if branches of render top, left, right and bottom.
This change will fix a potentially-bug in rerender left
  - old_dialog.column is used where it should be dialog.column
  - sign on ydiff looks wrong, compared to rerender right
  - dialog.column usually don't move right, ydiff is usually zero, so it's hard to write failing test

#### Fixed inconsistency of take_range and calculate_width with special charactors \1 and \2
I Added some take_range tests for newly added option and regression test for escape sequence.
Found \1 and \2 is disappeared that will causes inconsistency of calculate_width and take_range.
`calculate_width(take_range("a\1xxxxxxxx\2b", 0, 2), true) should be <=2, got 10`
This might solve the root cause of #465 (I'm not sure, I cannot reproduce it).



### Limitations
This pull request has a limitation. After document dialog is closed, right side of the completion dialog corrupts if there is full-width character between these dialogs.
![dialog_clear](https://user-images.githubusercontent.com/1780201/197549352-fa0c4c58-8cba-4fd9-8fb2-44725fc86f46.gif)
Clearing dialog depends on adjacent dialog positions, and to fix this, dialog rendering and clearing algorithm might need update.

```ruby
# change clear_each_dialog to use remaining dialog positions
def clear_each_dialog(dialog_to_be_cleared, remaining_dialog_positions)
  # Carefully clear the dialog
end

# or clear multiple dialogs at once
def clear_dialogs(dialogs_to_be_cleared, remaining_dialog_positions)
  # Check all dialogs and collect all ranges to be cleared
  # Clear each calculated ranges
  # In this approach, we might be able to clear trailing spaces created by clear_each_dialog
end

# or just make a space between correction dialog and document dialog
```