### PR TITLE
multiline_repl do not need to depend on RubyLex

### DIFF
--- a/test/reline/yamatanooroti/multiline_repl
+++ b/test/reline/yamatanooroti/multiline_repl
@@ -53,7 +53,9 @@ opt.on('--color-bold') {
   }
 }
 opt.on('--auto-indent') {
-  AutoIndent.new
+  Reline.auto_indent_proc = lambda do |lines, line_index, byte_pointer, is_newline|
+    AutoIndent.calculate_indent(lines, line_index, byte_pointer, is_newline)
+  end
 }
 opt.on('--dialog VAL') { |v|
   Reline.add_dialog_proc(:simple_dialog, lambda {
@@ -194,8 +196,7 @@ end
 begin
   prompt = ENV['RELINE_TEST_PROMPT'] || 'prompt> '
   puts 'Multiline REPL.'
-  checker = TerminationChecker.new
-  while code = Reline.readmultiline(prompt, true) { |code| checker.terminated?(code) }
+  while code = Reline.readmultiline(prompt, true) { |code| TerminationChecker.terminated?(code) }
     case code.chomp
     when 'exit', 'quit', 'q'
       exit 0

--- a/test/reline/yamatanooroti/termination_checker.rb
+++ b/test/reline/yamatanooroti/termination_checker.rb
@@ -1,28 +1,26 @@
 require 'ripper'
-require 'irb/ruby-lex'
 
-class TerminationChecker < RubyLex
-  def terminated?(code)
-    code.gsub!(/\n*$/, '').concat("\n")
-    tokens = self.class.ripper_lex_without_warning(code)
-    continue = process_continue(tokens)
-    code_block_open = check_code_block(code, tokens)
-    indent = process_nesting_level(tokens)
-    ltype = process_literal_type(tokens)
-    if code_block_open or ltype or continue or indent > 0
-      false
-    else
-      true
-    end
+module TerminationChecker
+  def self.terminated?(code)
+    Ripper.sexp(code) ? true : false
   end
 end
 
-class AutoIndent < RubyLex
-  def initialize
-    @context = Struct.new("MockIRBContext", :auto_indent_mode, :workspace, :local_variables).new(true, nil, [])
+module AutoIndent
+  def self.calculate_indent(lines, line_index, byte_pointer, is_newline)
+    if is_newline
+      2 * nesting_level(lines[0..line_index - 1])
+    else
+      lines = lines.dup
+      lines[line_index] = lines[line_index]&.byteslice(0, byte_pointer)
+      prev_level = nesting_level(lines[0..line_index - 1])
+      level = nesting_level(lines[0..line_index])
+      2 * level if level < prev_level
+    end
   end
 
-  def auto_indent(&block)
-    Reline.auto_indent_proc = block
+  def self.nesting_level(lines)
+    code = lines.join("\n")
+    code.scan(/if|def|\(|\[|\{/).size - code.scan(/end|\)|\]|\}/).size
   end
 end

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -661,6 +661,35 @@ begin
       EOC
     end
 
+    def test_auto_indent
+      start_terminal(10, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --auto-indent}, startup_message: 'Multiline REPL.')
+      "def hoge\nputs(\n1,\n2\n)\nend".lines do |line|
+        write line
+      end
+      close
+      assert_screen(<<~EOC)
+        Multiline REPL.
+        prompt> def hoge
+        prompt>   puts(
+        prompt>     1,
+        prompt>     2
+        prompt>   )
+        prompt> end
+      EOC
+    end
+
+    def test_auto_indent_when_inserting_line
+      start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --auto-indent}, startup_message: 'Multiline REPL.')
+      write 'aa(bb(cc(dd(ee('
+      write "\C-b" * 5 + "\n"
+      close
+      assert_screen(<<~EOC)
+        Multiline REPL.
+        prompt> aa(bb(cc(d
+        prompt>       d(ee(
+      EOC
+    end
+
     def test_suppress_auto_indent_just_after_pasted
       start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --auto-indent}, startup_message: 'Multiline REPL.')
       write("def hoge\n  [[\n      3]]\ned")


### PR DESCRIPTION
In master, it seems that test_yamatanooroti fails.

```
% bundle exec ruby -Ilib test/reline/yamatanooroti/multiline_repl
Multiline REPL.
/Users/tomoya/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/bundler/gems/irb-5c8d3df2df3c/lib/irb/ruby-lex.rb:19:in `initialize': wrong number of arguments (given 0, expected 1) (ArgumentError)
	from test/reline/yamatanooroti/multiline_repl:197:in `new'
	from test/reline/yamatanooroti/multiline_repl:197:in `<main>'
```

`class TerminationChecker < RubyLex` now needs context in constructor and `multiline_repl` does not work now.
I'm also opening a pull request in irb (https://github.com/ruby/irb/pull/500) that deletes `RubyLex#process_nesting_level` and `RubyLex#process_literal_type` and it will also breaks reline's test.
I think multiline_repl don't need to depend on RubyLex.

I implement simple `TerminationChecker.terminated?` and `AutoIndent#calculate_indent` that only looks `if` `def` `end`, brackets and parenthesis.

I also find that `ruby -Ilib test/reline/yamatanooroti/multiline_repl --auto-indent` was not working, no indent was applied.
```ruby
opt.on('--auto-indent') {
  AutoIndent.new # makes an instance of AutoIndent but doing nothing
}
```

```
% bundle exec ruby -Ilib test/reline/yamatanooroti/multiline_repl --auto-indent
Multiline REPL.
prompt> if 1
prompt> if 2
prompt> end
prompt> end
=> nil
↓
% bundle exec ruby -Ilib test/reline/yamatanooroti/multiline_repl --auto-indent
Multiline REPL.
prompt> if 1
prompt>   if 1
prompt>   end
prompt> end
=> nil
```

