### PR TITLE
Omit constant under Struct

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -17,7 +17,7 @@ module Reline
 
   class ConfigEncodingConversionError < StandardError; end
 
-  Key = Struct.new('Key', :char, :combined_char, :with_meta) do
+  Key = Struct.new(:char, :combined_char, :with_meta) do
     def match?(other)
       case other
       when Reline::Key

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -48,8 +48,8 @@ class Reline::LineEditor
     PERFECT_MATCH = :perfect_match
   end
 
-  CompletionJourneyData = Struct.new('CompletionJourneyData', :preposing, :postposing, :list, :pointer)
-  MenuInfo = Struct.new('MenuInfo', :target, :list)
+  CompletionJourneyData = Struct.new(:preposing, :postposing, :list, :pointer)
+  MenuInfo = Struct.new(:target, :list)
 
   PROMPT_LIST_CACHE_TIMEOUT = 0.5
   MINIMUM_SCROLLBAR_HEIGHT = 1


### PR DESCRIPTION
Fixes: https://github.com/ruby/reline/issues/551

We can create a structure named by its constant. Although writing the name under `Struct` is no problem, it would be better to be omitted it.

Ref: https://docs.ruby-lang.org/en/3.0/Struct.html

Thank you for having me the opportunity. I’m glad to start contributing to open-source projects.