### PR TITLE
Splat is always an Array

### DIFF
--- a/lib/reline/config.rb
+++ b/lib/reline/config.rb
@@ -93,7 +93,7 @@ class Reline::Config
   end
 
   def editing_mode_is?(*val)
-    (val.respond_to?(:any?) ? val : [val]).any?(@editing_mode_label)
+    val.any?(@editing_mode_label)
   end
 
   def keymap


### PR DESCRIPTION
A small thing I noticed while reading the source code. Since we're collecting the arguments with a splat, we'll always get an Array, which responds to `any?`, so it's not necessary to check for that.