### PR TITLE
test_dumb_terminal: "ruby" command is not always available

### DIFF
--- a/test/reline/test_reline.rb
+++ b/test/reline/test_reline.rb
@@ -370,7 +370,7 @@ class Reline::Test < Reline::TestCase
 
   def test_dumb_terminal
     lib = File.expand_path("../../lib", __dir__)
-    out = IO.popen([{"TERM"=>"dumb"}, "ruby", "-I#{lib}", "-rreline", "-e", "p Reline::IOGate"], &:read)
+    out = IO.popen([{"TERM"=>"dumb"}, Reline.test_rubybin, "-I#{lib}", "-rreline", "-e", "p Reline::IOGate"], &:read)
     assert_equal("Reline::GeneralIO", out.chomp)
   end
 


### PR DESCRIPTION
Fixes the same issue at https://github.com/ruby/ruby/pull/5417

`ruby` is not always available in certain build environments and configure options (e.g. --program-suffix)

This patch tries to choose an appropriate command line for spawning a fresh Ruby process, based on EnvUtil implementation in ruby/ruby's test suite.

Plus when this library is directly mirrored into ruby/ruby, prefer EnvUtil available there over the implementation in this library's test suite.

----

✅ verified the test suite passes when mirrored to ruby/ruby