### PR TITLE
Reline.add_dialog_proc should not accept nil as proc

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -166,9 +166,13 @@ module Reline
 
     DialogProc = Struct.new(:dialog_proc, :context)
     def add_dialog_proc(name_sym, p, context = nil)
-      raise ArgumentError unless p.respond_to?(:call) or p.nil?
       raise ArgumentError unless name_sym.instance_of?(Symbol)
-      @dialog_proc_list[name_sym] = DialogProc.new(p, context)
+      if p.nil?
+        @dialog_proc_list.delete(name_sym)
+      else
+        raise ArgumentError unless p.respond_to?(:call)
+        @dialog_proc_list[name_sym] = DialogProc.new(p, context)
+      end
     end
 
     def dialog_proc(name_sym)

--- a/test/reline/test_reline.rb
+++ b/test/reline/test_reline.rb
@@ -321,6 +321,9 @@ class Reline::Test < Reline::TestCase
     d = Reline.dialog_proc(:test_proc)
     assert_equal(dummy_proc_2, d.dialog_proc)
 
+    Reline.add_dialog_proc(:test_proc, nil)
+    assert_nil(Reline.dialog_proc(:test_proc))
+
     l = lambda {}
     Reline.add_dialog_proc(:test_lambda, l)
     d = Reline.dialog_proc(:test_lambda)


### PR DESCRIPTION
If you pass nil to add_dialog_proc, Reline suddenly raise error.
```
% ruby -rreline -e "Reline.add_dialog_proc(:a,nil);Reline.readmultiline('prompt>'){true}"
prompt>/usr/local/lib/ruby/3.3.0+0/reline/line_editor.rb:583:in `instance_exec': no block given (LocalJumpError)
	from /usr/local/lib/ruby/3.3.0+0/reline/line_editor.rb:583:in `call'
	from /usr/local/lib/ruby/3.3.0+0/reline/line_editor.rb:618:in `call'
        ...
```
~I chage add_dialog_proc not to accept nil~
I change to remove dialog_proc when nil is passed.
There was no way to remove dialog_proc before this pull request.
