### PR TITLE
Fix wrong byte_pointer passed to auto_indent_proc

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -1645,7 +1645,7 @@ class Reline::LineEditor
       @line = ' ' * new_indent + @line.lstrip
 
       new_indent = nil
-      result = @auto_indent_proc.(new_lines[0..-2], @line_index - 1, (new_lines[-2].size + 1), false)
+      result = @auto_indent_proc.(new_lines[0..-2], @line_index - 1, (new_lines[@line_index - 1].bytesize + 1), false)
       if result
         new_indent = result
       end

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -731,6 +731,24 @@ begin
       EOC
     end
 
+    def test_auto_indent_multibyte_insert_line
+      start_terminal(10, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --auto-indent}, startup_message: 'Multiline REPL.')
+      write "if true\n"
+      write "あいうえお\n"
+      4.times { write "\C-b\C-b\C-b\C-b\e\r" }
+      close
+      assert_screen(<<~EOC)
+        Multiline REPL.
+        prompt> if true
+        prompt>   あ
+        prompt>   い
+        prompt>   う
+        prompt>   え
+        prompt>   お
+        prompt>
+      EOC
+    end
+
     def test_newline_after_wrong_indent
       start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --auto-indent}, startup_message: 'Multiline REPL.')
       write "if 1\n    aa"


### PR DESCRIPTION
Fixes byte_pointer passed to auto_indent_proc when inserting newline.
If there is multiline character, wrong byte_pointer causes invalid byte sequence error.

Fixes #553 and https://github.com/ruby/irb/issues/627

