### PR TITLE
Always set ANSI CSI keybindings for Home, End, and Arrow.

### DIFF
--- a/test/reline/test_ansi_with_terminfo.rb
+++ b/test/reline/test_ansi_with_terminfo.rb
@@ -75,12 +75,28 @@ class Reline::ANSI::TestWithTerminfo < Reline::TestCase
     omit e.message
   end
 
+  # Home and End; always mapped regardless of terminfo enabled or not
+  def test_home_end
+    assert_key_binding("\e[H", :ed_move_to_beg)
+    assert_key_binding("\e[F", :ed_move_to_end)
+  end
+
+  # Arrow; always mapped regardless of terminfo enabled or not
+  def test_arrow
+    assert_key_binding("\e[A", :ed_prev_history)
+    assert_key_binding("\e[B", :ed_next_history)
+    assert_key_binding("\e[C", :ed_next_char)
+    assert_key_binding("\e[D", :ed_prev_char)
+  end
+
   # Ctrl+arrow and Meta+arrow; always mapped regardless of terminfo enabled or not
   def test_extended
     assert_key_binding("\e[1;5C", :em_next_word) # Ctrl+→
     assert_key_binding("\e[1;5D", :ed_prev_word) # Ctrl+←
     assert_key_binding("\e[1;3C", :em_next_word) # Meta+→
     assert_key_binding("\e[1;3D", :ed_prev_word) # Meta+←
+    assert_key_binding("\e\e[C", :em_next_word) # Meta+→
+    assert_key_binding("\e\e[D", :ed_prev_word) # Meta+←
   end
 
   # Shift-Tab; always mapped regardless of terminfo enabled or not

--- a/test/reline/test_ansi_without_terminfo.rb
+++ b/test/reline/test_ansi_without_terminfo.rb
@@ -60,6 +60,8 @@ class Reline::ANSI::TestWithoutTerminfo < Reline::TestCase
     assert_key_binding("\e[1;5D", :ed_prev_word) # Ctrl+←
     assert_key_binding("\e[1;3C", :em_next_word) # Meta+→
     assert_key_binding("\e[1;3D", :ed_prev_word) # Meta+←
+    assert_key_binding("\e\e[C", :em_next_word) # Meta+→
+    assert_key_binding("\e\e[D", :ed_prev_word) # Meta+←
   end
 
   # Shift-Tab; always mapped regardless of terminfo enabled or not


### PR DESCRIPTION
Fixes HOME key, END key, Meta + Arrow key problem in some terminal emulator.

## ANSI cursor sequence
Most terminals are vt100 compatible. In vt100 normal mode, ANSI cursor sequence `"\e[A", "\e[B", "\e[C", "\e[D"` will be sent on arrow key press.
("Cursor Control" section of https://vt100.net/docs/vt100-ug/chapter3.html, "Minimum requirements for VT100 emulation" section of https://www.real-world-systems.com/docs/ANSIcode.html)
These arrow key sequence are normally not written in terminfo. This pull request make Reline bind these cursor sequences as default.

HOME `\e[H` and END `\e[F` keys are also categorized as cursor sequence. You can check this by setting [Cursor Key Mode (DECCKM)](https://vt100.net/docs/vt510-rm/DECCKM.html). HOME/END key will change the behavior just like arrow key does.

```ruby
# This hack is not needed anymore.
when 'cuu', 'cud', 'cuf', 'cub'
  [ key_code.sub(/%p1%d/, '').bytes, key_binding ]
```

## Modifiers
In https://mdfs.net/Docs/Comp/Comms/ANSIKeys, it says that terminal emulator will add a modifier value like `"\e[1;3A"` for Meta+Up, `"\e[1;5A"` for Ctrl+Up. Some terminal emulator uses `"\e\e[A"` for Meta+Up instead of modifier value.

| | Up | Left | Meta + Up | Meta + Left | Ctrl + Up | Ctrl + Left
| --- | --- | --- | --- | --- | --- | --- |
| Terminal.app | \e[A | \e[D | \e\e[A | \eb | \e[A | \e[1;5D |
| iTerm2 | \e[A | \e[D |  \e\e[A | \e\e[D | \e[1;5A | \e[1;5D |
| Alacritty | \e[A | \e[D |  \e[1;3A | \e[1;3D | \e[1;5A | \e[1;5D |
| VSCode Terminal | \e[A | \e[D |  \e[1;3A | \eb | \e[1;5A | \e[1;5D |

(`\eb` is handled by `Reline::KeyStroke#compress_meta_key`)

This pull request also bind these arrow + modifier key sequences.

## Reduce comprehensive list
Some bytes in `set_default_key_bindings_comprehensive_list` will be registered as default. I've removed them from comprehensive_list.
