### PR TITLE
Test Reline::Face without mocking

### DIFF
--- a/.github/workflows/ruby-core.yml
+++ b/.github/workflows/ruby-core.yml
@@ -1,0 +1,59 @@
+name: ruby-core
+
+on:
+  pull_request:
+
+  push:
+    branches:
+      - master
+
+concurrency:
+  group: ci-${{ github.ref }}-${{ github.workflow }}
+
+permissions: # added using https://github.com/step-security/secure-workflows
+  contents: read
+
+jobs:
+  ruby_core:
+    name: Reline under a ruby-core setup
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+    timeout-minutes: 30
+    steps:
+      - name: Set up latest ruby head
+        uses: ruby/setup-ruby@250fcd6a742febb1123a77a841497ccaa8b9e939 # v1.152.0
+        with:
+          ruby-version: head
+          bundler: none
+      - name: Save latest buildable revision to environment
+        run: echo "REF=$(ruby -v | cut -d')' -f1 | cut -d' ' -f5)" >> $GITHUB_ENV
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v3.1.0
+        with:
+          repository: ruby/ruby
+          path: ruby/ruby
+          fetch-depth: 10
+      - name: Checkout the latest buildable revision
+        run: git switch -c ${{ env.REF }}
+        working-directory: ruby/ruby
+      - name: Install libraries
+        run: |
+          set -x
+          sudo apt-get update -q || :
+          sudo apt-get install --no-install-recommends -q -y build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm-dev bison autoconf ruby
+      - name: Build Ruby
+        run: |
+          autoconf
+          ./configure -C --disable-install-doc
+          make -j2
+        working-directory: ruby/ruby
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v3.1.0
+        with:
+          path: ruby/reline
+      - name: Sync tools
+        run: |
+          ruby tool/sync_default_gems.rb reline
+        working-directory: ruby/ruby
+      - name: Test Reline
+        run: make -j2 -s test-all TESTS="reline --no-retry"
+        working-directory: ruby/ruby

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,5 @@ end
 gem 'bundler'
 gem 'rake'
 gem 'test-unit'
-gem 'test-unit-rr'
 
 gem 'racc'

--- a/test/reline/helper.rb
+++ b/test/reline/helper.rb
@@ -4,7 +4,6 @@ ENV['TERM'] = 'xterm' # for some CI environments
 
 require 'reline'
 require 'test/unit'
-require 'test/unit/rr'
 
 begin
   require 'rbconfig'

--- a/test/reline/test_face.rb
+++ b/test/reline/test_face.rb
@@ -151,17 +151,6 @@ class Reline::Face::Test < Reline::TestCase
       @config = Reline::Face.const_get(:Config).new(:my_config) { }
     end
 
-    def test_the_order_of_define_values_should_be_preserved
-      any_instance_of(Reline::Face.const_get(:Config)) do |config|
-        mock(config).format_to_sgr(
-          [[:foreground, :blue], [:style, [:bold, :italicized]], [:background, :red]]
-        )
-      end
-      Reline::Face.config(:my_config) do |face|
-        face.define :default, foreground: :blue, style: [:bold, :italicized], background: :red
-      end
-    end
-
     def test_rgb?
       assert_equal true, @config.send(:rgb_expression?, "#FFFFFF")
     end
@@ -171,10 +160,15 @@ class Reline::Face::Test < Reline::TestCase
       assert_equal false, @config.send(:rgb_expression?, "#FFFFF")
     end
 
-    def test_format_to_sgr
+    def test_format_to_sgr_preserves_order
       assert_equal(
         "#{RESET_SGR}\e[37;41;1;3m",
         @config.send(:format_to_sgr, foreground: :white, background: :red, style: [:bold, :italicized])
+      )
+
+      assert_equal(
+        "#{RESET_SGR}\e[37;1;3;41m",
+        @config.send(:format_to_sgr, foreground: :white, style: [:bold, :italicized], background: :red)
       )
     end
 


### PR DESCRIPTION
Because `test-unit-rr` is not a default gem, using it would break CRuby's CI.
I also added a `ruby-core` workflow similar to [IRB's](https://github.com/ruby/irb/blob/master/.github/workflows/ruby-core.yml) that should prevent similar issues in the future.