### PR TITLE
Consider fullwidth characters for dialog rendering

### DIFF
--- a/test/reline/test_unicode.rb
+++ b/test/reline/test_unicode.rb
@@ -41,8 +41,8 @@ class Reline::Unicode::Test < Reline::TestCase
   def test_take_range
     assert_equal 'cdef', Reline::Unicode.take_range('abcdefghi', 2, 4)
     assert_equal 'あde', Reline::Unicode.take_range('abあdef', 2, 4)
-    assert_equal 'zerocdef', Reline::Unicode.take_range("ab\1zero\2cdef", 2, 4)
-    assert_equal 'bzerocde', Reline::Unicode.take_range("ab\1zero\2cdef", 1, 4)
+    assert_equal "\1zero\2cdef", Reline::Unicode.take_range("ab\1zero\2cdef", 2, 4)
+    assert_equal "b\1zero\2cde", Reline::Unicode.take_range("ab\1zero\2cdef", 1, 4)
     assert_equal "\e[31mcd\e[42mef", Reline::Unicode.take_range("\e[31mabcd\e[42mefg", 2, 4)
     assert_equal "\e]0;1\acd", Reline::Unicode.take_range("ab\e]0;1\acd", 2, 3)
     assert_equal 'いう', Reline::Unicode.take_range('あいうえお', 2, 4)
@@ -61,5 +61,25 @@ class Reline::Unicode::Test < Reline::TestCase
     assert_equal 4, Reline::Unicode.calculate_width("ab\e]0;1\acd", true)
     assert_equal 10, Reline::Unicode.calculate_width('あいうえお')
     assert_equal 10, Reline::Unicode.calculate_width('あいうえお', true)
+  end
+
+  def test_take_mbchar_range
+    assert_equal ['cdef', 2, 4], Reline::Unicode.take_mbchar_range('abcdefghi', 2, 4)
+    assert_equal ['cdef', 2, 4], Reline::Unicode.take_mbchar_range('abcdefghi', 2, 4, padding: true)
+    assert_equal ['cdef', 2, 4], Reline::Unicode.take_mbchar_range('abcdefghi', 2, 4, cover_begin: true)
+    assert_equal ['cdef', 2, 4], Reline::Unicode.take_mbchar_range('abcdefghi', 2, 4, cover_end: true)
+    assert_equal ['いう', 2, 4], Reline::Unicode.take_mbchar_range('あいうえお', 2, 4)
+    assert_equal ['いう', 2, 4], Reline::Unicode.take_mbchar_range('あいうえお', 2, 4, padding: true)
+    assert_equal ['いう', 2, 4], Reline::Unicode.take_mbchar_range('あいうえお', 2, 4, cover_begin: true)
+    assert_equal ['いう', 2, 4], Reline::Unicode.take_mbchar_range('あいうえお', 2, 4, cover_end: true)
+    assert_equal ['う', 4, 2], Reline::Unicode.take_mbchar_range('あいうえお', 3, 4)
+    assert_equal [' う ', 3, 4], Reline::Unicode.take_mbchar_range('あいうえお', 3, 4, padding: true)
+    assert_equal ['いう', 2, 4], Reline::Unicode.take_mbchar_range('あいうえお', 3, 4, cover_begin: true)
+    assert_equal ['うえ', 4, 4], Reline::Unicode.take_mbchar_range('あいうえお', 3, 4, cover_end: true)
+    assert_equal ['いう ', 2, 5], Reline::Unicode.take_mbchar_range('あいうえお', 3, 4, cover_begin: true, padding: true)
+    assert_equal [' うえ', 3, 5], Reline::Unicode.take_mbchar_range('あいうえお', 3, 4, cover_end: true, padding: true)
+    assert_equal [' うえお   ', 3, 10], Reline::Unicode.take_mbchar_range('あいうえお', 3, 10, padding: true)
+    assert_equal ["\e[31mc\1ABC\2d\e[0mef", 2, 4], Reline::Unicode.take_mbchar_range("\e[31mabc\1ABC\2d\e[0mefghi", 2, 4)
+    assert_equal ["\e[47m い ", 1, 4], Reline::Unicode.take_mbchar_range("\e[47mあいうえお\e[0m", 1, 4, padding: true)
   end
 end

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -1155,6 +1155,25 @@ begin
       EOC
     end
 
+    def test_autocomplete_rerender_fullwidth_under_dialog
+      start_terminal(20, 40, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --autocomplete}, startup_message: 'Multiline REPL.')
+      write("def hoge\n\n  あいうえおabかきくけこab\n  aあいうえおabかきくけこb\n  abあいうえおabかきくけこ\C-p\C-p\C-p  ")
+      write('S')
+      write('t')
+      write('          ')
+      write('S')
+      write('t')
+      close
+      assert_screen(<<~'EOC')
+        Multiline REPL.
+        prompt> def hoge
+        prompt>   St          St
+        prompt>   あいうえおabStringけこab
+        prompt>   aあいうえおaStruct けこb
+        prompt>   abあいうえおabかきくけこ
+      EOC
+    end
+
     def test_autocomplete_long_with_scrollbar
       start_terminal(20, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --autocomplete-long}, startup_message: 'Multiline REPL.')
       write('S')


### PR DESCRIPTION
When dialog is cleared, we need to restore the text that was hidden behind dialogs.

To implement restoring full width characters hidden behind dialog, `take_range` lacks of feature.
It does not provide where to render the string. column information is missing.
```ruby
Reline::Unicode.take_range('一二三四五a', 2, 5) #=> '二三' # should render at column=2
Reline::Unicode.take_range('a一二三四五', 2, 5) #=> '二三' # should render at column=3
```

Sometimes we need other cut variation depending on adjacent dialog position.
The image below shows a variation of `take_range('一二三四五六七八九', 5, 8, option)`
<img width="391" alt="dialog_restore" src="https://user-images.githubusercontent.com/1780201/225972452-f60df623-ba68-442d-b4c4-544d481b1534.png">


So I add `Reline::Unicode.take_mbchar_range` that has option `cover_begin, cover_end, padding` and make it return the actual cut position.
```ruby
take_mbchar_range('一二三', 1, 4) #=> ['二', 2, 2]
take_mbchar_range('一二三', 1, 4, cover_begin: true) #=> ['一二', 0, 4]
take_mbchar_range('一二三', 1, 4, cover_end: true) #=> ['二三', 2, 4]
take_mbchar_range('一二三', 1, 4, padding: true) #=> [' 二 ', 1, 4]
take_mbchar_range('一二三', 1, 4, cover_begin: true, padding: true) #=> ['一二 ', 0, 5]
take_mbchar_range('一二三', 1, 4, cover_end: true, padding: true) #=> [' 二三', 1, 5]
```
