### PR TITLE
correct Win32API capitalization for JRuby

### DIFF
--- a/lib/reline/windows.rb
+++ b/lib/reline/windows.rb
@@ -53,7 +53,7 @@ class Reline::Windows
   end
 
   if defined? JRUBY_VERSION
-    require 'win32api'
+    require 'Win32API'
   else
     class Win32API
       DLL = {}


### PR DESCRIPTION
JRuby 9.4.0.0 seems to have introduced a change in case sensitivity in require statements, meaning that an inclusion of `win32api` that previously loaded Win32API.rb no longer works. With this change, the require statement needs to be updated to the correct capitalization of the filename to avoid reline failures in newer versions of JRuby.

This is intended to address #476. I haven't had a chance to test it myself for resolution of the JRuby problem, but will update this request once I have.

EDIT: clarify problem description and apparent cause