### PR TITLE
Fix long autowrapped fullwidth chars disappear bug

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -1131,23 +1131,17 @@ class Reline::LineEditor
     if Reline::Unicode::CSI_REGEXP.match?(prompt + line_to_render)
       @output.write "\e[0m" # clear character decorations
     end
-    visual_lines.each_with_index do |line, index|
+    visual_lines.each do |line|
       Reline::IOGate.move_cursor_column(0)
       if line.nil?
-        if calculate_width(visual_lines[index - 1], true) == Reline::IOGate.get_screen_size.last
-          # reaches the end of line
-          if Reline::IOGate.win? and Reline::IOGate.win_legacy_console?
-            # A newline is automatically inserted if a character is rendered at
-            # eol on command prompt.
-          else
-            # When the cursor is at the end of the line and erases characters
-            # after the cursor, some terminals delete the character at the
-            # cursor position.
-            move_cursor_down(1)
-            Reline::IOGate.move_cursor_column(0)
-          end
+        # reaches the end of line
+        if Reline::IOGate.win? and Reline::IOGate.win_legacy_console?
+          # A newline is automatically inserted if a character is rendered at
+          # eol on command prompt.
         else
-          Reline::IOGate.erase_after_cursor
+          # When the cursor is at the end of the line and erases characters
+          # after the cursor, some terminals delete the character at the
+          # cursor position.
           move_cursor_down(1)
           Reline::IOGate.move_cursor_column(0)
         end

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -85,6 +85,21 @@ begin
       EOC
     end
 
+    def test_fullwidth_autowrap
+      start_terminal(10, 20, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
+      fullwidth_numbers = '０１２３４５６７８９'
+      write("'#{fullwidth_numbers * 2}-#{fullwidth_numbers * 2}")
+      close
+      assert_screen(<<~EOC)
+        Multiline REPL.
+        prompt> '０１２３４
+        ５６７８９０１２３４
+        ５６７８９-０１２３
+        ４５６７８９０１２３
+        ４５６７８９
+      EOC
+    end
+
     def test_finish_autowrapped_line
       start_terminal(10, 40, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write("[{'user'=>{'email'=>'a@a', 'id'=>'ABC'}, 'version'=>4, 'status'=>'succeeded'}]\n")


### PR DESCRIPTION
Fixes #581
Left: before, Right: after
![image](https://github.com/ruby/reline/assets/1780201/c6fd55ca-3a68-4db0-8875-1d29e283ae0c)
```ruby
# Input for the above screenshot (no linebreak, 0-9 are fullwidth numbers)
'０１２３４５６７８９０１２３４５６７８９-
０１２３４５６７８９０１２３４５６７８９-
０１２３４５６７８９０１２３４５６７８９-
０１２３４５６７８９０１２３４５６７８９'.size
```

Fixes rendering bug of #491 but cursor position bug is not fixed. (Need to change all `% @screen_size.last` in line_editor.rb)
