### PR TITLE
Set EastAsianWidth::UNICODE_VERSION

### DIFF
--- a/bin/generate_east_asian_width
+++ b/bin/generate_east_asian_width
@@ -51,7 +51,7 @@ open(ARGV.first, 'rt') do |f|
 class Reline::Unicode::EastAsianWidth
   # This is based on EastAsianWidth.txt
   # #{ARGV.first}
-  UNICODE_VERSION = #{unicode_version ? "'#{unicode_version}'" : 'nil'}
+  # UNICODE_VERSION = #{unicode_version ? "'#{unicode_version}'" : 'nil'}
 
 EOH
   puts grouped.map { |item|

--- a/bin/generate_east_asian_width
+++ b/bin/generate_east_asian_width
@@ -6,6 +6,13 @@ if ARGV.empty?
 end
 
 open(ARGV.first, 'rt') do |f|
+  if m = f.gets.match(/^# EastAsianWidth-(\d+\.\d+\.\d+)\.txt/)
+    unicode_version = m[1]
+  else
+    warn 'Failed to get UNICODE_VERSION'
+    unicode_version = nil
+  end
+
   list = []
   f.each_line do |line|
     next unless m = line.match(/^(\h+)(?:\.\.(\h+))?\s*;\s*(\w+)\s+#.+/)
@@ -44,6 +51,7 @@ open(ARGV.first, 'rt') do |f|
 class Reline::Unicode::EastAsianWidth
   # This is based on EastAsianWidth.txt
   # #{ARGV.first}
+  UNICODE_VERSION = #{unicode_version ? "'#{unicode_version}'" : 'nil'}
 
 EOH
   puts grouped.map { |item|

--- a/lib/reline/unicode/east_asian_width.rb
+++ b/lib/reline/unicode/east_asian_width.rb
@@ -1,6 +1,7 @@
 class Reline::Unicode::EastAsianWidth
   # This is based on EastAsianWidth.txt
   # EastAsianWidth.txt
+  UNICODE_VERSION = '15.0.0'
 
   # Fullwidth
   TYPE_F = /^[#{ %W(

--- a/lib/reline/unicode/east_asian_width.rb
+++ b/lib/reline/unicode/east_asian_width.rb
@@ -1,7 +1,7 @@
 class Reline::Unicode::EastAsianWidth
   # This is based on EastAsianWidth.txt
   # EastAsianWidth.txt
-  UNICODE_VERSION = '15.0.0'
+  # UNICODE_VERSION = '15.0.0'
 
   # Fullwidth
   TYPE_F = /^[#{ %W(


### PR DESCRIPTION
fix #438

The beginning of the comment in `EastAsianWidth.txt` contains the Unicode version.

```
% head -3 EastAsianWidth.txt
# EastAsianWidth-15.0.0.txt
# Date: 2022-05-24, 17:40:20 GMT [KW, LI]
# © 2022 Unicode®, Inc.
% 
```

At least since Unicode 3.2.0, the version seems to be included.

```
% curl --silent https://www.unicode.org/Public/3.2-Update/EastAsianWidth-3.2.0.txt | head -3
# EastAsianWidth-3.2.0.txt
#
# East Asian Width Properties
%
```

So, the version is retrieved from there.

```
% ruby bin/generate_east_asian_width EastAsianWidth.txt | head
class Reline::Unicode::EastAsianWidth
  # This is based on EastAsianWidth.txt
  # EastAsianWidth.txt
  UNICODE_VERSION = '15.0.0'

  # Fullwidth
  TYPE_F = /^[#{ %W(
    \u{3000}
    \u{FF01}-\u{FF60}
    \u{FFE0}-\u{FFE6}
%
```

The version is set to `Reline::Unicode::EastAsianWidth::UNICODE_VERSION`.

The variable name `UNICODE_VERSION` is taken from `RbConfig::CONFIG["UNICODE_VERSION"]`.

If the comment format is changed in the future and the Unicode version fails to be retrieved, a warning will be displayed and set `UNICODE_VERSION = nil`.

```
% ruby bin/generate_east_asian_width <(tail +2 EastAsianWidth.txt) > /dev/null
Failed to get UNICODE_VERSION
% ruby bin/generate_east_asian_width <(tail +2 EastAsianWidth.txt) | grep UNICODE_VERSION
Failed to get UNICODE_VERSION
  UNICODE_VERSION = nil
% 
```
