### PR TITLE
Fix cursor position overrun

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -994,11 +994,8 @@ class Reline::LineEditor
         calculate_height_by_lines(@buffer_of_lines[0..(@line_index - 1)], prompt_list || prompt)
       end
     first_line_diff = new_first_line_started_from - @first_line_started_from
-    new_cursor, new_cursor_max, new_started_from, new_byte_pointer = calculate_nearest_cursor(@buffer_of_lines[@line_index], @cursor, @started_from, @byte_pointer, false)
-    @cursor = new_cursor
-    @cursor_max = new_cursor_max
-    @byte_pointer = new_byte_pointer
-    new_started_from = calculate_height_by_width(prompt_width + new_cursor) - 1
+    @cursor, @cursor_max, _, @byte_pointer = calculate_nearest_cursor(@buffer_of_lines[@line_index], @cursor, @started_from, @byte_pointer, false)
+    new_started_from = calculate_height_by_width(prompt_width + @cursor) - 1
     calculate_scroll_partial_screen(@highest_in_all, new_first_line_started_from + new_started_from)
     @previous_line_index = nil
     @line = @buffer_of_lines[@line_index]

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -995,21 +995,20 @@ class Reline::LineEditor
       end
     first_line_diff = new_first_line_started_from - @first_line_started_from
     new_cursor, new_cursor_max, new_started_from, new_byte_pointer = calculate_nearest_cursor(@buffer_of_lines[@line_index], @cursor, @started_from, @byte_pointer, false)
+    @cursor = new_cursor
+    @cursor_max = new_cursor_max
+    @byte_pointer = new_byte_pointer
     new_started_from = calculate_height_by_width(prompt_width + new_cursor) - 1
     calculate_scroll_partial_screen(@highest_in_all, new_first_line_started_from + new_started_from)
     @previous_line_index = nil
+    @line = @buffer_of_lines[@line_index]
     if @rerender_all
-      @line = @buffer_of_lines[@line_index]
       rerender_all_lines
       @rerender_all = false
       true
     else
-      @line = @buffer_of_lines[@line_index]
       @first_line_started_from = new_first_line_started_from
       @started_from = new_started_from
-      @cursor = new_cursor
-      @cursor_max = new_cursor_max
-      @byte_pointer = new_byte_pointer
       move_cursor_down(first_line_diff + @started_from)
       Reline::IOGate.move_cursor_column((prompt_width + @cursor) % @screen_size.last)
       false

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -644,6 +644,30 @@ begin
       EOC
     end
 
+    def test_longer_than_screen_height_nearest_cursor_with_scroll_back
+      start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
+      write(<<~EOC.chomp)
+        if 1
+          if 2
+            if 3
+              if 4
+                puts
+              end
+            end
+          end
+        end
+      EOC
+      write("\C-p" * 4 + "\C-e" + "\C-p" * 4)
+      write("2")
+      assert_screen(<<~EOC)
+        prompt> if 12
+        prompt>   if 2
+        prompt>     if 3
+        prompt>       if 4
+        prompt>         puts
+      EOC
+    end
+
     def test_update_cursor_correctly_when_just_cursor_moving
       start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write("def hoge\n  01234678")


### PR DESCRIPTION
When input lines is larget than screen height, and move cursor up and down, cursor position sometimes overruns
And if you input something, irb will crash. this pull request fixes it.
I think #470 will be fixed.

Left: before, Right: after
https://user-images.githubusercontent.com/1780201/224025150-fd53acd6-7ea1-42fc-8150-76001990518f.mp4


## changes
```ruby
calculate_nearest_cursor
...
update_previous_line_index
if @rerender_all
  update_line
  # forgot update_cursor_to_nearest_cursor_position
  rerender_all_lines
else
  update_line
  maybe_prepareing_instance_variables_for_moving_cursor
  update_cursor_to_nearest_cursor_position
  move_cursor
end
```
↓
```ruby
calculate_nearest_cursor
update_cursor_to_nearest_cursor_position
...
# updating @line, @line_index, @previous_line_index are updated at once, used together in many place in line_editor.rb
update_line_and_previous_line_index

# rendering part
if @rerender_all
  # only doing rendering here
  rerender_all_lines
else
  # only doing cursor moving(≒ cursor rendering) here
  maybe_prepareing_instance_variables_for_moving_cursor
  move_cursor
end
```


