### PR TITLE
Reduce direct references to `Reline::IOGate`

### DIFF
--- a/lib/reline/ansi.rb
+++ b/lib/reline/ansi.rb
@@ -206,7 +206,7 @@ class Reline::ANSI
   end
 
   def self.in_pasting?
-    @@in_bracketed_paste_mode or (not Reline::IOGate.empty_buffer?)
+    @@in_bracketed_paste_mode or (not empty_buffer?)
   end
 
   def self.empty_buffer?

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -60,6 +60,10 @@ class Reline::LineEditor
     reset_variables(encoding: encoding)
   end
 
+  def io_gate
+    Reline::IOGate
+  end
+
   def set_pasting_state(in_pasting)
     @in_pasting = in_pasting
   end

--- a/test/reline/helper.rb
+++ b/test/reline/helper.rb
@@ -29,8 +29,8 @@ module Reline
           encoding = Encoding::UTF_8
         end
         Reline::GeneralIO.reset(encoding: encoding) unless ansi
-        send(:core).config.instance_variable_set(:@test_mode, true)
-        send(:core).config.reset
+        core.config.instance_variable_set(:@test_mode, true)
+        core.config.reset
     end
 
     def test_reset

--- a/test/reline/test_ansi_with_terminfo.rb
+++ b/test/reline/test_ansi_with_terminfo.rb
@@ -5,7 +5,7 @@ class Reline::ANSI::TestWithTerminfo < Reline::TestCase
   def setup
     Reline.send(:test_mode, ansi: true)
     @config = Reline::Config.new
-    Reline::IOGate.set_default_key_bindings(@config, allow_terminfo: true)
+    Reline.core.io_gate.set_default_key_bindings(@config, allow_terminfo: true)
   end
 
   def teardown

--- a/test/reline/test_ansi_without_terminfo.rb
+++ b/test/reline/test_ansi_without_terminfo.rb
@@ -5,7 +5,7 @@ class Reline::ANSI::TestWithoutTerminfo < Reline::TestCase
   def setup
     Reline.send(:test_mode, ansi: true)
     @config = Reline::Config.new
-    Reline::IOGate.set_default_key_bindings(@config, allow_terminfo: false)
+    Reline.core.io_gate.set_default_key_bindings(@config, allow_terminfo: false)
   end
 
   def teardown

--- a/test/reline/test_config.rb
+++ b/test/reline/test_config.rb
@@ -85,7 +85,7 @@ class Reline::Config::Test < Reline::TestCase
 
   def test_encoding_is_ascii
     @config.reset
-    Reline::IOGate.reset(encoding: Encoding::US_ASCII)
+    Reline.core.io_gate.reset(encoding: Encoding::US_ASCII)
     @config = Reline::Config.new
 
     assert_equal true, @config.convert_meta
@@ -93,7 +93,7 @@ class Reline::Config::Test < Reline::TestCase
 
   def test_encoding_is_not_ascii
     @config.reset
-    Reline::IOGate.reset(encoding: Encoding::UTF_8)
+    Reline.core.io_gate.reset(encoding: Encoding::UTF_8)
     @config = Reline::Config.new
 
     assert_equal nil, @config.convert_meta

--- a/test/reline/test_history.rb
+++ b/test/reline/test_history.rb
@@ -297,7 +297,7 @@ class Reline::History::Test < Reline::TestCase
   end
 
   def get_default_internal_encoding
-    if encoding = Reline::IOGate.encoding
+    if encoding = Reline.core.encoding
       encoding
     elsif RUBY_PLATFORM =~ /mswin|mingw/
       Encoding.default_internal || Encoding::UTF_8

--- a/test/reline/test_key_actor_emacs.rb
+++ b/test/reline/test_key_actor_emacs.rb
@@ -8,7 +8,7 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
     @config.autocompletion = false
     Reline::HISTORY.instance_variable_set(:@config, @config)
     Reline::HISTORY.clear
-    @encoding = Reline::IOGate.encoding
+    @encoding = Reline.core.encoding
     @line_editor = Reline::LineEditor.new(@config, @encoding)
     @line_editor.reset(@prompt, encoding: @encoding)
   end
@@ -2167,7 +2167,7 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
 
   # Unicode emoji test
   def test_ed_insert_for_include_zwj_emoji
-    omit "This test is for UTF-8 but the locale is #{Reline::IOGate.encoding}" if Reline::IOGate.encoding != Encoding::UTF_8
+    omit "This test is for UTF-8 but the locale is #{Reline.core.encoding}" if Reline.core.encoding != Encoding::UTF_8
     # U+1F468 U+200D U+1F469 U+200D U+1F467 U+200D U+1F466 is family: man, woman, girl, boy "👨‍👩‍👧‍👦"
     input_keys("\u{1F468}") # U+1F468 is man "👨"
     assert_line("\u{1F468}")
@@ -2213,7 +2213,7 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
   end
 
   def test_ed_insert_for_include_valiation_selector
-    omit "This test is for UTF-8 but the locale is #{Reline::IOGate.encoding}" if Reline::IOGate.encoding != Encoding::UTF_8
+    omit "This test is for UTF-8 but the locale is #{Reline.core.encoding}" if Reline.core.encoding != Encoding::UTF_8
     # U+0030 U+FE00 is DIGIT ZERO + VARIATION SELECTOR-1 "0︀"
     input_keys("\u0030") # U+0030 is DIGIT ZERO
     assert_line("\u0030")

--- a/test/reline/test_key_actor_vi.rb
+++ b/test/reline/test_key_actor_vi.rb
@@ -8,7 +8,7 @@ class Reline::KeyActor::ViInsert::Test < Reline::TestCase
     @config.read_lines(<<~LINES.split(/(?<=\n)/))
       set editing-mode vi
     LINES
-    @encoding = Reline::IOGate.encoding
+    @encoding = Reline.core.encoding
     @line_editor = Reline::LineEditor.new(@config, @encoding)
     @line_editor.reset(@prompt, encoding: @encoding)
   end

--- a/test/reline/test_macro.rb
+++ b/test/reline/test_macro.rb
@@ -4,7 +4,7 @@ class Reline::MacroTest < Reline::TestCase
   def setup
     Reline.send(:test_mode)
     @config = Reline::Config.new
-    @encoding = Reline::IOGate.encoding
+    @encoding = Reline.core.encoding
     @line_editor = Reline::LineEditor.new(@config, @encoding)
     @line_editor.instance_variable_set(:@screen_size, [24, 80])
     @output = @line_editor.output = File.open(IO::NULL, "w")

--- a/test/reline/test_reline.rb
+++ b/test/reline/test_reline.rb
@@ -285,7 +285,7 @@ class Reline::Test < Reline::TestCase
     input, to_write = IO.pipe
     to_read, output = IO.pipe
     unless Reline.__send__(:input=, input)
-      omit "Setting to input is not effective on #{Reline::IOGate}"
+      omit "Setting to input is not effective on #{Reline.core.io_gate}"
     end
     Reline.output = output
 
@@ -374,12 +374,12 @@ class Reline::Test < Reline::TestCase
 
   def test_dumb_terminal
     lib = File.expand_path("../../lib", __dir__)
-    out = IO.popen([{"TERM"=>"dumb"}, Reline.test_rubybin, "-I#{lib}", "-rreline", "-e", "p Reline::IOGate"], &:read)
+    out = IO.popen([{"TERM"=>"dumb"}, Reline.test_rubybin, "-I#{lib}", "-rreline", "-e", "p Reline.core.io_gate"], &:read)
     assert_equal("Reline::GeneralIO", out.chomp)
   end
 
   def get_reline_encoding
-    if encoding = Reline::IOGate.encoding
+    if encoding = Reline.core.encoding
       encoding
     elsif RUBY_PLATFORM =~ /mswin|mingw/
       Encoding::UTF_8

--- a/test/reline/test_reline.rb
+++ b/test/reline/test_reline.rb
@@ -303,12 +303,12 @@ class Reline::Test < Reline::TestCase
 
   def test_vi_editing_mode
     Reline.vi_editing_mode
-    assert_equal(Reline::KeyActor::ViInsert, Reline.send(:core).config.editing_mode.class)
+    assert_equal(Reline::KeyActor::ViInsert, Reline.core.config.editing_mode.class)
   end
 
   def test_emacs_editing_mode
     Reline.emacs_editing_mode
-    assert_equal(Reline::KeyActor::Emacs, Reline.send(:core).config.editing_mode.class)
+    assert_equal(Reline::KeyActor::Emacs, Reline.core.config.editing_mode.class)
   end
 
   def test_add_dialog_proc

--- a/test/reline/test_string_processing.rb
+++ b/test/reline/test_string_processing.rb
@@ -6,7 +6,7 @@ class Reline::LineEditor::StringProcessingTest < Reline::TestCase
     @prompt = '> '
     @config = Reline::Config.new
     Reline::HISTORY.instance_variable_set(:@config, @config)
-    @encoding = Reline::IOGate.encoding
+    @encoding = Reline.core.encoding
     @line_editor = Reline::LineEditor.new(@config, @encoding)
     @line_editor.reset(@prompt, encoding: @encoding)
   end

--- a/test/reline/test_within_pipe.rb
+++ b/test/reline/test_within_pipe.rb
@@ -3,14 +3,14 @@ require_relative 'helper'
 class Reline::WithinPipeTest < Reline::TestCase
   def setup
     Reline.send(:test_mode)
-    @encoding = Reline::IOGate.encoding
+    @encoding = Reline.core.encoding
     @input_reader, @writer = IO.pipe(@encoding)
     Reline.input = @input_reader
     @reader, @output_writer = IO.pipe(@encoding)
     @output = Reline.output = @output_writer
-    @config = Reline.send(:core).config
+    @config = Reline.core.config
     @config.keyseq_timeout *= 600 if defined?(RubyVM::RJIT) && RubyVM::RJIT.enabled? # for --jit-wait CI
-    @line_editor = Reline.send(:core).line_editor
+    @line_editor = Reline.core.line_editor
   end
 
   def teardown

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -490,7 +490,7 @@ begin
     end
 
     def test_enable_bracketed_paste
-      omit if Reline::IOGate.win?
+      omit if Reline.core.io_gate.win?
       write_inputrc <<~LINES
         set enable-bracketed-paste on
       LINES
@@ -877,7 +877,7 @@ begin
     end
 
     def test_with_newline
-      omit if Reline::IOGate.win?
+      omit if Reline.core.io_gate.win?
       cmd = %Q{ruby -e 'print(%Q{abc def \\e\\r})' | ruby -I#{@pwd}/lib -rreline -e 'p Reline.readline(%{> })'}
       start_terminal(40, 50, ['bash', '-c', cmd])
       sleep 1


### PR DESCRIPTION
## Background

Storing the IO gate object in a constant is not ideal given:

- We constantly need to call [`remove_const` and `const_set`](https://github.com/ruby/reline/blob/master/test/reline/helper.rb#L23-L40) in test cases to change its value, which somewhat defeats the purpose of constant.
- But more importantly, with #559 we also need to do it in production code (see #560).

If we combine the above cases, the IO gate object is more suitable to be an attribute of either `Reline::Core` or `Reline::Config`. And this is the direction we'll be working toward to.

## Description

To make the above refactor easier, I want to reduce the direct references to `IOGate` in this PR. All existing usages should still refer to `IOGate` as the source of truth, but with either `Core#io_gate` or `LineEditor#io_gate`.