### PR TITLE
Reduce duplicate code in `Reline::Core#inner_readline`

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -370,19 +370,13 @@ module Reline
         io_gate.move_cursor_column(0)
       rescue Errno::EIO
         # Maybe the I/O has been closed.
-      rescue StandardError => e
-        line_editor.finalize
-        io_gate.deprep(otio)
-        raise e
-      rescue Exception
-        # Including Interrupt
-        line_editor.finalize
-        io_gate.deprep(otio)
-        raise
+        closed = true
+      ensure
+        unless closed
+          line_editor.finalize
+          io_gate.deprep(otio)
+        end
       end
-
-      line_editor.finalize
-      io_gate.deprep(otio)
     end
 
     # GNU Readline waits for "keyseq-timeout" milliseconds to see if the ESC


### PR DESCRIPTION
Clean up always except for `Errno::EIO` case, including `throw`.