### PR TITLE
Revert #335 (Trap TSTP to handle C-z)

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -239,21 +239,10 @@ class Reline::LineEditor
         @old_trap.call if @old_trap.respond_to?(:call)
       end
     }
-    begin
-      @old_tstp_trap = Signal.trap('TSTP') {
-        Reline::IOGate.ungetc("\C-z".ord)
-        @old_tstp_trap.call if @old_tstp_trap.respond_to?(:call)
-      }
-    rescue ArgumentError
-    end
   end
 
   def finalize
     Signal.trap('INT', @old_trap)
-    begin
-      Signal.trap('TSTP', @old_tstp_trap)
-    rescue ArgumentError
-    end
   end
 
   def eof?


### PR DESCRIPTION
Fixes https://github.com/ruby/reline/issues/466

#335 was an effort to address #321 (ed_quoted_insert doesn't work properly) but [per the reporter](https://github.com/ruby/reline/issues/321#issuecomment-919170815) the change did not work correctly.

Moreover, it introduced a major regression: Shell job control stopped working in all applications that use reline, notably IRB.

Shells send SIGTSTP [in response to SUSP (C-z)](https://www.gnu.org/software/libc/manual/html_node/Job-Control-Signals.html#index-SIGTSTP) to implement the suspension part of job control. Adding a handler for SIGTSTP opts out of this functionality. For a line oriented terminal program this should be avoided when possible (not to mention, this behavior diverges from readline's)

cc @aycabta