### PR TITLE
Replace `object_id` comparison with `equal?`

### DIFF
--- a/lib/reline/kill_ring.rb
+++ b/lib/reline/kill_ring.rb
@@ -14,7 +14,7 @@ class Reline::KillRing
     end
 
     def ==(other)
-      object_id == other.object_id
+      equal?(other)
     end
   end
 


### PR DESCRIPTION
Found this while auditing uses of `object_id` in `ruby/ruby`. Pulled out from ruby/ruby#9276

This PR replaces an `object_id` comparison with an `equal?`, which has the same semantics, but is faster and doesn't trigger allocation of IDs for these objects.