### PR TITLE
Bump version to 0.3.7

### DIFF
--- a/lib/reline/version.rb
+++ b/lib/reline/version.rb
@@ -1,3 +1,3 @@
 module Reline
-  VERSION = '0.3.6'
+  VERSION = '0.3.7'
 end


### PR DESCRIPTION
Diff: https://github.com/ruby/reline/compare/v0.3.6...master

With #569 and #577 both fixed long-standing issues, I think it's worth cutting another release for them.