### PR TITLE
Fix completion during constant input after bracket

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -553,8 +553,8 @@ module Reline
       core.key_stroke = Reline::KeyStroke.new(core.config)
       core.line_editor = Reline::LineEditor.new(core.config, core.encoding)
 
-      core.basic_word_break_characters = " \t\n`><=;|&{("
-      core.completer_word_break_characters = " \t\n`><=;|&{("
+      core.basic_word_break_characters = " \t\n`><=;|&{(["
+      core.completer_word_break_characters = " \t\n`><=;|&{(["
       core.basic_quote_characters = '"\''
       core.completer_quote_characters = '"\''
       core.filename_quote_characters = ""

--- a/test/reline/test_reline.rb
+++ b/test/reline/test_reline.rb
@@ -50,7 +50,7 @@ class Reline::Test < Reline::TestCase
   def test_basic_word_break_characters
     basic_word_break_characters = Reline.basic_word_break_characters
 
-    assert_equal(" \t\n`><=;|&{(", Reline.basic_word_break_characters)
+    assert_equal(" \t\n`><=;|&{([", Reline.basic_word_break_characters)
 
     Reline.basic_word_break_characters = "[".encode(Encoding::ASCII)
     assert_equal("[", Reline.basic_word_break_characters)
@@ -62,7 +62,7 @@ class Reline::Test < Reline::TestCase
   def test_completer_word_break_characters
     completer_word_break_characters = Reline.completer_word_break_characters
 
-    assert_equal(" \t\n`><=;|&{(", Reline.completer_word_break_characters)
+    assert_equal(" \t\n`><=;|&{([", Reline.completer_word_break_characters)
 
     Reline.completer_word_break_characters = "[".encode(Encoding::ASCII)
     assert_equal("[", Reline.completer_word_break_characters)


### PR DESCRIPTION
Fix: https://github.com/ruby/irb/issues/550

**Before**
<img width="180" alt="スクリーンショット 2023-11-14 2 23 41" src="https://github.com/ruby/reline/assets/8371588/f6cd9b0a-22ab-4c10-916d-92a65bc48198">

**After**
<img width="212" alt="スクリーンショット 2023-11-14 2 22 53" src="https://github.com/ruby/reline/assets/8371588/0c0efdcb-1c6c-490f-afb8-ad5eb7cc4731">

Add `[` to word break charactor.
