### PR TITLE
Activate yamatanooroti tests with WITH_VTERM=1

### DIFF
--- a/.github/workflows/reline.yml
+++ b/.github/workflows/reline.yml
@@ -109,4 +109,4 @@ jobs:
       - name: Install dependencies
         run:  WITH_VTERM=1 bundle install
       - name: rake test_yamatanooroti
-        run:  bundle exec rake test_yamatanooroti
+        run:  WITH_VTERM=1 bundle exec rake test_yamatanooroti


### PR DESCRIPTION
Currently the `yamatanooroti` tests don't actually run anything on CI ([example](https://github.com/ruby/reline/actions/runs/3692513824/jobs/6251490594)). This is because #480 added `bundle exec`, so the `vterm` gem won't be required without `WITH_VTERM` env set.

This PR fixes the issue.


<img width="70%" alt="Screenshot 2022-12-21 at 14 17 11" src="https://user-images.githubusercontent.com/5079556/208926346-fef65d9c-a8e6-45cd-baac-596954aec403.png">
