### PR TITLE
Reintroduce test-unit-rr

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,5 +12,6 @@ end
 gem 'bundler'
 gem 'rake'
 gem 'test-unit'
+gem 'test-unit-rr'
 
 gem 'racc'

--- a/test/reline/helper.rb
+++ b/test/reline/helper.rb
@@ -4,6 +4,7 @@ ENV['TERM'] = 'xterm' # for some CI environments
 
 require 'reline'
 require 'test/unit'
+require 'test/unit/rr'
 
 begin
   require 'rbconfig'

--- a/test/reline/helper.rb
+++ b/test/reline/helper.rb
@@ -4,7 +4,15 @@ ENV['TERM'] = 'xterm' # for some CI environments
 
 require 'reline'
 require 'test/unit'
-require 'test/unit/rr'
+
+begin
+  unless ENV['TEST_UNIT_RR'] == 'no'
+    require 'test/unit/rr'
+    ENV['TEST_UNIT_RR'] = 'yes'
+  end
+rescue LoadError
+  ENV['TEST_UNIT_RR'] = 'no'
+end
 
 begin
   require 'rbconfig'

--- a/test/reline/test_face.rb
+++ b/test/reline/test_face.rb
@@ -161,6 +161,7 @@ class Reline::Face::Test < Reline::TestCase
     end
 
     def test_define_method_proxies_the_order_of_arguments
+      pend "skip because test-unit-rr could not be loaded" if ENV['TEST_UNIT_RR'] == 'no'
       mock(@config).format_to_sgr(
         [[:foreground, :blue], [:style, [:bold, :italicized]], [:background, :red]]
       )

--- a/test/reline/test_face.rb
+++ b/test/reline/test_face.rb
@@ -160,7 +160,14 @@ class Reline::Face::Test < Reline::TestCase
       assert_equal false, @config.send(:rgb_expression?, "#FFFFF")
     end
 
-    def test_format_to_sgr_preserves_order
+    def test_define_method_proxies_the_order_of_arguments
+      mock(@config).format_to_sgr(
+        [[:foreground, :blue], [:style, [:bold, :italicized]], [:background, :red]]
+      )
+      @config.define :default, foreground: :blue, style: [:bold, :italicized], background: :red
+    end
+
+    def test_format_to_sgr_preserves_order_of_values
       assert_equal(
         "#{RESET_SGR}\e[37;41;1;3m",
         @config.send(:format_to_sgr, foreground: :white, background: :red, style: [:bold, :italicized])


### PR DESCRIPTION
I'd like to introduce test-unit-rr again that is removed in https://github.com/ruby/reline/pull/600 due to the failure of Ruby CI http://ci.rvm.jp/results/trunk-yjit@ruby-sp2-docker/4766571

Now we can use test-unit-rr thanks to @hsbt https://git.ruby-lang.org/ruby.git/tree/common.mk#n1554