### PR TITLE
Remove unapproved color setting APIs

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -46,21 +46,6 @@ module Reline
     keyword_init: true
   )
 
-  DIALOG_COLOR_APIS = [
-    :dialog_default_bg_color,
-    :dialog_default_bg_color_sequence,
-    :dialog_default_bg_color=,
-    :dialog_default_fg_color,
-    :dialog_default_fg_color_sequence,
-    :dialog_default_fg_color=,
-    :dialog_highlight_bg_color,
-    :dialog_highlight_bg_color_sequence,
-    :dialog_highlight_bg_color=,
-    :dialog_highlight_fg_color,
-    :dialog_highlight_fg_color_sequence,
-    :dialog_highlight_fg_color=
-  ]
-
   class Core
     ATTR_READER_NAMES = %i(
       completion_append_character
@@ -87,8 +72,7 @@ module Reline
     extend Forwardable
     def_delegators :config,
       :autocompletion,
-      :autocompletion=,
-      *DIALOG_COLOR_APIS
+      :autocompletion=
 
     def initialize
       self.output = STDOUT
@@ -272,10 +256,10 @@ module Reline
         contents: result,
         scrollbar: true,
         height: 15,
-        bg_color: config.dialog_default_bg_color_sequence,
-        pointer_bg_color: config.dialog_highlight_bg_color_sequence,
-        fg_color: config.dialog_default_fg_color_sequence,
-        pointer_fg_color: config.dialog_highlight_fg_color_sequence
+        bg_color: 46,
+        pointer_bg_color: 45,
+        fg_color: 37,
+        pointer_fg_color: 37
       )
     }
     Reline::DEFAULT_DIALOG_CONTEXT = Array.new
@@ -561,7 +545,6 @@ module Reline
   def_single_delegators :core, :add_dialog_proc
   def_single_delegators :core, :dialog_proc
   def_single_delegators :core, :autocompletion, :autocompletion=
-  def_single_delegators :core, *DIALOG_COLOR_APIS
 
   def_single_delegators :core, :readmultiline
   def_instance_delegators self, :readmultiline
@@ -584,10 +567,6 @@ module Reline
       core.filename_quote_characters = ""
       core.special_prefixes = ""
       core.add_dialog_proc(:autocomplete, Reline::DEFAULT_DIALOG_PROC_AUTOCOMPLETE, Reline::DEFAULT_DIALOG_CONTEXT)
-      core.dialog_default_bg_color = :cyan
-      core.dialog_default_fg_color = :white
-      core.dialog_highlight_bg_color = :magenta
-      core.dialog_highlight_fg_color = :white
     }
   end
 

--- a/lib/reline/config.rb
+++ b/lib/reline/config.rb
@@ -46,10 +46,6 @@ class Reline::Config
   end
 
   attr_accessor :autocompletion
-  attr_reader :dialog_default_bg_color_sequence,
-    :dialog_default_fg_color_sequence,
-    :dialog_highlight_bg_color_sequence,
-    :dialog_highlight_fg_color_sequence
 
   def initialize
     @additional_key_bindings = {} # from inputrc
@@ -75,10 +71,6 @@ class Reline::Config
     @test_mode = false
     @autocompletion = false
     @convert_meta = true if seven_bit_encoding?(Reline::IOGate.encoding)
-    @dialog_default_bg_color_sequence = nil
-    @dialog_highlight_bg_color_sequence = nil
-    @dialog_default_fg_color_sequence = nil
-    @dialog_highlight_fg_color_sequence = nil
   end
 
   def reset
@@ -102,65 +94,6 @@ class Reline::Config
 
   def editing_mode_is?(*val)
     (val.respond_to?(:any?) ? val : [val]).any?(@editing_mode_label)
-  end
-
-  def dialog_default_bg_color=(color)
-    @dialog_default_bg_color_sequence = dialog_color_to_code(:bg, color)
-  end
-
-  def dialog_default_fg_color=(color)
-    @dialog_default_fg_color_sequence = dialog_color_to_code(:fg, color)
-  end
-
-  def dialog_highlight_bg_color=(color)
-    @dialog_highlight_bg_color_sequence = dialog_color_to_code(:bg, color)
-  end
-
-  def dialog_highlight_fg_color=(color)
-    @dialog_highlight_fg_color_sequence = dialog_color_to_code(:fg, color)
-  end
-
-  def dialog_default_bg_color
-    dialog_code_to_color(:bg, @dialog_default_bg_color_sequence)
-  end
-
-  def dialog_default_fg_color
-    dialog_code_to_color(:fg, @dialog_default_fg_color_sequence)
-  end
-
-  def dialog_highlight_bg_color
-    dialog_code_to_color(:bg, @dialog_highlight_bg_color_sequence)
-  end
-
-  def dialog_highlight_fg_color
-    dialog_code_to_color(:fg, @dialog_highlight_fg_color_sequence)
-  end
-
-  COLORS = [
-    :black,
-    :red,
-    :green,
-    :yellow,
-    :blue,
-    :magenta,
-    :cyan,
-    :white
-  ].freeze
-
-  private def dialog_color_to_code(type, color)
-    base = type == :bg ? 40 : 30
-    c = COLORS.index(color.to_sym)
-
-    if c
-      base + c
-    else
-      raise ArgumentError.new("Unknown color: #{color}.\nAvailable colors: #{COLORS.join(", ")}")
-    end
-  end
-
-  private def dialog_code_to_color(type, code)
-    base = type == :bg ? 40 : 30
-    COLORS[code - base]
   end
 
   def keymap
@@ -395,14 +328,6 @@ class Reline::Config
       @vi_ins_mode_string = retrieve_string(value)
     when 'emacs-mode-string'
       @emacs_mode_string = retrieve_string(value)
-    when 'dialog-default-bg-color'
-      self.dialog_default_bg_color = value
-    when 'dialog-default-fg-color'
-      self.dialog_default_fg_color = value
-    when 'dialog-highlight-bg-color'
-      self.dialog_highlight_bg_color = value
-    when 'dialog-highlight-fg-color'
-      self.dialog_highlight_fg_color = value
     when *VARIABLE_NAMES then
       variable_name = :"@#{name.tr(?-, ?_)}"
       instance_variable_set(variable_name, value.nil? || value == '1' || value == 'on')

--- a/test/reline/test_config.rb
+++ b/test/reline/test_config.rb
@@ -408,19 +408,5 @@ class Reline::Config::Test < Reline::TestCase
     ENV['XDG_CONFIG_HOME'] = xdg_config_home_backup
     ENV['HOME'] = home_backup
   end
-
-  def test_dialog_configurations
-    @config.read_lines(<<~LINES.lines)
-      set dialog-default-bg-color white
-      set dialog-highlight-bg-color black
-      set dialog-default-fg-color cyan
-      set dialog-highlight-fg-color magenta
-    LINES
-
-    assert_equal :white, @config.dialog_default_bg_color
-    assert_equal :black, @config.dialog_highlight_bg_color
-    assert_equal :cyan, @config.dialog_default_fg_color
-    assert_equal :magenta, @config.dialog_highlight_fg_color
-  end
 end
 

--- a/test/reline/test_reline.rb
+++ b/test/reline/test_reline.rb
@@ -46,35 +46,6 @@ class Reline::Test < Reline::TestCase
     Reline.completion_append_character = completion_append_character
   end
 
-  def test_dialog_color_configuration
-    # defaults
-    assert_equal(:cyan, Reline.dialog_default_bg_color)
-    assert_equal(:white, Reline.dialog_default_fg_color)
-    assert_equal(:magenta, Reline.dialog_highlight_bg_color)
-    assert_equal(:white, Reline.dialog_highlight_fg_color)
-
-    Reline.dialog_default_bg_color = :black
-    assert_equal(:black, Reline.dialog_default_bg_color)
-    assert_equal(40, Reline.dialog_default_bg_color_sequence)
-
-    Reline.dialog_default_fg_color = :white
-    assert_equal(:white, Reline.dialog_default_fg_color)
-    assert_equal(37, Reline.dialog_default_fg_color_sequence)
-
-    Reline.dialog_highlight_bg_color = :white
-    assert_equal(:white, Reline.dialog_highlight_bg_color)
-    assert_equal(47, Reline.dialog_highlight_bg_color_sequence)
-
-    Reline.dialog_highlight_fg_color = :black
-    assert_equal(:black, Reline.dialog_highlight_fg_color)
-    assert_equal(30, Reline.dialog_highlight_fg_color_sequence)
-
-    # test value validation
-    assert_raise(ArgumentError) do
-      Reline.dialog_highlight_fg_color = :foo
-    end
-  end
-
   def test_basic_word_break_characters
     basic_word_break_characters = Reline.basic_word_break_characters
 


### PR DESCRIPTION
These APIs/configs are not approved by the Ruby core, so they can't be released to the public. This means having them in the codebase will block other fixes/features from being released as well.

So this commit removes those exposed interfaces to unblock the release.

Hopefully when https://bugs.ruby-lang.org/issues/18996 is approved we can re-implement better APIs.

([Conclusion about this feature](https://github.com/ruby/dev-meeting-log/blob/master/DevMeeting-2022-12-01.md#feature-18996-proposal-introduce-new-apis-to-reline-for-changing-dialog-ui-colours-st0012) in the 1st Dec dev meeting)

cc @pocari 