### PR TITLE
Fix Home and End keys on macOS

### DIFF
--- a/lib/reline/ansi.rb
+++ b/lib/reline/ansi.rb
@@ -344,12 +344,26 @@ class Reline::ANSI
     @@old_winch_handler = Signal.trap('WINCH', &handler)
   end
 
+  def self.enter_keyboard_transmit_mode
+    @@output.write Reline::Terminfo.tigetstr('smkx') if Reline::Terminfo.enabled?
+  rescue Reline::Terminfo::TerminfoError
+    # smkx is undefined
+  end
+
+  def self.leave_keyboard_transmit_mode
+    @@output.write Reline::Terminfo.tigetstr('rmkx') if Reline::Terminfo.enabled?
+  rescue Reline::Terminfo::TerminfoError
+    # rmkx is undefined
+  end
+
   def self.prep
     retrieve_keybuffer
+    enter_keyboard_transmit_mode
     nil
   end
 
   def self.deprep(otio)
+    leave_keyboard_transmit_mode
     Signal.trap('WINCH', @@old_winch_handler) if @@old_winch_handler
   end
 end

--- a/lib/reline/ansi.rb
+++ b/lib/reline/ansi.rb
@@ -12,10 +12,6 @@ class Reline::ANSI
     'kcud1' => :ed_next_history,
     'kcuf1' => :ed_next_char,
     'kcub1' => :ed_prev_char,
-    'cuu' => :ed_prev_history,
-    'cud' => :ed_next_history,
-    'cuf' => :ed_next_char,
-    'cub' => :ed_prev_char,
   }
 
   if Reline::Terminfo.enabled?
@@ -66,14 +62,7 @@ class Reline::ANSI
     key_bindings = CAPNAME_KEY_BINDINGS.map do |capname, key_binding|
       begin
         key_code = Reline::Terminfo.tigetstr(capname)
-        case capname
-        # Escape sequences that omit the move distance and are set to defaults
-        # value 1 may be sometimes sent by pressing the arrow-key.
-        when 'cuu', 'cud', 'cuf', 'cub'
-          [ key_code.sub(/%p1%d/, '').bytes, key_binding ]
-        else
-          [ key_code.bytes, key_binding ]
-        end
+        [ key_code.bytes, key_binding ]
       rescue Reline::Terminfo::TerminfoError
         # capname is undefined
       end


### PR DESCRIPTION
Fix https://github.com/ruby/irb/issues/330 by entering keyboard transmit mode (aka application mode) to ensure the escape sequences line up with terminfo.

Also, remove a hack that is no longer needed (see [commit](https://github.com/ruby/reline/pull/521/commits/d453a2be231b0403fb1cc7b8588db3f9412ae9a2) comment for explanation).

This replaces https://github.com/ruby/reline/pull/462, which had some issues and was never finished up.