### PR TITLE
Fix misuse of kwarg in IO#raw

### DIFF
--- a/lib/reline/ansi.rb
+++ b/lib/reline/ansi.rb
@@ -150,7 +150,7 @@ class Reline::ANSI
     until c = @@input.raw(intr: true) { @@input.wait_readable(0.1) && @@input.getbyte }
       Reline.core.line_editor.resize
     end
-    (c == 0x16 && @@input.raw(min: 0, tim: 0, &:getbyte)) || c
+    (c == 0x16 && @@input.raw(min: 0, time: 0, &:getbyte)) || c
   rescue Errno::EIO
     # Maybe the I/O has been closed.
     nil


### PR DESCRIPTION
- Obviously, `tim` is a typo for `time`. see https://github.com/ruby/ruby/blob/v3_1_3/ext/io/console/console.c#L1637
- This didn't cause an ArgumentError because IO#raw is implemented in C and it doesn't check the keyword
- Also, this typo works well because `tim: 0` is not inconsistent with the `time`'s default value `0`. see https://github.com/ruby/ruby/blob/v3_1_3/ext/io/console/console.c#L147
- This typo doesn't produce any problems for now, though I think it'd be better to fix it just in case for the future
