### PR TITLE
Bump version to v0.4.2

### DIFF
--- a/lib/reline/version.rb
+++ b/lib/reline/version.rb
@@ -1,3 +1,3 @@
 module Reline
-  VERSION = '0.4.1'
+  VERSION = '0.4.2'
 end


### PR DESCRIPTION
[Diff](https://github.com/ruby/reline/compare/v0.4.1...master)

Since #630 fixes a crashing issue, I think we can get it out sooner than later.