### PR TITLE
Remove `ARGV.first` in east_asian_width.rb

### DIFF
--- a/bin/generate_east_asian_width
+++ b/bin/generate_east_asian_width
@@ -50,7 +50,6 @@ open(ARGV.first, 'rt') do |f|
   puts <<EOH
 class Reline::Unicode::EastAsianWidth
   # This is based on EastAsianWidth.txt
-  # #{ARGV.first}
   # UNICODE_VERSION = #{unicode_version ? "'#{unicode_version}'" : 'nil'}
 
 EOH

--- a/lib/reline/unicode/east_asian_width.rb
+++ b/lib/reline/unicode/east_asian_width.rb
@@ -1,6 +1,5 @@
 class Reline::Unicode::EastAsianWidth
   # This is based on EastAsianWidth.txt
-  # EastAsianWidth.txt
   # UNICODE_VERSION = '15.0.0'
 
   # Fullwidth


### PR DESCRIPTION
`ARGV.first` is the name of the EastAsianWidth file and is not needed for east_asian_width.rb