### PR TITLE
Properly restore Reline::IOGate in test teardown

### DIFF
--- a/lib/reline/general_io.rb
+++ b/lib/reline/general_io.rb
@@ -3,7 +3,11 @@ require 'io/wait'
 class Reline::GeneralIO
   def self.reset(encoding: nil)
     @@pasting = false
-    @@encoding = encoding
+    if encoding
+      @@encoding = encoding
+    elsif defined?(@@encoding)
+      remove_class_variable(:@@encoding)
+    end
   end
 
   def self.encoding

--- a/test/reline/helper.rb
+++ b/test/reline/helper.rb
@@ -21,21 +21,23 @@ end
 module Reline
   class <<self
     def test_mode(ansi: false)
-        remove_const('IOGate') if const_defined?('IOGate')
-        const_set('IOGate', ansi ? Reline::ANSI : Reline::GeneralIO)
-        if ENV['RELINE_TEST_ENCODING']
-          encoding = Encoding.find(ENV['RELINE_TEST_ENCODING'])
-        else
-          encoding = Encoding::UTF_8
-        end
-        Reline::GeneralIO.reset(encoding: encoding) unless ansi
-        core.config.instance_variable_set(:@test_mode, true)
-        core.config.reset
+      @original_iogate = IOGate
+      remove_const('IOGate')
+      const_set('IOGate', ansi ? Reline::ANSI : Reline::GeneralIO)
+      if ENV['RELINE_TEST_ENCODING']
+        encoding = Encoding.find(ENV['RELINE_TEST_ENCODING'])
+      else
+        encoding = Encoding::UTF_8
+      end
+      Reline::GeneralIO.reset(encoding: encoding) unless ansi
+      core.config.instance_variable_set(:@test_mode, true)
+      core.config.reset
     end
 
     def test_reset
-      remove_const('IOGate') if const_defined?('IOGate')
-      const_set('IOGate', Reline::GeneralIO)
+      remove_const('IOGate')
+      const_set('IOGate', @original_iogate)
+      Reline::GeneralIO.reset
       Reline.instance_variable_set(:@core, nil)
     end
 

--- a/test/reline/test_reline_key.rb
+++ b/test/reline/test_reline_key.rb
@@ -3,6 +3,7 @@ require "reline"
 
 class Reline::TestKey < Reline::TestCase
   def setup
+    Reline.test_mode
   end
 
   def teardown


### PR DESCRIPTION
`make test-all TESTS="reline/test_reline.rb irb/test_cmd.rb"` was failing. Pager is shown and test will stop until you enter `q`.

The reason of the failure is:
- Reline sets IOGate to GeneralIO in teardown
- GeneralIO.get_screen_size returns [1, 1]
- If show-source content exceeds screen height, IRB uses pager

This pull request fixes test teardown to restore IOGate correctly.

show-source's test is also fixed in https://github.com/ruby/irb/pull/720
