### PR TITLE
Fix scrolldown condition in dialog rendering

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -714,7 +714,7 @@ class Reline::LineEditor
     ymax = ymax.clamp(screen_y_range.begin, screen_y_range.end)
     dialog_y = @first_line_started_from + @started_from
     cursor_y = dialog_y
-    if @highest_in_all < ymax
+    if @highest_in_all <= ymax
       scroll_down(ymax - cursor_y)
       move_cursor_up(ymax - cursor_y)
     end

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -957,6 +957,25 @@ begin
       EOC
     end
 
+    def test_dialog_scroll_pushup_condition
+      start_terminal(10, 50, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --autocomplete}, startup_message: 'Multiline REPL.')
+      write("\n" * 10)
+      write("if 1\n  sSt\nend")
+      write("\C-p\C-h\C-e")
+      assert_screen(<<~'EOC')
+        prompt>
+        prompt>
+        prompt>
+        prompt>
+        prompt>
+        prompt>
+        prompt> if 1
+        prompt>   St
+        prompt> enString
+                  Struct
+      EOC
+    end
+
     def test_simple_dialog_with_scroll_screen
       start_terminal(5, 50, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --dialog simple}, startup_message: 'Multiline REPL.')
       write("if 1\n  2\n  3\n  4\n  5\n  6")


### PR DESCRIPTION
Fix scrolldown bug.

Left: master branch, Right: this pull request
<img width="598" alt="scrolldown" src="https://github.com/ruby/reline/assets/1780201/beed32cc-9ffd-4556-b983-7e27c2bb3a39">

Scroll down condition was wrong.



In the case below, `@highest_in_all` (total lines, including wordwrap) is 7 and the maximum row index is 6(`@highest_in_all - 1`

```
prompt:0> puts 'Hello World'
Hello World
=> nil
prompt:0> def f
prompt:1>   1
prompt:2>   2; ruby/
prompt:3>   3
prompt:4>   4
prompt:5>   5
prompt:6> end
```

When dialog is going to be rendered in row=3 to row=7 (`ymin == 3` and `ymax == 7` )

```
prompt:0> puts 'Hello World'
Hello World
=> nil
prompt:0> def f
prompt:1>   1
prompt:2>   2; ruby/r
prompt:3>   3       re
prompt:4>   4       rel
prompt:5>  5        reli
prompt:6> end       relin
prompt:7>           reline
```

`ymax` is larger than maximum row index `@highest_in_all - 1` so reline needs to scroll down to make space to render dialog.
The condition to scroll down is `@highest_in_all - 1 < ymax` or `@highest_in_all <= ymax`, but was `@highest_in_all < ymax`
