### PR TITLE
Fix the cause of test_yamatanooroti randomly failing

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -266,19 +266,21 @@ module Reline
     Reline::DEFAULT_DIALOG_CONTEXT = Array.new
 
     def readmultiline(prompt = '', add_hist = false, &confirm_multiline_termination)
-      unless confirm_multiline_termination
-        raise ArgumentError.new('#readmultiline needs block to confirm multiline termination')
-      end
-      inner_readline(prompt, add_hist, true, &confirm_multiline_termination)
+      Reline::IOGate.with_raw_input do
+        unless confirm_multiline_termination
+          raise ArgumentError.new('#readmultiline needs block to confirm multiline termination')
+        end
+        inner_readline(prompt, add_hist, true, &confirm_multiline_termination)
 
-      whole_buffer = line_editor.whole_buffer.dup
-      whole_buffer.taint if RUBY_VERSION < '2.7'
-      if add_hist and whole_buffer and whole_buffer.chomp("\n").size > 0
-        Reline::HISTORY << whole_buffer
-      end
+        whole_buffer = line_editor.whole_buffer.dup
+        whole_buffer.taint if RUBY_VERSION < '2.7'
+        if add_hist and whole_buffer and whole_buffer.chomp("\n").size > 0
+          Reline::HISTORY << whole_buffer
+        end
 
-      line_editor.reset_line if line_editor.whole_buffer.nil?
-      whole_buffer
+        line_editor.reset_line if line_editor.whole_buffer.nil?
+        whole_buffer
+      end
     end
 
     def readline(prompt = '', add_hist = false)

--- a/lib/reline/ansi.rb
+++ b/lib/reline/ansi.rb
@@ -143,6 +143,10 @@ class Reline::ANSI
     @@output = val
   end
 
+  def self.with_raw_input
+    @@input.raw { yield }
+  end
+
   @@buf = []
   def self.inner_getc
     unless @@buf.empty?

--- a/lib/reline/general_io.rb
+++ b/lib/reline/general_io.rb
@@ -31,6 +31,10 @@ class Reline::GeneralIO
     @@input = val
   end
 
+  def self.with_raw_input
+    yield
+  end
+
   def self.getc
     unless @@buf.empty?
       return @@buf.shift

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -457,7 +457,7 @@ class Reline::LineEditor
         new_lines = whole_lines
       end
       modify_lines(new_lines).each_with_index do |line, index|
-        @output.write "#{prompt_list ? prompt_list[index] : prompt}#{line}\n"
+        @output.write "#{prompt_list ? prompt_list[index] : prompt}#{line}\r\n"
         Reline::IOGate.erase_after_cursor
       end
       @output.flush

--- a/lib/reline/windows.rb
+++ b/lib/reline/windows.rb
@@ -291,6 +291,10 @@ class Reline::Windows
     end
   end
 
+  def self.with_raw_input
+    yield
+  end
+
   def self.getc
     check_input_event
     @@output_buf.shift

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -1425,6 +1425,16 @@ begin
       EOC
     end
 
+    def test_repeated_input_delete
+      start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
+      write("a\C-h" * 4000)
+      close
+      assert_screen(<<~'EOC')
+        Multiline REPL.
+        prompt>
+      EOC
+    end
+
     def write_inputrc(content)
       File.open(@inputrc_file, 'w') do |f|
         f.write content


### PR DESCRIPTION
When pressing tab key for a long time, cursor is moving right and left. On the right end, something(`nt` and `----`) is remain displayed.
![tabpress](https://user-images.githubusercontent.com/1780201/197398708-b40c7f0e-f659-4b47-9124-c35705a3d20d.gif)

This behavior is also causing random test failure in `rake test_yamatanooroti`.
These tests failed in my local environment (macOS, Terminal.app, vterm 0.2, looks like fails more frequently compared to ci)
```
test_autocomplete_after_2nd_line
test_autowrap_in_the_middle_of_a_line
test_backspace
test_dynamic_prompt_returns_empty
test_dynamic_prompt_with_newline
test_finish_autowrapped_line_in_the_middle_of_multilines
test_force_enter
test_incremental_search_on_not_last_line
test_insert_line_in_the_middle_of_line
test_insert_newline_in_the_middle_of_buffer_just_after_dialog
test_mode_string_vi
test_mode_string_vi_changing
test_original_mode_string_vi
test_prompt
test_prompt_list_caching
test_prompt_with_escape_sequence
test_two_fullwidth
test_update_cursor_correctly_when_just_cursor_moving
```

I ran `test_update_cursor_correctly_when_just_cursor_moving`, the most frequently failing test in local for 100 times(local) and 50 times(ci in forked repository: https://github.com/tompng/reline/commit/da6b2c5b946c5e880cb31a3cad02950073756c6a, job result: https://github.com/tompng/reline/actions/runs/3307143383/jobs/5458548780)

| result | local(100 runs) | ci(50 runs) |description |
| --- | --- | --- | --- |
| "Multiline REPL.\nprompt> def hoge\nprompt>   0123456789\n" | 75 | 48 | expected result |
| "Multiline REPL.\nprompt> def hoge^B\nprompt>   0123456789\n" | 9 | 0 | extra ^B |
| "Multiline REPL.\nprompt> def hog^N\nprompt>   0123456789\n" | 9 | 2 | extra ^N |
| "Multiline REPL.\nprompt> def hoge\nprompt> def hoge^B\nprompt>   0123456789\n" | 2 | 0 | extra line and ^B |
| "Multiline REPL.\nprompt> def hog^NB\nprompt>   0123456789\n" | 4 | 0 | extra ^NB |
| "Multiline REPL.\nprompt> def hoge\nprompt> def hoge\nprompt>   0123456789\n" | 1 | 0 | extra line |

Failing result sometimes contains `^B` and `^N`.
This is because getc in ansi.rb is using `STDIN.raw{getc}`, that means there is a non-raw time between the next getc.
When there is new input while rendering a dialog, prompt or something else, the input is echo-ed.
To fix this, reline should not echo while editing multiline.

### Changes
I added `Reline::IOGate.with_raw_input` and used in `Reline.readmultiline`.
I used `IO#raw`, not `IO#noecho`. noecho will show a key mark cursor for password input in Terminal.app and iTerm2 and maybe other teminals.

In raw mode, `\n` will only move cursor down, not left-end of the next line and `test_terminate_in_the_middle_of_lines` will fail. So I added `\r` to method `rerender` in `line_editor.rb`

Added test writing `a[delete]a[delete]a[delete]...(4000 times)` to vterm.
In HEAD, it fails with
```
<"Multiline REPL.\n" + "prompt>\n"> expected but was
<"a^Ha^Ha^Ha^Ha^Ha^Ha^Ha^Ha^Ha^H\n" +
"a^Ha^Ha^Ha^Ha^Ha^Ha^Ha^Ha^Ha^H\n" +
"a^Ha^Ha^Ha^Ha^Ha^Ha^Ha^Ha^Ha^H\n" +
"a^Ha^Ha^Ha^Ha^Ha^Ha^Ha^Ha^Ha^H\n" +
"prompt>\n">
```
failed result: https://github.com/tompng/reline/actions/runs/3307571761/jobs/5459304761
