### PR TITLE
Fix crash when using ed_next_history after using ed_search_prev_history

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -1756,10 +1756,12 @@ class Reline::LineEditor
     if @is_multiline
       @buffer_of_lines = Reline::HISTORY[@history_pointer].split("\n")
       @buffer_of_lines = [String.new(encoding: @encoding)] if @buffer_of_lines.empty?
+      @line_backup_in_history = whole_buffer
       @line_index = line_no
       calculate_nearest_cursor(cursor)
     else
       @buffer_of_lines = [Reline::HISTORY[@history_pointer]]
+      @line_backup_in_history = whole_buffer
       calculate_nearest_cursor(cursor)
     end
     arg -= 1


### PR DESCRIPTION
This bug also exists in master, but this branch was created from 0.5.0pre to avoid conflicts with reline_0.5.0.pre.

Step to reproduce:

1. Register `history-search-backward` to `C-a` in `.inputrc`.

```
$if Ruby
  "\C-a": history-search-backward
$endif
```

2. Run `irb` with `INPUTRC=.inputrc`

3. Press `C-a` and press `↓`

4. Get error

```
irb(main):001> /Users/mi/.asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/reline-0.4.2/lib/reline/line_editor.rb:2450:in `ed_next_history': undefined method `split' for nil (NoMethodError)

        @buffer_of_lines = @line_backup_in_history.split("\n")
                                                  ^^^^^^
        from /Users/mi/.asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/reline-0.4.2/lib/reline/line_editor.rb:1433:in `call'
        from /Users/mi/.asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/reline-0.4.2/lib/reline/line_editor.rb:1433:in `wrap_method_call'
        from /Users/mi/.asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/reline-0.4.2/lib/reline/line_editor.rb:1450:in `process_key'
        from /Users/mi/.asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/reline-0.4.2/lib/reline/line_editor.rb:1586:in `input_key'
        from /Users/mi/.asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/reline-0.4.2/lib/reline.rb:350:in `block (3 levels) in inner_readline'
        from /Users/mi/.asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/reline-0.4.2/lib/reline.rb:349:in `each'
        from /Users/mi/.asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/reline-0.4.2/lib/reline.rb:349:in `block (2 levels) in inner_readline'
        from /Users/mi/.asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/reline-0.4.2/lib/reline.rb:408:in `block in read_io'
        from <internal:kernel>:187:in `loop'
        from /Users/mi/.asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/reline-0.4.2/lib/reline.rb:394:in `read_io'
        from /Users/mi/.asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/reline-0.4.2/lib/reline.rb:347:in `block in inner_readline'
        from <internal:kernel>:187:in `loop'
        from /Users/mi/.asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/reline-0.4.2/lib/reline.rb:345:in `inner_readline'
        from /Users/mi/.asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/reline-0.4.2/lib/reline.rb:273:in `block in readmultiline'
        from /Users/mi/.asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/reline-0.4.2/lib/reline/ansi.rb:152:in `block in with_raw_input'
        from /Users/mi/.asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/reline-0.4.2/lib/reline/ansi.rb:152:in `raw'
        from /Users/mi/.asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/reline-0.4.2/lib/reline/ansi.rb:152:in `with_raw_input'
        from /Users/mi/.asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/reline-0.4.2/lib/reline.rb:269:in `readmultiline'
        from /Users/mi/.asdf/installs/ruby/3.3.0/lib/ruby/3.3.0/forwardable.rb:240:in `readmultiline'
        from /Users/mi/.asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/irb-1.11.1/lib/irb/input-method.rb:453:in `gets'
        from /Users/mi/.asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/irb-1.11.1/lib/irb.rb:1029:in `block in read_input'
        from /Users/mi/.asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/irb-1.11.1/lib/irb.rb:1317:in `signal_status'
        from /Users/mi/.asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/irb-1.11.1/lib/irb.rb:1027:in `read_input'
        from /Users/mi/.asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/irb-1.11.1/lib/irb.rb:1049:in `readmultiline'
        from /Users/mi/.asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/irb-1.11.1/lib/irb.rb:1076:in `block in each_top_level_statement'
        from <internal:kernel>:187:in `loop'
        from /Users/mi/.asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/irb-1.11.1/lib/irb.rb:1075:in `each_top_level_statement'
        from /Users/mi/.asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/irb-1.11.1/lib/irb.rb:997:in `eval_input'
        from /Users/mi/.asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/irb-1.11.1/lib/irb.rb:984:in `block in run'
        from /Users/mi/.asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/irb-1.11.1/lib/irb.rb:983:in `catch'
        from /Users/mi/.asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/irb-1.11.1/lib/irb.rb:983:in `run'
        from /Users/mi/.asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/irb-1.11.1/lib/irb.rb:885:in `start'
        from /Users/mi/.asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/irb-1.11.1/exe/irb:9:in `<top (required)>'
        from /Users/mi/.asdf/installs/ruby/3.3.0/bin/irb:25:in `load'
        from /Users/mi/.asdf/installs/ruby/3.3.0/bin/irb:25:in `<main>'
```