### PR TITLE
Remove unused method

### DIFF
--- a/lib/reline/unicode.rb
+++ b/lib/reline/unicode.rb
@@ -41,26 +41,6 @@ class Reline::Unicode
   OSC_REGEXP = /\e\]\d+(?:;[^;\a\e]+)*(?:\a|\e\\)/
   WIDTH_SCANNER = /\G(?:(#{NON_PRINTING_START})|(#{NON_PRINTING_END})|(#{CSI_REGEXP})|(#{OSC_REGEXP})|(\X))/o
 
-  def self.get_mbchar_byte_size_by_first_char(c)
-    # Checks UTF-8 character byte size
-    case c.ord
-    # 0b0xxxxxxx
-    when ->(code) { (code ^ 0b10000000).allbits?(0b10000000) } then 1
-    # 0b110xxxxx
-    when ->(code) { (code ^ 0b00100000).allbits?(0b11100000) } then 2
-    # 0b1110xxxx
-    when ->(code) { (code ^ 0b00010000).allbits?(0b11110000) } then 3
-    # 0b11110xxx
-    when ->(code) { (code ^ 0b00001000).allbits?(0b11111000) } then 4
-    # 0b111110xx
-    when ->(code) { (code ^ 0b00000100).allbits?(0b11111100) } then 5
-    # 0b1111110x
-    when ->(code) { (code ^ 0b00000010).allbits?(0b11111110) } then 6
-    # successor of mbchar
-    else 0
-    end
-  end
-
   def self.escape_for_print(str)
     str.chars.map! { |gr|
       escaped = EscapedPairs[gr.ord]


### PR DESCRIPTION
`get_mbchar_byte_size_by_first_char` isn't used in Reline.
Also, this method implements the same functionality as `String#bytesize` and is unnecessary.