### PR TITLE
Reline.readline("prompt>") should use prompt specified by parameter

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -326,7 +326,7 @@ module Reline
       line_editor.completion_proc = completion_proc
       line_editor.completion_append_character = completion_append_character
       line_editor.output_modifier_proc = output_modifier_proc
-      line_editor.prompt_proc = prompt_proc
+      line_editor.prompt_proc = multiline ? prompt_proc : nil
       line_editor.auto_indent_proc = auto_indent_proc
       line_editor.dig_perfect_match_proc = dig_perfect_match_proc
       line_editor.pre_input_hook = pre_input_hook

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -151,6 +151,20 @@ begin
       EOC
     end
 
+    def test_readline_prompt
+      start_terminal(5, 40, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --dynamic-prompt}, startup_message: 'Multiline REPL.')
+      write("Reline.readline('prompt> ')\n")
+      write("hello\n")
+      close
+      assert_screen(<<~EOC)
+        Multiline REPL.
+        [0000]> Reline.readline('prompt> ')
+        prompt> hello
+        => "hello"
+        [0000]>
+      EOC
+    end
+
     def test_mode_string_emacs
       write_inputrc <<~LINES
         set show-mode-in-prompt on


### PR DESCRIPTION
I expect `Reline.readline(prompt)` to use prompt instead of prompt_proc. I think prompt_proc is for readmultiline.

Before
```ruby
irb(main):001:0> Reline.readline 'prompt> '
irb(main):002:0> hello # IRB's prompt is used instead of "prompt> "
=> "hello"
irb(main):002:0> 
```

After
```ruby
irb(main):001:0> Reline.readline 'prompt> '
prompt> hello # "prompt> " is used
=> "hello"
irb(main):002:0> 
```

### For Reline.readmultiline
I also want to fix Reline.readmultiline. https://github.com/ruby/debug/issues/308

```ruby
# Idea of changing readmultiline
Reline.readmultiline(&termination_proc) # use prompt_proc
Reline.readmultiline(prompt_string, &termination_proc) # use prompt_string
Reline.readmultiline(prompt_string, add_hist, &termination_proc) # use prompt_string ← IRB is using this style
Reline.readmultiline(nil, add_hist, &termination_proc) # use prompt_proc

# Keyword argument looks better, but has compatibility problem
def Reline.readmultiline(prompt = nil, add_history: false, &confirm_multiline_termination)
```

But it will break IRB's prompt.
```
irb(main):001:0> if false
irb(main):001:0>   line num is 001
irb(main):001:0>   does not increment
irb(main):001:0>   still 001
irb(main):001:0> end
=> nil
```
