### PR TITLE
Use gray and bright-white as the default dialog theme

### DIFF
--- a/lib/reline/face.rb
+++ b/lib/reline/face.rb
@@ -186,9 +186,9 @@ class Reline::Face
       conf.define :scrollbar, style: :reset
     end
     config(:completion_dialog) do |conf|
-      conf.define :default, foreground: :white, background: :cyan
-      conf.define :enhanced, foreground: :white, background: :magenta
-      conf.define :scrollbar, foreground: :white, background: :cyan
+      conf.define :default, foreground: :bright_white, background: :gray
+      conf.define :enhanced, foreground: :black, background: :white
+      conf.define :scrollbar, foreground: :white, background: :gray
     end
   end
 


### PR DESCRIPTION
I think this has a few benefits:

1. Most terminal themes generally don't change or only pick similar colors for their black and white colors, so it's more likely to be consistent across terminals/themes.
2. They don't have the potential color-blind issues that other color options may have.
3. We won't need additional changes for no color mode.

<img width="50%" src="https://github.com/ruby/reline/assets/5079556/78c2e33d-491d-417d-b593-94adb13fc5a3">

<img width="50%" src="https://github.com/ruby/reline/assets/5079556/47636d7e-6e27-4708-8cd9-ac56efc6a672">

