### PR TITLE
Add comment for unused constants

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -11,6 +11,7 @@ require 'reline/terminfo'
 require 'rbconfig'
 
 module Reline
+  # NOTE: For making compatible with the rb-readline gem
   FILENAME_COMPLETION_PROC = nil
   USERNAME_COMPLETION_PROC = nil
 


### PR DESCRIPTION
FILENAME_COMPLETION_PROC and USERNAME_COMPLETION_PROC are not used by Reline.
However, they were added for compatibility with the rb-readline gem.
These constants have been retained and comments added.

```
~/ghq/github.com/ruby/reline remove-unused-constants*
❯ git grep USERNAME_COMPLETION_PROC

~/ghq/github.com/ruby/reline remove-unused-constants*
❯ git grep FILENAME_COMPLETION_PROC

```