### PR TITLE
Ignore unhandled escape sequences

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -1571,11 +1571,13 @@ class Reline::LineEditor
       return if key.char >= 128 # maybe, first byte of multi byte
       method_symbol = @config.editing_mode.get_method(key.combined_char)
       if key.with_meta and method_symbol == :ed_unassigned
-        # split ESC + key
-        method_symbol = @config.editing_mode.get_method("\e".ord)
-        process_key("\e".ord, method_symbol)
-        method_symbol = @config.editing_mode.get_method(key.char)
-        process_key(key.char, method_symbol)
+        if @config.editing_mode_is?(:vi_command, :vi_insert)
+          # split ESC + key in vi mode
+          method_symbol = @config.editing_mode.get_method("\e".ord)
+          process_key("\e".ord, method_symbol)
+          method_symbol = @config.editing_mode.get_method(key.char)
+          process_key(key.char, method_symbol)
+        end
       else
         process_key(key.combined_char, method_symbol)
       end
@@ -3345,4 +3347,7 @@ class Reline::LineEditor
     @mark_pointer = new_pointer
   end
   alias_method :exchange_point_and_mark, :em_exchange_mark
+
+  private def em_meta_next(key)
+  end
 end

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -237,6 +237,20 @@ begin
       EOC
     end
 
+    def test_esc_input
+      omit if Reline::IOGate.win?
+      start_terminal(5, 20, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
+      write("def\C-aabc")
+      write("\e") # single ESC
+      sleep 1
+      write("A")
+      write("B\eAC") # ESC + A (M-A, specified ed_unassigned in Reline::KeyActor::Emacs)
+      assert_screen(<<~EOC)
+        Multiline REPL.
+        prompt> abcABCdef
+      EOC
+    end
+
     def test_prompt_with_escape_sequence
       ENV['RELINE_TEST_PROMPT'] = "\1\e[30m\2prompt> \1\e[m\2"
       start_terminal(5, 20, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')


### PR DESCRIPTION
Fixes #514

When unknown escape sequence is typed, reline prints the escape sequence.
In Mac Terminal.app, the keys are F1~F12 keys, option+A, option+up, etc.

This pull request will change reline to correctly ignore unmatched CSI sequence, SS3 sequence, ESC+char and single ESC input.
