### PR TITLE
Add timeout minutes

### DIFF
--- a/.github/workflows/reline.yml
+++ b/.github/workflows/reline.yml
@@ -11,6 +11,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         ruby: [ 'head', '3.2', '3.1', '3.0', '2.7', '2.6' ]
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby
@@ -35,6 +36,7 @@ jobs:
           - { ruby: head,  os: macos-latest   }
           - { ruby: mingw, os: windows-latest }
           - { ruby: mswin, os: windows-latest }
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby
@@ -61,6 +63,7 @@ jobs:
       matrix:
         ruby: [ head ]
         os: [ ubuntu-latest ]
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby
@@ -91,6 +94,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         ruby: [ 'head', '3.2', '3.1', '3.0', '2.7', '2.6' ]
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby


### PR DESCRIPTION
Because the default timeout is 6 hours. Sometimes ci runs until it timeout.
The most recent run time is about 5 minutes, so 30 minutes will be fine.