### PR TITLE
Drop Unicode.take_range's optional arg as it's never used

### DIFF
--- a/lib/reline/unicode.rb
+++ b/lib/reline/unicode.rb
@@ -192,8 +192,8 @@ class Reline::Unicode
   end
 
   # Take a chunk of a String cut by width with escape sequences.
-  def self.take_range(str, start_col, max_width, encoding = str.encoding)
-    chunk = String.new(encoding: encoding)
+  def self.take_range(str, start_col, max_width)
+    chunk = String.new(encoding: str.encoding)
     total_width = 0
     rest = str.encode(Encoding::UTF_8)
     in_zero_width = false


### PR DESCRIPTION
In all usages of `Unicode.take_range`, the last parameter never receives anything:

```
lib/reline/line_editor.rb
751:      str = padding_space_with_escape_sequences(Reline::Unicode.take_range(item, 0, str_width), str_width)
810:          s = Reline::Unicode.take_range(visual_lines[start + i], old_dialog.column, old_dialog.width)
828:          s = Reline::Unicode.take_range(visual_lines[start + i], old_dialog.column, old_dialog.width)
847:          s = Reline::Unicode.take_range(visual_lines[start + i], old_dialog.column, width)
866:          s = Reline::Unicode.take_range(visual_lines[start + i], old_dialog.column + dialog.width, width)
917:        str = Reline::Unicode.take_range(visual_lines_under_dialog[i], dialog.column, dialog.width)
```

So we can drop it to make it easier to understand.

(IRB doesn't use this method)