### PR TITLE
EastAsianWidth.txt Format Change after Unicode 15.1.0

### DIFF
--- a/bin/generate_east_asian_width
+++ b/bin/generate_east_asian_width
@@ -8,11 +8,11 @@ end
 open(ARGV.first, 'rt') do |f|
   list = []
   f.each_line do |line|
-    next unless /^(\h+)(?:\.\.(\h+))?\s*;\s*(\w+)\s+#.+/ =~ line
+    next unless m = line.match(/^(\h+)(?:\.\.(\h+))?\s*;\s*(\w+)\s+#.+/)
 
-    first = Regexp.last_match(1).to_i(16)
-    last = Regexp.last_match(2)&.to_i(16) || first
-    type = Regexp.last_match(3).to_sym
+    first = m[1].to_i(16)
+    last = m[2]&.to_i(16) || first
+    type = m[3].to_sym
     if !list.empty? and (list.last[:range].last + 1) == first and list.last[:type] == type
       list.last[:range] = (list.last[:range].first..last)
     else

--- a/bin/generate_east_asian_width
+++ b/bin/generate_east_asian_width
@@ -8,16 +8,11 @@ end
 open(ARGV.first, 'rt') do |f|
   list = []
   f.each_line do |line|
-    next if line.start_with?(?#)
-    line.chomp!.sub!(/ .*/, '')
-    next if line.empty?
-    range, type = line.chomp.split(';')
-    type = type.to_sym
-    if range =~ /\h+\.\.\h+/
-      first, last = range.split('..').map{ |_| _.to_i(16) }
-    else
-      first = last = range.to_i(16)
-    end
+    next unless /^(\h+)(?:\.\.(\h+))?\s*;\s*(\w*)\s+#.+/ =~ line
+
+    first = Regexp.last_match(1).to_i(16)
+    last = Regexp.last_match(2)&.to_i(16) || first
+    type = Regexp.last_match(3).to_sym
     if !list.empty? and (list.last[:range].last + 1) == first and list.last[:type] == type
       list.last[:range] = (list.last[:range].first..last)
     else

--- a/bin/generate_east_asian_width
+++ b/bin/generate_east_asian_width
@@ -8,7 +8,7 @@ end
 open(ARGV.first, 'rt') do |f|
   list = []
   f.each_line do |line|
-    next unless /^(\h+)(?:\.\.(\h+))?\s*;\s*(\w*)\s+#.+/ =~ line
+    next unless /^(\h+)(?:\.\.(\h+))?\s*;\s*(\w+)\s+#.+/ =~ line
 
     first = Regexp.last_match(1).to_i(16)
     last = Regexp.last_match(2)&.to_i(16) || first


### PR DESCRIPTION
The format of EastAsianWidth.txt seems to change after Unicode 15.1.0 (draft).

15.0.0: https://www.unicode.org/Public/15.0.0/ucd/EastAsianWidth.txt
```
# For legacy reasons, there are no spaces before or after the semicolon
# which separates the two fields. The comments following the number sign
# "#" list the General_Category property value or the L& alias of the
# derived value LC, the Unicode character name or names, and, in lines
# with ranges of code points, the code point count in square brackets.
#
# For more information, see UAX #11: East Asian Width,
# at https://www.unicode.org/reports/tr11/
#
# @missing: 0000..10FFFF; N
0000..001F;N     # Cc    [32] <control-0000>..<control-001F>
0020;Na          # Zs         SPACE
0021..0023;Na    # Po     [3] EXCLAMATION MARK..NUMBER SIGN
0024;Na          # Sc         DOLLAR SIGN
```

15.1.0 draft: https://www.unicode.org/Public/draft/UCD/ucd/EastAsianWidth.txt
```
# The comments following the number sign "#" list the General_Category
# property value or the L& alias of the derived value LC, the Unicode
# character name or names, and, in lines with ranges of code points,
# the code point count in square brackets.
#
# For more information, see UAX #11: East Asian Width,
# at https://www.unicode.org/reports/tr11/
#
# @missing: 0000..10FFFF; N
0000..001F     ; N  # Cc    [32] <control-0000>..<control-001F>
0020           ; Na # Zs         SPACE
0021..0023     ; Na # Po     [3] EXCLAMATION MARK..NUMBER SIGN
0024           ; Na # Sc         DOLLAR SIGN
```

Therefore, `bin/generate_east_asian_width` will fail.

```
% ruby bin/generate_east_asian_width EastAsianWidth-15.1.0-draft.txt
bin/generate_east_asian_width:15:in `block (2 levels) in <main>': undefined method `to_sym' for nil:NilClass (NoMethodError)

    type = type.to_sym
               ^^^^^^^
        from bin/generate_east_asian_width:10:in `each_line'
        from bin/generate_east_asian_width:10:in `block in <main>'
        from bin/generate_east_asian_width:8:in `open'
        from bin/generate_east_asian_width:8:in `<main>'
%
```

So, I fix this.

## Test

Convert the current version 15.0.0.

```
% ruby bin/generate_east_asian_width EastAsianWidth-15.0.0.txt > eaw-15.0.0.rb
% diff lib/reline/unicode/east_asian_width.rb eaw-15.0.0.rb
3c3
<   # EastAsianWidth.txt
---
>   # EastAsianWidth-15.0.0.txt
%
```

The same as the current version is generated.

Convert the draft version 15.1.0.

```
% ruby bin/generate_east_asian_width EastAsianWidth-15.1.0-draft.txt > eaw-15.1.0.rb
% diff eaw-15.0.0.rb eaw-15.1.0.rb
3c3
<   # EastAsianWidth-15.0.0.txt
---
>   # EastAsianWidth-15.1.0-draft.txt
63c63
<     \u{2FF0}-\u{2FFB}
---
>     \u{2FF0}-\u{2FFF}
70c70
<     \u{31F0}-\u{321E}
---
>     \u{31EF}-\u{321E}
%
```

Probably OK.

By the way, this EastAsianWidth.txt is still a draft, so it does not seem to include any [New CJK Ideographs](http://blog.unicode.org/2023/08/622-new-cjk-ideographs-to-be-available.html), etc.
