### PR TITLE
Remove irb from test dependeicy and from test matrix

### DIFF
--- a/.github/workflows/reline.yml
+++ b/.github/workflows/reline.yml
@@ -55,37 +55,6 @@ jobs:
           TERM: xterm-256color
         run: bundle exec rake ci-test
 
-  irb:
-    name: >-
-      irb ${{ matrix.ruby }}  ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        ruby: [ head ]
-        os: [ ubuntu-latest ]
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby }}
-      - name: Install dependencies
-        run:  bundle install
-      - name: Install reline
-        run:  |
-          rake build
-          rake install
-      - name: Download ruby/irb
-        run:  |
-          git clone https://github.com/ruby/irb
-      - name: Setup ruby/irb
-        run:  |
-          cd irb
-          bundle install
-      - name: Run irb test
-        run:  bundle exec rake test
-
   vterm-yamatanooroti:
     name: >-
       vterm-yamatanooroti ${{ matrix.os }} ${{ matrix.ruby }}

--- a/Gemfile
+++ b/Gemfile
@@ -12,4 +12,3 @@ end
 gem 'bundler'
 gem 'rake'
 gem 'test-unit'
-gem 'irb', github: "ruby/irb"


### PR DESCRIPTION
Reline's test no longer depends on irb.

CI was failing in ruby 2.6 because github:ruby/irb requires ruby >= 2.7
```
Could not find compatible versions

Because every version of irb depends on Ruby >= 2.7
  and Gemfile depends on irb >= 0,
  Ruby >= 2.7 is required.
So, because current Ruby version is = 2.6.10,
  version solving has failed.
```
https://github.com/ruby/reline/actions/runs/4678386950/jobs/8287063665?pr=532