### PR TITLE
Fix IRB's completion of multiline and noautocomplete

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -1371,8 +1371,8 @@ class Reline::LineEditor
         @completion_state = CompletionState::MENU
       end
       if not just_show_list and target < completed
-        @line = preposing + completed + completion_append_character.to_s + postposing
-        line_to_pointer = preposing + completed + completion_append_character.to_s
+        @line = (preposing + completed + completion_append_character.to_s + postposing).split("\n")[@line_index] || String.new(encoding: @encoding)
+        line_to_pointer = (preposing + completed + completion_append_character.to_s).split("\n").last || String.new(encoding: @encoding)
         @cursor_max = calculate_width(@line)
         @cursor = calculate_width(line_to_pointer)
         @byte_pointer = line_to_pointer.bytesize

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -839,6 +839,18 @@ begin
       EOC
     end
 
+    def test_multiline_completion
+      start_terminal(10, 50, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --complete}, startup_message: 'Multiline REPL.')
+      write("def hoge\n  St\n  St\C-p\t")
+      close
+      assert_screen(<<~'EOC')
+        Multiline REPL.
+        prompt> def hoge
+        prompt>   String
+        prompt>   St
+      EOC
+    end
+
     def test_completion_journey_2nd_line
       write_inputrc <<~LINES
         set editing-mode vi


### PR DESCRIPTION
When you are editing multiline with `irb --noautocomplete` or `IRB_USE_AUTOCOMPLETE=false irb`, TAB completion corrupts the screen.


https://user-images.githubusercontent.com/1780201/221970703-be8f53be-1bc3-4a54-9f4a-08f168ea83a5.mp4




For this example input
```ruby
if 1
  Arr█
end
```
preposing is `"if 1\n  "`, target is `"Arr"` and postposing = `"\nend"`
Before this pullrequest, reline was not considering preposing and postposing having `"\n"` in noautocomplete mode.



reference code:
https://github.com/ruby/reline/blob/51b0297e461f6c0e39d5670f8ec4da28694290b6/lib/reline/line_editor.rb#L1420-L1426
