### PR TITLE
Fix: line longer than terminal width breaks rendering

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -972,6 +972,7 @@ class Reline::LineEditor
       prev_line_prompt = @prompt_proc ? prompt_list[@line_index - 1] : prompt
       prev_line_prompt_width = @prompt_proc ? calculate_width(prev_line_prompt, true) : prompt_width
       prev_line = modify_lines(lines)[@line_index - 1]
+      move_cursor_up(@started_from)
       render_partial(prev_line_prompt, prev_line_prompt_width, prev_line, @first_line_started_from + @started_from, with_control: false)
       scroll_down(1)
       render_partial(prompt, prompt_width, @line, @first_line_started_from + @started_from + 1, with_control: false)

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -281,6 +281,23 @@ begin
       EOC
     end
 
+    def test_multiline_add_new_line_and_autowrap
+      start_terminal(10, 20, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
+      write("def aaaaaaaaaa")
+      write("\n")
+      write("  bbbbbbbbbbbb")
+      write("\n")
+      close
+      assert_screen(<<~EOC)
+        Multiline REPL.
+        prompt> def aaaaaaaa
+        aa
+        prompt>   bbbbbbbbbb
+        bb
+        prompt>
+      EOC
+    end
+
     def test_clear
       start_terminal(10, 15, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write("3\C-l")


### PR DESCRIPTION
This pull request fixes a bug introduced by #507 
When you input long line, longer than the terminal width to irb and type enter, rendering breaks.

```ruby
# Input data that I added in this pullrequest
def aaaaaaaaaa
  bbbbbbbbbb

# Before
prompt> def aaaaaaaa
prompt> def aaaaaaaa
aa
prompt>   bbbbbbbbbb
prompt>   bbbbbbbbbb
bb
prompt>

# After
prompt> def aaaaaaaa
aa
prompt>   bbbbbbbbbb
bb
prompt>
```

### description
When newline is added to the end of the buffer, reline rerenders last line (because indent might changed) and the added newline.
When the last line is autowrapped (height of last line >= 2), cursor must move up before rerendering the last line, this pull request adds this process.

