### PR TITLE
Fallback to 256color if COLORTERM != truecolor

### DIFF
--- a/doc/reline/face.md
+++ b/doc/reline/face.md
@@ -102,7 +102,10 @@ irb(main):001:0> Reline::Face.configs
    :scrollbar=>{:foreground=>:white, :background=>:cyan, :escape_sequence=>"\e[0m\e[37;46m"}}}
 ```
 
-## Backlog
+## 256-Color and TrueColor
 
-- Support for 256-color terminal emulator. Fallback hex color code such as "#FF1020" to 256 colors
-
+Reline will automatically detect if your terminal emulator supports truecolor with `ENV['COLORTERM] in 'truecolor' | '24bit'`. When this env is not set, Reline will fallback to 256-color.
+If your terminal emulator supports truecolor but does not set COLORTERM env, add this line to `.irbrc`.
+```ruby
+Reline::Face.force_truecolor
+```

--- a/lib/reline/face.rb
+++ b/lib/reline/face.rb
@@ -82,12 +82,38 @@ class Reline::Face
 
     def sgr_rgb(key, value)
       return nil unless rgb_expression?(value)
+      if ENV['COLORTERM'] == 'truecolor'
+        sgr_rgb_truecolor(key, value)
+      else
+        sgr_rgb_256color(key, value)
+      end
+    end
+
+    def sgr_rgb_truecolor(key, value)
       case key
       when :foreground
         "38;2;"
       when :background
         "48;2;"
       end + value[1, 6].scan(/../).map(&:hex).join(";")
+    end
+
+    def sgr_rgb_256color(key, value)
+      # 256 colors are
+      # 0..15: standard colors, hight intensity colors
+      # 16..232: 216 colors (R, G, B each 6 steps)
+      # 233..255: grayscale colors (24 steps)
+      # This methods converts rgb_expression to 216 colors
+      rgb = value[1, 6].scan(/../).map(&:hex)
+      # Color steps are [0, 95, 135, 175, 215, 255]
+      r, g, b = rgb.map { |v| v <= 95 ? v / 48 : (v - 35) / 40 }
+      color = (16 + 36 * r + 6 * g + b)
+      case key
+      when :foreground
+        "38;5;#{color}"
+      when :background
+        "48;5;#{color}"
+      end
     end
 
     def format_to_sgr(ordered_values)

--- a/test/reline/test_face.rb
+++ b/test/reline/test_face.rb
@@ -5,12 +5,19 @@ require_relative 'helper'
 class Reline::Face::Test < Reline::TestCase
   RESET_SGR = "\e[0m"
 
+  def setup
+    @colorterm_backup = ENV['COLORTERM']
+    ENV['COLORTERM'] = 'truecolor'
+  end
+
   def teardown
     Reline::Face.reset_to_initial_configs
+    ENV['COLORTERM'] = @colorterm_backup
   end
 
   class WithInsufficientSetupTest < self
     def setup
+      super
       Reline::Face.config(:my_insufficient_config) do |face|
       end
       @face = Reline::Face[:my_insufficient_config]
@@ -37,6 +44,7 @@ class Reline::Face::Test < Reline::TestCase
 
   class WithSetupTest < self
     def setup
+      super
       Reline::Face.config(:my_config) do |face|
         face.define :default, foreground: :blue
         face.define :enhanced, foreground: "#FF1020", background: :black, style: [:bold, :underlined]
@@ -148,6 +156,7 @@ class Reline::Face::Test < Reline::TestCase
 
   class ConfigTest < self
     def setup
+      super
       @config = Reline::Face.const_get(:Config).new(:my_config) { }
     end
 
@@ -190,9 +199,26 @@ class Reline::Face::Test < Reline::TestCase
       )
     end
 
-    def test_sgr_rgb
+    def test_sgr_rgb_truecolor
+      ENV['COLORTERM'] = 'truecolor'
       assert_equal "38;2;255;255;255", @config.send(:sgr_rgb, :foreground, "#ffffff")
       assert_equal "48;2;18;52;86", @config.send(:sgr_rgb, :background, "#123456")
+    end
+
+    def test_sgr_rgb_256color
+      ENV['COLORTERM'] = nil
+      assert_equal '38;5;231', @config.send(:sgr_rgb, :foreground, '#ffffff')
+      assert_equal '48;5;16', @config.send(:sgr_rgb, :background, '#000000')
+      # Color steps are [0x00, 0x5f, 0x87, 0xaf, 0xd7, 0xff]
+      assert_equal '38;5;24', @config.send(:sgr_rgb, :foreground, '#005f87')
+      assert_equal '38;5;67', @config.send(:sgr_rgb, :foreground, '#5f87af')
+      assert_equal '48;5;110', @config.send(:sgr_rgb, :background, '#87afd7')
+      assert_equal '48;5;153', @config.send(:sgr_rgb, :background, '#afd7ff')
+      # Boundary values are [0x30, 0x73, 0x9b, 0xc3, 0xeb]
+      assert_equal '38;5;24', @config.send(:sgr_rgb, :foreground, '#2f729a')
+      assert_equal '38;5;67', @config.send(:sgr_rgb, :foreground, '#30739b')
+      assert_equal '48;5;110', @config.send(:sgr_rgb, :background, '#9ac2ea')
+      assert_equal '48;5;153', @config.send(:sgr_rgb, :background, '#9bc3eb')
     end
   end
 end


### PR DESCRIPTION
Face supports hex color `'#aabbcc'` but some terminal does not support truecolor. (example: macOS Terminal.app)
This pull request adds fallback to 256color if `ENV['COLORTERM']` is not `'truecolor' | '24bit'`

## About 256color
`0..15` is standard color and high intensity color (this color table is customizable by terminal emulator's config)
`16..231` is 216 color (r,g,b each 6 steps, 6**3 == 216) This pull request uses this part.
`232..255` grayscale 24step. This pull request does not use this part event if the specified color is gray.

Each R,G,B in 216 color are 6 steps, `[0, 95, 135, 175, 215, 255]`
In ruby code, steps are `[0, *95.step(255,40)]`
when value > 95, color index can be calculated by `1 + ((value-95)/40.0).round` or in short, `(value - 35) / 40`

## COLORTERM env
Many tools uses `ENV['COLORTERM'] == 'truecolor'`  or `ENV['COLORTERM'] in 'truecolor' | '24bit'` to check if truecolor is supported.
https://github.com/search?q=COLORTERM&type=code

Some terminal emulator does not set env COLORTERM even if it supports truecolor. (example: Windows Terminal)
To enable truecolor without COLORTERM env, I added `Reline::Face.force_truecolor`

```ruby
Reline::Face.force_truecolor
Reline::Face.config(:foo) do |conf|
  conf.define :bar, foreground: '#123456'
end
# Reline::Face.force_truecolor # Writing here is also ok. It will regenerate escape sequences for truecolor
```
