### PR TITLE
Fix line rendering when newline is added at the end of the buffer

### DIFF
--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -690,6 +690,19 @@ begin
       EOC
     end
 
+    def test_newline_after_wrong_indent
+      start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --auto-indent}, startup_message: 'Multiline REPL.')
+      write "if 1\n    aa"
+      write "\n"
+      close
+      assert_screen(<<~EOC)
+        Multiline REPL.
+        prompt> if 1
+        prompt>   aa
+        prompt>
+      EOC
+    end
+
     def test_suppress_auto_indent_just_after_pasted
       start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --auto-indent}, startup_message: 'Multiline REPL.')
       write("def hoge\n  [[\n      3]]\ned")


### PR DESCRIPTION
Fixed #505 

When newline is added at the end of the buffer, reline re-calculates previous line indentation.
Reline needs to render both previous line and added line, but renderes only added line.
I changed `rerender_added_newline` to also render previous line.