### PR TITLE
Remove Timeout usage

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -1,5 +1,4 @@
 require 'io/console'
-require 'timeout'
 require 'forwardable'
 require 'reline/version'
 require 'reline/config'
@@ -397,7 +396,7 @@ module Reline
     private def read_io(keyseq_timeout, &block)
       buffer = []
       loop do
-        c = io_gate.getc
+        c = io_gate.getc(Float::INFINITY)
         if c == -1
           result = :unmatched
           @bracketed_paste_finished = true
@@ -434,15 +433,9 @@ module Reline
     end
 
     private def read_2nd_character_of_key_sequence(keyseq_timeout, buffer, c, block)
-      begin
-        succ_c = nil
-        Timeout.timeout(keyseq_timeout / 1000.0) {
-          succ_c = io_gate.getc
-        }
-      rescue Timeout::Error # cancel matching only when first byte
-        block.([Reline::Key.new(c, c, false)])
-        return :break
-      else
+      succ_c = io_gate.getc(keyseq_timeout / 1000)
+
+      if succ_c
         case key_stroke.match_status(buffer.dup.push(succ_c))
         when :unmatched
           if c == "\e".ord
@@ -462,27 +455,23 @@ module Reline
           block.(expanded)
           return :break
         end
+      else
+        block.([Reline::Key.new(c, c, false)])
+        return :break
       end
     end
 
     private def read_escaped_key(keyseq_timeout, c, block)
-      begin
-        escaped_c = nil
-        Timeout.timeout(keyseq_timeout / 1000.0) {
-          escaped_c = io_gate.getc
-        }
-      rescue Timeout::Error # independent ESC
+      escaped_c = io_gate.getc(keyseq_timeout / 1000)
+
+      if escaped_c.nil?
         block.([Reline::Key.new(c, c, false)])
+      elsif escaped_c >= 128 # maybe, first byte of multi byte
+        block.([Reline::Key.new(c, c, false), Reline::Key.new(escaped_c, escaped_c, false)])
+      elsif escaped_c == "\e".ord # escape twice
+        block.([Reline::Key.new(c, c, false), Reline::Key.new(c, c, false)])
       else
-        if escaped_c.nil?
-          block.([Reline::Key.new(c, c, false)])
-        elsif escaped_c >= 128 # maybe, first byte of multi byte
-          block.([Reline::Key.new(c, c, false), Reline::Key.new(escaped_c, escaped_c, false)])
-        elsif escaped_c == "\e".ord # escape twice
-          block.([Reline::Key.new(c, c, false), Reline::Key.new(c, c, false)])
-        else
-          block.([Reline::Key.new(escaped_c, escaped_c | 0b10000000, true)])
-        end
+        block.([Reline::Key.new(escaped_c, escaped_c | 0b10000000, true)])
       end
     end
 

--- a/lib/reline/general_io.rb
+++ b/lib/reline/general_io.rb
@@ -1,4 +1,3 @@
-require 'timeout'
 require 'io/wait'
 
 class Reline::GeneralIO
@@ -35,7 +34,7 @@ class Reline::GeneralIO
     yield
   end
 
-  def self.getc
+  def self.getc(_timeout_second)
     unless @@buf.empty?
       return @@buf.shift
     end

--- a/lib/reline/windows.rb
+++ b/lib/reline/windows.rb
@@ -295,7 +295,7 @@ class Reline::Windows
     yield
   end
 
-  def self.getc
+  def self.getc(_timeout_second)
     check_input_event
     @@output_buf.shift
   end

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -3,7 +3,7 @@ require 'reline'
 begin
   require 'yamatanooroti'
 
-  class Reline::TestRendering < Yamatanooroti::TestCase
+  class Reline::RenderingTest < Yamatanooroti::TestCase
     def setup
       @pwd = Dir.pwd
       suffix = '%010d' % Random.rand(0..65535)


### PR DESCRIPTION
Timeout's implementation relies on Thread, which would conflict with `ruby/debug`'s thread-freezing implementation and has casued issues like

- ruby/debug#877
- ruby/debug#934
- ruby/debug#1000

This commit avoids the issue by completely removing the use of Timeout.