### PR TITLE
Fix pasting tab-indented code crash

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -1313,7 +1313,7 @@ class Reline::LineEditor
       end
       if not just_show_list and target < completed
         @line = (preposing + completed + completion_append_character.to_s + postposing).split("\n")[@line_index] || String.new(encoding: @encoding)
-        line_to_pointer = (preposing + completed + completion_append_character.to_s).split("\n").last || String.new(encoding: @encoding)
+        line_to_pointer = (preposing + completed + completion_append_character.to_s).split("\n")[@line_index] || String.new(encoding: @encoding)
         @cursor_max = calculate_width(@line)
         @cursor = calculate_width(line_to_pointer)
         @byte_pointer = line_to_pointer.bytesize
@@ -1360,7 +1360,7 @@ class Reline::LineEditor
     completed = @completion_journey_data.list[@completion_journey_data.pointer]
     new_line = (@completion_journey_data.preposing + completed + @completion_journey_data.postposing).split("\n")[@line_index]
     @line = new_line.nil? ? String.new(encoding: @encoding) : new_line
-    line_to_pointer = (@completion_journey_data.preposing + completed).split("\n").last
+    line_to_pointer = (@completion_journey_data.preposing + completed).split("\n")[@line_index]
     line_to_pointer = String.new(encoding: @encoding) if line_to_pointer.nil?
     @cursor_max = calculate_width(@line)
     @cursor = calculate_width(line_to_pointer)

--- a/test/reline/yamatanooroti/multiline_repl
+++ b/test/reline/yamatanooroti/multiline_repl
@@ -153,6 +153,10 @@ opt.on('--autocomplete') {
     %w{String Struct Symbol ScriptError SyntaxError Signal}.select{ |c| c.start_with?(target) }
   }
 }
+opt.on('--autocomplete-empty') {
+  Reline.autocompletion = true
+  Reline.completion_proc = lambda { |target, preposing = nil, postposing = nil| [] }
+}
 opt.on('--autocomplete-long') {
   Reline.autocompletion = true
   Reline.completion_proc = lambda { |target, preposing = nil, postposing = nil|

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -1213,6 +1213,32 @@ begin
       EOC
     end
 
+    def test_autocomplete_empty_string
+      start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --autocomplete}, startup_message: 'Multiline REPL.')
+      write("\C-i")
+      close
+      assert_screen(<<~'EOC')
+        Multiline REPL.
+        prompt> String
+                String     █
+                Struct     ▀
+                Symbol
+      EOC
+    end
+
+    def test_paste_code_with_tab_indent_does_not_fail
+      start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --autocomplete-empty}, startup_message: 'Multiline REPL.')
+      write("2.times do\n\tputs\n\tputs\nend")
+      close
+      assert_screen(<<~'EOC')
+        Multiline REPL.
+        prompt> 2.times do
+        prompt> puts
+        prompt> puts
+        prompt> end
+      EOC
+    end
+
     def test_autocomplete_after_2nd_line
       start_terminal(20, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --autocomplete}, startup_message: 'Multiline REPL.')
       write("def hoge\n  Str")


### PR DESCRIPTION
## When you paste code below that is indented with tab, Reline crashes.

```ruby
2.times do
	puts
	puts
end
```

## Reproduce
It happens when completion candidates of autocomplete at the beginning of the line is empty.
Example: With `irb --type-completor` or with ruby/irb:master that disabled empty target completion.
