### PR TITLE
Improve OSC sequence regexp

### DIFF
--- a/lib/reline/unicode.rb
+++ b/lib/reline/unicode.rb
@@ -38,7 +38,7 @@ class Reline::Unicode
   NON_PRINTING_START = "\1"
   NON_PRINTING_END = "\2"
   CSI_REGEXP = /\e\[[\d;]*[ABCDEFGHJKSTfminsuhl]/
-  OSC_REGEXP = /\e\]\d+(?:;[^;]+)*\a/
+  OSC_REGEXP = /\e\]\d+(?:;[^;\a\e]+)*(?:\a|\e\\)/
   WIDTH_SCANNER = /\G(?:(#{NON_PRINTING_START})|(#{NON_PRINTING_END})|(#{CSI_REGEXP})|(#{OSC_REGEXP})|(\X))/o
 
   def self.get_mbchar_byte_size_by_first_char(c)

--- a/test/reline/test_unicode.rb
+++ b/test/reline/test_unicode.rb
@@ -18,6 +18,17 @@ class Reline::Unicode::Test < Reline::TestCase
     assert_equal 2, Reline::Unicode.calculate_width('√', true)
   end
 
+  def test_csi_regexp
+    csi_sequences = ["\e[m", "\e[1m", "\e[12;34m", "\e[12;34H"]
+    assert_equal(csi_sequences, "text#{csi_sequences.join('text')}text".scan(Reline::Unicode::CSI_REGEXP))
+  end
+
+  def test_osc_regexp
+    osc_sequences = ["\e]1\a", "\e]0;OSC\a", "\e]1\e\\", "\e]0;OSC\e\\"]
+    separator = "text\atext"
+    assert_equal(osc_sequences, "#{separator}#{osc_sequences.join(separator)}#{separator}".scan(Reline::Unicode::OSC_REGEXP))
+  end
+
   def test_split_by_width
     assert_equal [['abc', nil, 'de'], 2], Reline::Unicode.split_by_width('abcde', 3)
     assert_equal [['abc', nil, 'def', nil, ''], 3], Reline::Unicode.split_by_width('abcdef', 3)


### PR DESCRIPTION
Reline::Unicode::OSC_REGEXP `/\e\]\d+(?:;[^;]+)*\a/` has a bug.
```ruby
"text \e]1;OSC\a text \a text \e]1;OSC\a text".scan(Reline::Unicode::OSC_REGEXP)
#=> actual: ["\e]1;OSC\a text \a text \e]1;OSC\a"]
#=> expected: ["\e]1;OSC\a", "\e]1;OSC\a"] 
```

Change
`/\e\]\d+(?:;[^;]+)*\a/`
↓
`/\e\]\d+(?:;[^;\a\e]+)*(?:\a|\e\\)/`

OSC sequence ends with `BEL`(already implemented) or `ST(="\e\\")` (implemented in this pull request).
OSC sequence does not include BEL and ESC inside. (tested in Terminal.app, iTerm2, Alacritty with `printf "text \e]0;WindowTitleInclu\eDingESC\a text"`)
As a side effect, `Reline::Unicode.calculate_width("\e]1;"*10000, true)` gets faster.

I think this pull request does not affect/improve the actual behavior because IRB is not using OSC sequence