### PR TITLE
Use `em_delete` in `key_delete`

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -1944,8 +1944,10 @@ class Reline::LineEditor
   end
 
   private def key_delete(key)
-    if @config.editing_mode_is?(:vi_insert, :emacs)
+    if @config.editing_mode_is?(:vi_insert)
       ed_delete_next_char(key)
+    elsif @config.editing_mode_is?(:emacs)
+      em_delete(key)
     end
   end
 
@@ -2651,7 +2653,7 @@ class Reline::LineEditor
   alias_method :kill_whole_line, :em_kill_line
 
   private def em_delete(key)
-    if @line.empty? and (not @is_multiline or @buffer_of_lines.size == 1)
+    if @line.empty? and (not @is_multiline or @buffer_of_lines.size == 1) and key == "\C-d".ord
       @line = nil
       if @buffer_of_lines.size > 1
         scroll_down(@highest_in_all - @first_line_started_from)

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -2651,7 +2651,7 @@ class Reline::LineEditor
   alias_method :kill_whole_line, :em_kill_line
 
   private def em_delete(key)
-    if (not @is_multiline and @line.empty?) or (@is_multiline and @line.empty? and @buffer_of_lines.size == 1)
+    if @line.empty? and (not @is_multiline or @buffer_of_lines.size == 1)
       @line = nil
       if @buffer_of_lines.size > 1
         scroll_down(@highest_in_all - @first_line_started_from)

--- a/test/reline/test_key_actor_emacs.rb
+++ b/test/reline/test_key_actor_emacs.rb
@@ -428,6 +428,12 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
     assert_line("き\u3099")
   end
 
+  def test_em_delete_ends_editing
+    input_keys("\C-d") # quit from inputing
+    assert_line(nil)
+    assert(@line_editor.finished?)
+  end
+
   def test_ed_clear_screen
     refute(@line_editor.instance_variable_get(:@cleared))
     input_keys("\C-l", false)
@@ -449,7 +455,7 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
     assert_line('abc')
   end
 
-  def test_ed_delete_next_char
+  def test_key_delete
     input_keys('abc')
     assert_cursor(3)
     assert_cursor_max(3)
@@ -457,6 +463,14 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
     assert_cursor(3)
     assert_cursor_max(3)
     assert_line('abc')
+  end
+
+  def test_key_delete_does_not_end_editing
+    @line_editor.input_key(Reline::Key.new(:key_delete, :key_delete, false))
+    assert_cursor(0)
+    assert_cursor_max(0)
+    assert_line('')
+    refute(@line_editor.finished?)
   end
 
   def test_em_next_word

--- a/test/reline/test_key_actor_emacs.rb
+++ b/test/reline/test_key_actor_emacs.rb
@@ -473,6 +473,17 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
     refute(@line_editor.finished?)
   end
 
+  def test_key_delete_preserves_cursor
+    input_keys('abc')
+    input_keys("\C-b", false)
+    assert_cursor(2)
+    assert_cursor_max(3)
+    @line_editor.input_key(Reline::Key.new(:key_delete, :key_delete, false))
+    assert_cursor(2)
+    assert_cursor_max(2)
+    assert_line('ab')
+  end
+
   def test_em_next_word
     assert_byte_pointer_size('')
     assert_cursor(0)


### PR DESCRIPTION
Since #434, the <kbd>Del</kbd> key is bound to `:key_delete`, but `:key_delete` doesn't behave like readline does in emacs mode. It moves the cursor left if a character was deleted under the cursor, while in readline, it just deletes the character under the cursor.

line | type | `key_delete` | `em_delete`
-|-|-|-
| `abc\|` | <kbd>DEL</kbd> | `abc\|` | same
| `ab\|c` | <kbd>DEL</kbd> | `a\|b` | `ab\|`
| `ab\|c` | <kbd>DEL</kbd> <kbd>DEL</kbd> | `\|a` | `ab\|`

`:em_delete` is almost <kbd>Del</kbd> like readline, except it also handles the end-of-file situation. Which is annoying because if you type <kbd>Del</kbd> on an empty line, you get EOF instead of no changes.

This fixes it by using `:em_delete` in emacs mode, but also tweaking the behavior of `:em_delete` to only handle EOF when the key received is Ctrl-D. I hardcoded this but we could revisit that, see #501.