### PR TITLE
Add key bindings for PgUp and PgDn

### DIFF
--- a/lib/reline/ansi.rb
+++ b/lib/reline/ansi.rb
@@ -8,6 +8,8 @@ class Reline::ANSI
     'khome' => :ed_move_to_beg,
     'kend'  => :ed_move_to_end,
     'kdch1' => :key_delete,
+    'kpp' => :ed_ignore,
+    'knp' => :ed_ignore,
     'kcuu1' => :ed_prev_history,
     'kcud1' => :ed_next_history,
     'kcuf1' => :ed_next_char,

--- a/test/reline/test_ansi_with_terminfo.rb
+++ b/test/reline/test_ansi_with_terminfo.rb
@@ -33,6 +33,20 @@ class Reline::ANSI::TestWithTerminfo < Reline::TestCase
     omit e.message
   end
 
+  # PgUp key
+  def test_kpp
+    assert_key_binding(Reline::Terminfo.tigetstr('kpp'), :ed_ignore)
+  rescue Reline::Terminfo::TerminfoError => e
+    omit e.message
+  end
+
+  # PgDn key
+  def test_knp
+    assert_key_binding(Reline::Terminfo.tigetstr('knp'), :ed_ignore)
+  rescue Reline::Terminfo::TerminfoError => e
+    omit e.message
+  end
+
   # Up arrow key
   def test_kcuu1
     assert_key_binding(Reline::Terminfo.tigetstr('kcuu1'), :ed_prev_history)


### PR DESCRIPTION
This adds default key bindings for PgUp and PgDn so that instead of spewing out ugly escape codes they will just be ignored.

Helps with issue https://github.com/ruby/irb/issues/330.