### PR TITLE
Add assertion to auto_indent_proc's parameter, add Ctrl-d exit test

### DIFF
--- a/test/reline/yamatanooroti/multiline_repl
+++ b/test/reline/yamatanooroti/multiline_repl
@@ -59,8 +59,24 @@ opt.on('--dynamic-prompt-show-line') {
     }
   }
 }
+
+def assert_auto_indent_params(lines, line_index, byte_pointer, is_newline)
+  raise 'Wrong lines type' unless lines.all?(String)
+
+  line = lines[line_index]
+  raise 'Wrong line_index value' unless line
+
+  # The condition `byte_pointer <= line.bytesize` is not satisfied. Maybe bug.
+  # Instead, loose constraint `byte_pointer <= line.bytesize + 1` seems to be satisfied when is_newline is false.
+  return if is_newline
+
+  raise 'byte_pointer out of bounds' unless byte_pointer <= line.bytesize + 1
+  raise 'Invalid byte_pointer' unless line.byteslice(0, byte_pointer).valid_encoding?
+end
+
 opt.on('--auto-indent') {
   Reline.auto_indent_proc = lambda do |lines, line_index, byte_pointer, is_newline|
+    assert_auto_indent_params(lines, line_index, byte_pointer, is_newline)
     AutoIndent.calculate_indent(lines, line_index, byte_pointer, is_newline)
   end
 }

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -1591,6 +1591,20 @@ begin
       EOC
     end
 
+    def test_exit_with_ctrl_d
+      start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --auto-indent}, startup_message: 'Multiline REPL.')
+      begin
+        write("\C-d")
+        close
+      rescue EOFError
+        # EOFError is raised when process terminated.
+      end
+      assert_screen(<<~EOC)
+        Multiline REPL.
+        prompt>
+      EOC
+    end
+
     def write_inputrc(content)
       File.open(@inputrc_file, 'w') do |f|
         f.write content


### PR DESCRIPTION
Reline was passing `lines=[nil]` to auto_indent_proc when exit with Ctrl-d. This pull request add assertion to auto_indent_proc's parameter in rendering test and add Ctrl-d exit test.

Without #571, test added in this pull request will fail. https://github.com/tompng/reline/actions/runs/5592504740/jobs/10225040010

I think there are several bug that wrong byte_pointer is passed to auto_indent_proc.
Adding a strict assertion for byte_pointer will make many test fail, so I added a loose assertion for now.
