### PR TITLE
Fix scrollbar wrongly displayed bug

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -52,6 +52,7 @@ class Reline::LineEditor
   MenuInfo = Struct.new('MenuInfo', :target, :list)
 
   PROMPT_LIST_CACHE_TIMEOUT = 0.5
+  MINIMUM_SCROLLBAR_HEIGHT = 1
 
   def initialize(config, encoding)
     @config = config
@@ -713,7 +714,7 @@ class Reline::LineEditor
       moving_distance = (dialog_render_info.contents.size - height) * 2
       position_ratio = dialog.scroll_top.zero? ? 0.0 : ((dialog.scroll_top * 2).to_f / moving_distance)
       bar_height = (bar_max_height * ((dialog.contents.size * 2).to_f / (dialog_render_info.contents.size * 2))).floor.to_i
-      bar_height = 1 if bar_height.zero?
+      bar_height = MINIMUM_SCROLLBAR_HEIGHT if bar_height < MINIMUM_SCROLLBAR_HEIGHT
       dialog.scrollbar_pos = ((bar_max_height - bar_height) * position_ratio).floor.to_i
     else
       dialog.scrollbar_pos = nil

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -703,17 +703,17 @@ class Reline::LineEditor
           dialog.scroll_top = dialog.pointer
         end
         pointer = dialog.pointer - dialog.scroll_top
+      else
+        dialog.scroll_top = 0
       end
       dialog.contents = dialog.contents[dialog.scroll_top, height]
-    end
-    if dialog.contents and dialog.scroll_top >= dialog.contents.size
-      dialog.scroll_top = dialog.contents.size - height
     end
     if dialog_render_info.scrollbar and dialog_render_info.contents.size > height
       bar_max_height = height * 2
       moving_distance = (dialog_render_info.contents.size - height) * 2
       position_ratio = dialog.scroll_top.zero? ? 0.0 : ((dialog.scroll_top * 2).to_f / moving_distance)
       bar_height = (bar_max_height * ((dialog.contents.size * 2).to_f / (dialog_render_info.contents.size * 2))).floor.to_i
+      bar_height = 1 if bar_height.zero?
       dialog.scrollbar_pos = ((bar_max_height - bar_height) * position_ratio).floor.to_i
     else
       dialog.scrollbar_pos = nil
@@ -755,7 +755,7 @@ class Reline::LineEditor
       str_width = dialog.width - (dialog.scrollbar_pos.nil? ? 0 : @block_elem_width)
       str = padding_space_with_escape_sequences(Reline::Unicode.take_range(item, 0, str_width), str_width)
       @output.write "\e[#{bg_color}m\e[#{fg_color}m#{str}"
-      if dialog.scrollbar_pos and (dialog.scrollbar_pos != old_dialog.scrollbar_pos or dialog.column != old_dialog.column)
+      if dialog.scrollbar_pos
         @output.write "\e[37m"
         if dialog.scrollbar_pos <= (i * 2) and (i * 2 + 1) < (dialog.scrollbar_pos + bar_height)
           @output.write @full_block

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -1081,6 +1081,32 @@ begin
       EOC
     end
 
+    def test_autocomplete_super_long_scroll_to_bottom
+      start_terminal(20, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --autocomplete-super-long}, startup_message: 'Multiline REPL.')
+      shift_tab = [27, 91, 90]
+      write('S' + shift_tab.map(&:chr).join)
+      close
+      assert_screen(<<~'EOC')
+        Multiline REPL.
+        prompt> Str_BXX
+                Str_BXJ
+                Str_BXK
+                Str_BXL
+                Str_BXM
+                Str_BXN
+                Str_BXO
+                Str_BXP
+                Str_BXQ
+                Str_BXR
+                Str_BXS
+                Str_BXT
+                Str_BXU
+                Str_BXV
+                Str_BXW
+                Str_BXX▄
+      EOC
+    end
+
     def test_autocomplete_super_long_and_backspace
       start_terminal(20, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --autocomplete-super-long}, startup_message: 'Multiline REPL.')
       shift_tab = [27, 91, 90]
@@ -1090,15 +1116,15 @@ begin
       assert_screen(<<~'EOC')
         Multiline REPL.
         prompt> Str_BX
-                Str_BX
-                Str_BXA
-                Str_BXB
-                Str_BXC
-                Str_BXD
-                Str_BXE
-                Str_BXF
-                Str_BXG
-                Str_BXH
+                Str_BX █
+                Str_BXA█
+                Str_BXB█
+                Str_BXC█
+                Str_BXD█
+                Str_BXE█
+                Str_BXF█
+                Str_BXG█
+                Str_BXH█
                 Str_BXI
                 Str_BXJ
                 Str_BXK
@@ -1142,7 +1168,7 @@ begin
         Multiline R
         EPL.
         prompt> Sym
-        String
+        String    █
         Struct    █
         Symbol    █
         StopIterat█


### PR DESCRIPTION
### Fixes these scrollbar bugs
- Scrollbar is not shown at bottom when I scrolled to bottom
- Pink color is remained in scrollbar area
- Scrollbar sometimes disappears after you scroll or when dialog size change (not shown in the gif below)
- Scrollbar will disappear if contents is very long (not shown in the gif below)
![scroll](https://user-images.githubusercontent.com/1780201/209539614-cdbce0fb-ff84-4c00-afa4-e573e4573ebc.gif)

### Change 1
```diff
         pointer = dialog.pointer - dialog.scroll_top
+      else
+        dialog.scroll_top = 0
       end
```

Resets scroll_top to zero if `dialog.pointer == nil`. It will be nil when `dialog_render_info.contents` changed.
Originally, reset is done at `dialog.scroll_top = dialog.contents.size - height` that I deleted in change2.

### Change 2
```diff
-    if dialog.contents and dialog.scroll_top >= dialog.contents.size
-      dialog.scroll_top = dialog.contents.size - height
-    end
```

The original code unintentionally resets dialog.scroll_top to zero because `dialog.contents.size - height` is always zero.
This will wrongly calculates scroll_top when `scroll_top >= height`.
I think the purpose of the original code is to satisfy the condition `0 <= scroll_top and scroll_top + height <= dialog_render_info.contents.size` when the content shrinks.
After I add `dialog.scroll_top = 0` in change1, the condition seems to be always satisfied.

### Change 3
```diff
+      bar_height = 1 if bar_height.zero?
```

If the dialog content is too long, calculated bar_height will be zero.
Since most scrollbar in GUI apps has a minimum hight, I set the minimum hight to 1.

### Change 4
```diff
-      if dialog.scrollbar_pos and (dialog.scrollbar_pos != old_dialog.scrollbar_pos or dialog.column != old_dialog.column)
+      if dialog.scrollbar_pos
```

The condition I deleted is for optimization to skip re-rendering scrollbar.
When pointer moved or dialog contents changed, scrollbar needs to be re-rendered. This is almost always, so I deleted the optimization condition.
