### PR TITLE
Store IO gate in `Config` and avoid referencing the `Reline::IOGate` directly

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -76,15 +76,19 @@ module Reline
       :autocompletion=
 
     def initialize
-      self.output = STDOUT
       @dialog_proc_list = {}
       yield self
+      self.output = STDOUT
       @completion_quote_character = nil
       @bracketed_paste_finished = false
     end
 
+    def io_gate
+      @config.io_gate
+    end
+
     def encoding
-      Reline::IOGate.encoding
+      io_gate.encoding
     end
 
     def completion_append_character=(val)
@@ -181,16 +185,16 @@ module Reline
 
     def input=(val)
       raise TypeError unless val.respond_to?(:getc) or val.nil?
-      if val.respond_to?(:getc) && Reline::IOGate.respond_to?(:input=)
-        Reline::IOGate.input = val
+      if val.respond_to?(:getc) && io_gate.respond_to?(:input=)
+        io_gate.input = val
       end
     end
 
     def output=(val)
       raise TypeError unless val.respond_to?(:write) or val.nil?
       @output = val
-      if Reline::IOGate.respond_to?(:output=)
-        Reline::IOGate.output = val
+      if io_gate.respond_to?(:output=)
+        io_gate.output = val
       end
     end
 
@@ -213,7 +217,7 @@ module Reline
     end
 
     def get_screen_size
-      Reline::IOGate.get_screen_size
+      io_gate.get_screen_size
     end
 
     Reline::DEFAULT_DIALOG_PROC_AUTOCOMPLETE = ->() {
@@ -266,7 +270,7 @@ module Reline
     Reline::DEFAULT_DIALOG_CONTEXT = Array.new
 
     def readmultiline(prompt = '', add_hist = false, &confirm_multiline_termination)
-      Reline::IOGate.with_raw_input do
+      io_gate.with_raw_input do
         unless confirm_multiline_termination
           raise ArgumentError.new('#readmultiline needs block to confirm multiline termination')
         end
@@ -298,7 +302,7 @@ module Reline
 
     private def inner_readline(prompt, add_hist, multiline, &confirm_multiline_termination)
       if ENV['RELINE_STDERR_TTY']
-        if Reline::IOGate.win?
+        if io_gate.win?
           $stderr = File.open(ENV['RELINE_STDERR_TTY'], 'a')
         else
           $stderr.reopen(ENV['RELINE_STDERR_TTY'], 'w')
@@ -306,7 +310,7 @@ module Reline
         $stderr.sync = true
         $stderr.puts "Reline is used by #{Process.pid}"
       end
-      otio = Reline::IOGate.prep
+      otio = io_gate.prep
 
       may_req_ambiguous_char_width
       line_editor.reset(prompt, encoding: encoding)
@@ -333,7 +337,7 @@ module Reline
       unless config.test_mode
         config.read
         config.reset_default_key_bindings
-        Reline::IOGate.set_default_key_bindings(config)
+        io_gate.set_default_key_bindings(config)
       end
 
       line_editor.rerender
@@ -342,9 +346,9 @@ module Reline
         line_editor.set_signal_handlers
         prev_pasting_state = false
         loop do
-          prev_pasting_state = Reline::IOGate.in_pasting?
+          prev_pasting_state = io_gate.in_pasting?
           read_io(config.keyseq_timeout) { |inputs|
-            line_editor.set_pasting_state(Reline::IOGate.in_pasting?)
+            line_editor.set_pasting_state(io_gate.in_pasting?)
             inputs.each { |c|
               line_editor.input_key(c)
               line_editor.rerender
@@ -354,29 +358,29 @@ module Reline
               @bracketed_paste_finished = false
             end
           }
-          if prev_pasting_state == true and not Reline::IOGate.in_pasting? and not line_editor.finished?
+          if prev_pasting_state == true and not io_gate.in_pasting? and not line_editor.finished?
             line_editor.set_pasting_state(false)
             prev_pasting_state = false
             line_editor.rerender_all
           end
           break if line_editor.finished?
         end
-        Reline::IOGate.move_cursor_column(0)
+        io_gate.move_cursor_column(0)
       rescue Errno::EIO
         # Maybe the I/O has been closed.
       rescue StandardError => e
         line_editor.finalize
-        Reline::IOGate.deprep(otio)
+        io_gate.deprep(otio)
         raise e
       rescue Exception
         # Including Interrupt
         line_editor.finalize
-        Reline::IOGate.deprep(otio)
+        io_gate.deprep(otio)
         raise
       end
 
       line_editor.finalize
-      Reline::IOGate.deprep(otio)
+      io_gate.deprep(otio)
     end
 
     # GNU Readline waits for "keyseq-timeout" milliseconds to see if the ESC
@@ -391,7 +395,7 @@ module Reline
     private def read_io(keyseq_timeout, &block)
       buffer = []
       loop do
-        c = Reline::IOGate.getc
+        c = io_gate.getc
         if c == -1
           result = :unmatched
           @bracketed_paste_finished = true
@@ -431,7 +435,7 @@ module Reline
       begin
         succ_c = nil
         Timeout.timeout(keyseq_timeout / 1000.0) {
-          succ_c = Reline::IOGate.getc
+          succ_c = io_gate.getc
         }
       rescue Timeout::Error # cancel matching only when first byte
         block.([Reline::Key.new(c, c, false)])
@@ -446,7 +450,7 @@ module Reline
           end
           return :break
         when :matching
-          Reline::IOGate.ungetc(succ_c)
+          io_gate.ungetc(succ_c)
           return :next
         when :matched
           buffer << succ_c
@@ -463,7 +467,7 @@ module Reline
       begin
         escaped_c = nil
         Timeout.timeout(keyseq_timeout / 1000.0) {
-          escaped_c = Reline::IOGate.getc
+          escaped_c = io_gate.getc
         }
       rescue Timeout::Error # independent ESC
         block.([Reline::Key.new(c, c, false)])
@@ -486,19 +490,19 @@ module Reline
     end
 
     private def may_req_ambiguous_char_width
-      @ambiguous_width = 2 if Reline::IOGate == Reline::GeneralIO or !STDOUT.tty?
+      @ambiguous_width = 2 if io_gate == Reline::GeneralIO or !STDOUT.tty?
       return if defined? @ambiguous_width
-      Reline::IOGate.move_cursor_column(0)
+      io_gate.move_cursor_column(0)
       begin
         output.write "\u{25bd}"
       rescue Encoding::UndefinedConversionError
         # LANG=C
         @ambiguous_width = 1
       else
-        @ambiguous_width = Reline::IOGate.cursor_pos.x
+        @ambiguous_width = io_gate.cursor_pos.x
       end
-      Reline::IOGate.move_cursor_column(0)
-      Reline::IOGate.erase_after_cursor
+      io_gate.move_cursor_column(0)
+      io_gate.erase_after_cursor
     end
   end
 
@@ -554,12 +558,12 @@ module Reline
   private :readmultiline
 
   def self.encoding_system_needs
-    self.core.encoding
+    core.encoding
   end
 
   def self.core
     @core ||= Core.new { |core|
-      core.config = Reline::Config.new
+      core.config = Reline::Config.new(Reline::IOGate)
       core.key_stroke = Reline::KeyStroke.new(core.config)
       core.line_editor = Reline::LineEditor.new(core.config, core.encoding)
 
@@ -574,7 +578,7 @@ module Reline
   end
 
   def self.ungetc(c)
-    Reline::IOGate.ungetc(c)
+    core.io_gate.ungetc(c)
   end
 
   def self.line_editor

--- a/lib/reline/config.rb
+++ b/lib/reline/config.rb
@@ -46,8 +46,9 @@ class Reline::Config
   end
 
   attr_accessor :autocompletion
+  attr_accessor :io_gate
 
-  def initialize
+  def initialize(io_gate)
     @additional_key_bindings = {} # from inputrc
     @additional_key_bindings[:emacs] = {}
     @additional_key_bindings[:vi_insert] = {}
@@ -70,7 +71,8 @@ class Reline::Config
     @keyseq_timeout = 500
     @test_mode = false
     @autocompletion = false
-    @convert_meta = true if seven_bit_encoding?(Reline::IOGate.encoding)
+    @io_gate = io_gate
+    @convert_meta = true if seven_bit_encoding?(@io_gate.encoding)
   end
 
   def reset

--- a/test/reline/helper.rb
+++ b/test/reline/helper.rb
@@ -21,16 +21,19 @@ end
 module Reline
   class <<self
     def test_mode(ansi: false)
+        config = send(:core).config
         remove_const('IOGate') if const_defined?('IOGate')
-        const_set('IOGate', ansi ? Reline::ANSI : Reline::GeneralIO)
+        io_gate = ansi ? Reline::ANSI : Reline::GeneralIO
+        const_set('IOGate', io_gate)
+        config.io_gate = io_gate
         if ENV['RELINE_TEST_ENCODING']
           encoding = Encoding.find(ENV['RELINE_TEST_ENCODING'])
         else
           encoding = Encoding::UTF_8
         end
-        Reline::GeneralIO.reset(encoding: encoding) unless ansi
-        send(:core).config.instance_variable_set(:@test_mode, true)
-        send(:core).config.reset
+        io_gate.reset(encoding: encoding) unless ansi
+        config.instance_variable_set(:@test_mode, true)
+        config.reset
     end
 
     def test_reset

--- a/test/reline/test_ansi_with_terminfo.rb
+++ b/test/reline/test_ansi_with_terminfo.rb
@@ -4,7 +4,7 @@ require 'reline/ansi'
 class Reline::ANSI::TestWithTerminfo < Reline::TestCase
   def setup
     Reline.send(:test_mode, ansi: true)
-    @config = Reline::Config.new
+    @config = Reline::Config.new(Reline::IOGate)
     Reline::IOGate.set_default_key_bindings(@config, allow_terminfo: true)
   end
 

--- a/test/reline/test_ansi_without_terminfo.rb
+++ b/test/reline/test_ansi_without_terminfo.rb
@@ -4,7 +4,7 @@ require 'reline/ansi'
 class Reline::ANSI::TestWithoutTerminfo < Reline::TestCase
   def setup
     Reline.send(:test_mode, ansi: true)
-    @config = Reline::Config.new
+    @config = Reline::Config.new(Reline::IOGate)
     Reline::IOGate.set_default_key_bindings(@config, allow_terminfo: false)
   end
 

--- a/test/reline/test_config.rb
+++ b/test/reline/test_config.rb
@@ -12,7 +12,7 @@ class Reline::Config::Test < Reline::TestCase
     end
     Dir.chdir(@tmpdir)
     Reline.test_mode
-    @config = Reline::Config.new
+    @config = Reline::Config.new(Reline::IOGate)
   end
 
   def teardown
@@ -86,7 +86,7 @@ class Reline::Config::Test < Reline::TestCase
   def test_encoding_is_ascii
     @config.reset
     Reline::IOGate.reset(encoding: Encoding::US_ASCII)
-    @config = Reline::Config.new
+    @config = Reline::Config.new(Reline::IOGate)
 
     assert_equal true, @config.convert_meta
   end
@@ -94,7 +94,7 @@ class Reline::Config::Test < Reline::TestCase
   def test_encoding_is_not_ascii
     @config.reset
     Reline::IOGate.reset(encoding: Encoding::UTF_8)
-    @config = Reline::Config.new
+    @config = Reline::Config.new(Reline::IOGate)
 
     assert_equal nil, @config.convert_meta
   end

--- a/test/reline/test_key_actor_emacs.rb
+++ b/test/reline/test_key_actor_emacs.rb
@@ -4,7 +4,7 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
   def setup
     Reline.send(:test_mode)
     @prompt = '> '
-    @config = Reline::Config.new # Emacs mode is default
+    @config = Reline::Config.new(Reline::IOGate) # Emacs mode is default
     @config.autocompletion = false
     Reline::HISTORY.instance_variable_set(:@config, @config)
     Reline::HISTORY.clear

--- a/test/reline/test_key_actor_vi.rb
+++ b/test/reline/test_key_actor_vi.rb
@@ -4,7 +4,7 @@ class Reline::KeyActor::ViInsert::Test < Reline::TestCase
   def setup
     Reline.send(:test_mode)
     @prompt = '> '
-    @config = Reline::Config.new
+    @config = Reline::Config.new(Reline::IOGate)
     @config.read_lines(<<~LINES.split(/(?<=\n)/))
       set editing-mode vi
     LINES

--- a/test/reline/test_key_stroke.rb
+++ b/test/reline/test_key_stroke.rb
@@ -14,7 +14,7 @@ class Reline::KeyStroke::Test < Reline::TestCase
   }
 
   def test_match_status
-    config = Reline::Config.new
+    config = Reline::Config.new(Reline::IOGate)
     {
       'a' => 'xx',
       'ab' => 'y',
@@ -37,7 +37,7 @@ class Reline::KeyStroke::Test < Reline::TestCase
   end
 
   def test_expand
-    config = Reline::Config.new
+    config = Reline::Config.new(Reline::IOGate)
     {
       'abc' => '123',
     }.each_pair do |key, func|
@@ -48,7 +48,7 @@ class Reline::KeyStroke::Test < Reline::TestCase
   end
 
   def test_oneshot_key_bindings
-    config = Reline::Config.new
+    config = Reline::Config.new(Reline::IOGate)
     {
       'abc' => '123',
     }.each_pair do |key, func|
@@ -60,7 +60,7 @@ class Reline::KeyStroke::Test < Reline::TestCase
   end
 
   def test_with_reline_key
-    config = Reline::Config.new
+    config = Reline::Config.new(Reline::IOGate)
     {
       [
         Reline::Key.new(100, 228, true), # Alt+d

--- a/test/reline/test_line_editor.rb
+++ b/test/reline/test_line_editor.rb
@@ -3,8 +3,8 @@ require 'reline/line_editor'
 
 class Reline::LineEditor::Test < Reline::TestCase
   def test_range_subtract
-    dummy_config = nil
-    editor = Reline::LineEditor.new(dummy_config, 'ascii-8bit')
+    config = Reline::Config.new(Reline::IOGate)
+    editor = Reline::LineEditor.new(config, 'ascii-8bit')
     base_ranges = [3...5, 4...10, 6...8, 12...15, 15...20]
     subtract_ranges = [5...7, 8...9, 11...13, 17...18, 18...19]
     expected_result = [3...5, 7...8, 9...10, 13...17, 19...20]

--- a/test/reline/test_macro.rb
+++ b/test/reline/test_macro.rb
@@ -3,7 +3,7 @@ require_relative 'helper'
 class Reline::MacroTest < Reline::TestCase
   def setup
     Reline.send(:test_mode)
-    @config = Reline::Config.new
+    @config = Reline::Config.new(Reline::IOGate)
     @encoding = Reline::IOGate.encoding
     @line_editor = Reline::LineEditor.new(@config, @encoding)
     @line_editor.instance_variable_set(:@screen_size, [24, 80])

--- a/test/reline/test_string_processing.rb
+++ b/test/reline/test_string_processing.rb
@@ -4,7 +4,7 @@ class Reline::LineEditor::StringProcessingTest < Reline::TestCase
   def setup
     Reline.send(:test_mode)
     @prompt = '> '
-    @config = Reline::Config.new
+    @config = Reline::Config.new(Reline::IOGate)
     Reline::HISTORY.instance_variable_set(:@config, @config)
     @encoding = Reline::IOGate.encoding
     @line_editor = Reline::LineEditor.new(@config, @encoding)


### PR DESCRIPTION
IO gate is a component that's widely used in Reline. However, it's not supposed to be assigned right when `Reline` is loaded, which has been causing problems described in https://github.com/ruby/reline/issues/559

And the need to lazily assign it when `readline`/`readmultiline` being called means it should not be a constant but an attribute of either `Core` or `Config`.

Since it's widely used in `LineEditor`, I think making it an attribute of `Config` is better than `Core`.

Note:

- The goal is to drop the `Reline::IOGate` constant completely. But I want to avoid making breaking change here as it's supposed to be a refactoring.
- Before we drop `Reline::IOGate`, there's a chance that `Reline.core.io_gate` could be different than it. So the goal is to make gems switch to `Reline.core.io_gate` ASAP and drop `Reline::IOGate`.