### PR TITLE
Fix dialog corrupts rendering by pushing up input line too much

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -713,8 +713,10 @@ class Reline::LineEditor
     ymax = ymax.clamp(screen_y_range.begin, screen_y_range.end)
     dialog_y = @first_line_started_from + @started_from
     cursor_y = dialog_y
-    scroll_down(ymax - cursor_y)
-    move_cursor_up(ymax - cursor_y)
+    if @highest_in_all < ymax
+      scroll_down(ymax - cursor_y)
+      move_cursor_up(ymax - cursor_y)
+    end
     (ymin..ymax).each do |y|
       move_cursor_down(y - cursor_y)
       cursor_y = y

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -708,7 +708,8 @@ class Reline::LineEditor
     # Clear and rerender all dialogs line by line
     Reline::IOGate.hide_cursor
     ymin, ymax = (ranges_to_restore.keys + new_dialog_ranges.keys).minmax
-    screen_y_range = (@scroll_partial_screen || 0)..(@scroll_partial_screen || 0) + @screen_height - 1
+    scroll_partial_screen = @scroll_partial_screen || 0
+    screen_y_range = scroll_partial_screen..(scroll_partial_screen + @screen_height - 1)
     ymin = ymin.clamp(screen_y_range.begin, screen_y_range.end)
     ymax = ymax.clamp(screen_y_range.begin, screen_y_range.end)
     dialog_y = @first_line_started_from + @started_from

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -708,6 +708,9 @@ class Reline::LineEditor
     # Clear and rerender all dialogs line by line
     Reline::IOGate.hide_cursor
     ymin, ymax = (ranges_to_restore.keys + new_dialog_ranges.keys).minmax
+    screen_y_range = (@scroll_partial_screen || 0)..(@scroll_partial_screen || 0) + @screen_height - 1
+    ymin = ymin.clamp(screen_y_range.begin, screen_y_range.end)
+    ymax = ymax.clamp(screen_y_range.begin, screen_y_range.end)
     dialog_y = @first_line_started_from + @started_from
     cursor_y = dialog_y
     scroll_down(ymax - cursor_y)

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -957,6 +957,20 @@ begin
       EOC
     end
 
+    def test_simple_dialog_with_scroll_screen
+      start_terminal(5, 50, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --dialog simple}, startup_message: 'Multiline REPL.')
+      write("if 1\n  2\n  3\n  4\n  5\n  6")
+      write("\C-p\C-n\C-p\C-p\C-p#")
+      close
+      assert_screen(<<~'EOC')
+        prompt>   2
+        prompt>   3#
+        prompt>   4
+        prompt>   5
+        prompt>   6 Ruby is...
+      EOC
+    end
+
     def test_autocomplete_at_bottom
       start_terminal(15, 50, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --autocomplete}, startup_message: 'Multiline REPL.')
       write('def hoge' + "\C-m" * 10 + "end\C-p  ")

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -1360,12 +1360,12 @@ begin
         prompt>
         prompt>
         prompt>
+        prompt>   S
         prompt>   String
         prompt>   Struct
-        prompt>   Symbol
-        prompt> enScriptError
+        prompt> enSymbol
+                  ScriptError
                   SyntaxError
-                  Signal
       EOC
     end
 


### PR DESCRIPTION
# Description
Fix this redering corrupt bug.
Left: before, Right: after

https://user-images.githubusercontent.com/1780201/227573618-67a2bc4e-4e63-430a-aae7-999560d910c8.mp4

# Problem
If the terminal height is 5
```
prompt > 1 + 2
=> 3
prompt> if 1
prompt>   2.

```

Reline can only render 3 lines of dialog if the cursor is on line 2.
```
prompt> if 1
prompt>   2.
          2.remeinder
          2.abs
          2.magnitude
```

If reline breaks this rule and render 4 lines
```
prompt>   2.
          2.remeinder
          2.abs
          2.magnitude
          2.zero?
```
Reline cannot move cursor to the beginning of line, where `if 1` was displayed.
This is making reline's rendering corrupt.
I changed dialog rendering not to render where it overflows screen.