### PR TITLE
Change autocompletion dialog's background to simple black-and-white

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -256,10 +256,10 @@ module Reline
         contents: result,
         scrollbar: true,
         height: 15,
-        bg_color: 46,
-        pointer_bg_color: 45,
+        bg_color: 40,
         fg_color: 37,
-        pointer_fg_color: 37
+        pointer_bg_color: 47,
+        pointer_fg_color: 30
       )
     }
     Reline::DEFAULT_DIALOG_CONTEXT = Array.new


### PR DESCRIPTION
The default light background (cyan) has low contrast with the white text (foreground). And it's making autocompletion's texts hard to read, as demonstrated in [this ticket](https://bugs.ruby-lang.org/issues/18996):

![](https://user-images.githubusercontent.com/3303032/148653612-e3dff786-1a10-4923-a0eb-3975cae10a7f.png)

So even though we can't let users customise desirable colours yet, we can still make the default black and white and thus easier to read.

|   |  Background  |  Foreground (text) |
|---|---|---|
| Non-selected | Black (40) | White (37) |
| Selected | White (47) | Black (30) |


### In dark background `Terminal.app`

<img width="30%" alt="Now colours with dark background terminal" src="https://user-images.githubusercontent.com/5079556/205627462-30605469-c1dc-414e-bffc-52625e0b9368.png">

### In bright background `Terminal.app`

<img width="30%" alt="Now colours with light background terminal" src="https://user-images.githubusercontent.com/5079556/205627468-5db24b7f-a91e-46d4-be8c-57223aa8f91f.png">

### In customised, dark background `iTerms2`

<img width="45%" alt="Now colours with customised dark background terminal" src="https://user-images.githubusercontent.com/5079556/205627474-67ba8ab8-4391-4019-89c1-64125867eefa.png">

