### PR TITLE
Run IRB test in workflow

### DIFF
--- a/.github/workflows/reline.yml
+++ b/.github/workflows/reline.yml
@@ -55,6 +55,37 @@ jobs:
           TERM: xterm-256color
         run: bundle exec rake ci-test
 
+  irb:
+    name: >-
+      irb ${{ matrix.ruby }}  ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        ruby: [ head ]
+        os: [ ubuntu-latest ]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: Install dependencies
+        run:  bundle install
+      - name: Install reline
+        run:  |
+          rake build
+          rake install
+      - name: Download ruby/irb
+        run:  |
+          git clone https://github.com/ruby/irb
+      - name: Setup ruby/irb
+        run:  |
+          cd irb
+          bundle install
+      - name: Run irb test
+        run:  bundle exec rake test
+
   vterm-yamatanooroti:
     name: >-
       vterm-yamatanooroti ${{ matrix.os }} ${{ matrix.ruby }}

--- a/.github/workflows/reline.yml
+++ b/.github/workflows/reline.yml
@@ -70,6 +70,15 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+      - name: Install libvterm
+        run: |
+          sudo apt install -y libtool-bin
+          wget http://www.leonerd.org.uk/code/libvterm/libvterm-0.1.4.tar.gz
+          tar xvzf libvterm-0.1.4.tar.gz
+          cd libvterm-0.1.4
+          sed -i -e 's/^PREFIX=.*$/PREFIX=\/usr/g' Makefile
+          make
+          sudo make install
       - name: Install dependencies
         run:  bundle install
       - name: Install reline
@@ -79,12 +88,16 @@ jobs:
       - name: Download ruby/irb
         run:  |
           git clone https://github.com/ruby/irb
-      - name: Setup ruby/irb
-        run:  |
-          cd irb
-          bundle install
       - name: Run irb test
-        run:  bundle exec rake test
+        working-directory: ./irb
+        run: |
+          bundle install
+          bundle exec rake test
+      - name: Run irb yamatanooroti test
+        working-directory: ./irb
+        run: |
+          WITH_VTERM=1 bundle install
+          WITH_VTERM=1 bundle exec rake test_yamatanooroti
 
   vterm-yamatanooroti:
     name: >-

--- a/.github/workflows/reline.yml
+++ b/.github/workflows/reline.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        ruby: [ head ]
+        ruby: [ 'head', '3.2' ]
         os: [ ubuntu-latest ]
     timeout-minutes: 30
     steps:

--- a/.github/workflows/reline.yml
+++ b/.github/workflows/reline.yml
@@ -95,9 +95,11 @@ jobs:
           bundle exec rake test
       - name: Run irb yamatanooroti test
         working-directory: ./irb
+        env:
+          WITH_VTERM: 1
         run: |
-          WITH_VTERM=1 bundle install
-          WITH_VTERM=1 bundle exec rake test_yamatanooroti
+          bundle install
+          bundle exec rake test_yamatanooroti
 
   vterm-yamatanooroti:
     name: >-


### PR DESCRIPTION
I reverted the change I made in #533 that removed irb-test from workflow.

I also fixed the bug in irb-test workflow. It was running reline's test instead of irb's test.
`cd irb` is missing and `bundle exec rake test` was running in the wrong directory.
I also add irb's test_yamatanooroti in the workflow

Example of wrong test. 3068 assertions with different encoding is reline's test.
https://github.com/ruby/reline/actions/runs/4678386950/jobs/8287060129?pr=532
