### PR TITLE
Add missing `close` to test_rendering.rb

### DIFF
--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -245,6 +245,7 @@ begin
       sleep 1
       write("A")
       write("B\eAC") # ESC + A (M-A, specified ed_unassigned in Reline::KeyActor::Emacs)
+      close
       assert_screen(<<~EOC)
         Multiline REPL.
         prompt> abcABCdef
@@ -690,6 +691,7 @@ begin
       EOC
       write("\C-p" * 4 + "\C-e" + "\C-p" * 4)
       write("2")
+      close
       assert_screen(<<~EOC)
         prompt> if 12
         prompt>   if 2
@@ -994,6 +996,7 @@ begin
       write("\n" * 10)
       write("if 1\n  sSt\nend")
       write("\C-p\C-h\C-e")
+      close
       assert_screen(<<~'EOC')
         prompt>
         prompt>


### PR DESCRIPTION
Without `close`, process `ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}` will remain until every test ends.

```
% grep -c "close" test/reline/yamatanooroti/test_rendering.rb 
96 → 99
% grep -c "assert_screen" test/reline/yamatanooroti/test_rendering.rb
99
% grep -c "def test_" test/reline/yamatanooroti/test_rendering.rb              
99
```