### PR TITLE
Simple test refactors

### DIFF
--- a/test/reline/helper.rb
+++ b/test/reline/helper.rb
@@ -29,8 +29,8 @@ module Reline
           encoding = Encoding::UTF_8
         end
         Reline::GeneralIO.reset(encoding: encoding) unless ansi
-        send(:core).config.instance_variable_set(:@test_mode, true)
-        send(:core).config.reset
+        core.config.instance_variable_set(:@test_mode, true)
+        core.config.reset
     end
 
     def test_reset

--- a/test/reline/test_history.rb
+++ b/test/reline/test_history.rb
@@ -297,7 +297,7 @@ class Reline::History::Test < Reline::TestCase
   end
 
   def get_default_internal_encoding
-    if encoding = Reline::IOGate.encoding
+    if encoding = Reline.core.encoding
       encoding
     elsif RUBY_PLATFORM =~ /mswin|mingw/
       Encoding.default_internal || Encoding::UTF_8

--- a/test/reline/test_key_actor_emacs.rb
+++ b/test/reline/test_key_actor_emacs.rb
@@ -8,7 +8,7 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
     @config.autocompletion = false
     Reline::HISTORY.instance_variable_set(:@config, @config)
     Reline::HISTORY.clear
-    @encoding = Reline::IOGate.encoding
+    @encoding = Reline.core.encoding
     @line_editor = Reline::LineEditor.new(@config, @encoding)
     @line_editor.reset(@prompt, encoding: @encoding)
   end
@@ -2167,7 +2167,7 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
 
   # Unicode emoji test
   def test_ed_insert_for_include_zwj_emoji
-    omit "This test is for UTF-8 but the locale is #{Reline::IOGate.encoding}" if Reline::IOGate.encoding != Encoding::UTF_8
+    omit "This test is for UTF-8 but the locale is #{Reline.core.encoding}" if Reline.core.encoding != Encoding::UTF_8
     # U+1F468 U+200D U+1F469 U+200D U+1F467 U+200D U+1F466 is family: man, woman, girl, boy "👨‍👩‍👧‍👦"
     input_keys("\u{1F468}") # U+1F468 is man "👨"
     assert_line("\u{1F468}")
@@ -2213,7 +2213,7 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
   end
 
   def test_ed_insert_for_include_valiation_selector
-    omit "This test is for UTF-8 but the locale is #{Reline::IOGate.encoding}" if Reline::IOGate.encoding != Encoding::UTF_8
+    omit "This test is for UTF-8 but the locale is #{Reline.core.encoding}" if Reline.core.encoding != Encoding::UTF_8
     # U+0030 U+FE00 is DIGIT ZERO + VARIATION SELECTOR-1 "0︀"
     input_keys("\u0030") # U+0030 is DIGIT ZERO
     assert_line("\u0030")

--- a/test/reline/test_key_actor_vi.rb
+++ b/test/reline/test_key_actor_vi.rb
@@ -8,7 +8,7 @@ class Reline::KeyActor::ViInsert::Test < Reline::TestCase
     @config.read_lines(<<~LINES.split(/(?<=\n)/))
       set editing-mode vi
     LINES
-    @encoding = Reline::IOGate.encoding
+    @encoding = Reline.core.encoding
     @line_editor = Reline::LineEditor.new(@config, @encoding)
     @line_editor.reset(@prompt, encoding: @encoding)
   end

--- a/test/reline/test_macro.rb
+++ b/test/reline/test_macro.rb
@@ -4,7 +4,7 @@ class Reline::MacroTest < Reline::TestCase
   def setup
     Reline.send(:test_mode)
     @config = Reline::Config.new
-    @encoding = Reline::IOGate.encoding
+    @encoding = Reline.core.encoding
     @line_editor = Reline::LineEditor.new(@config, @encoding)
     @line_editor.instance_variable_set(:@screen_size, [24, 80])
     @output = @line_editor.output = File.open(IO::NULL, "w")

--- a/test/reline/test_reline.rb
+++ b/test/reline/test_reline.rb
@@ -378,7 +378,7 @@ class Reline::Test < Reline::TestCase
   end
 
   def get_reline_encoding
-    if encoding = Reline::IOGate.encoding
+    if encoding = Reline.core.encoding
       encoding
     elsif RUBY_PLATFORM =~ /mswin|mingw/
       Encoding::UTF_8

--- a/test/reline/test_reline.rb
+++ b/test/reline/test_reline.rb
@@ -302,12 +302,12 @@ class Reline::Test < Reline::TestCase
 
   def test_vi_editing_mode
     Reline.vi_editing_mode
-    assert_equal(Reline::KeyActor::ViInsert, Reline.send(:core).config.editing_mode.class)
+    assert_equal(Reline::KeyActor::ViInsert, Reline.core.config.editing_mode.class)
   end
 
   def test_emacs_editing_mode
     Reline.emacs_editing_mode
-    assert_equal(Reline::KeyActor::Emacs, Reline.send(:core).config.editing_mode.class)
+    assert_equal(Reline::KeyActor::Emacs, Reline.core.config.editing_mode.class)
   end
 
   def test_add_dialog_proc

--- a/test/reline/test_string_processing.rb
+++ b/test/reline/test_string_processing.rb
@@ -6,7 +6,7 @@ class Reline::LineEditor::StringProcessingTest < Reline::TestCase
     @prompt = '> '
     @config = Reline::Config.new
     Reline::HISTORY.instance_variable_set(:@config, @config)
-    @encoding = Reline::IOGate.encoding
+    @encoding = Reline.core.encoding
     @line_editor = Reline::LineEditor.new(@config, @encoding)
     @line_editor.reset(@prompt, encoding: @encoding)
   end

--- a/test/reline/test_within_pipe.rb
+++ b/test/reline/test_within_pipe.rb
@@ -3,14 +3,14 @@ require_relative 'helper'
 class Reline::WithinPipeTest < Reline::TestCase
   def setup
     Reline.send(:test_mode)
-    @encoding = Reline::IOGate.encoding
+    @encoding = Reline.core.encoding
     @input_reader, @writer = IO.pipe(@encoding)
     Reline.input = @input_reader
     @reader, @output_writer = IO.pipe(@encoding)
     @output = Reline.output = @output_writer
-    @config = Reline.send(:core).config
+    @config = Reline.core.config
     @config.keyseq_timeout *= 600 if defined?(RubyVM::RJIT) && RubyVM::RJIT.enabled? # for --jit-wait CI
-    @line_editor = Reline.send(:core).line_editor
+    @line_editor = Reline.core.line_editor
   end
 
   def teardown


### PR DESCRIPTION
1. Use `Reline.core` directly instead of `Reline.send(:core)`
2. Reduce IOGate's references in tests