### PR TITLE
Add metadata for rubygems.org

### DIFF
--- a/reline.gemspec
+++ b/reline.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
 
   spec.files         = Dir['BSDL', 'COPYING', 'README.md', 'license_of_rb-readline', 'lib/**/*']
   spec.require_paths = ['lib']
+  spec.metadata = {
+    "bug_tracker_uri"   => "https://github.com/ruby/reline/issues",
+    "changelog_uri"     => "https://github.com/ruby/reline/releases",
+    "source_code_uri"   => "https://github.com/ruby/reline"
+  }
 
   spec.required_ruby_version = Gem::Requirement.new('>= 2.6')
 


### PR DESCRIPTION
This PR adds [metadata](https://guides.rubygems.org/specification-reference/#metadata) for [rubygems.org](https://rubygems.org/gems/reline?locale=ja)