### PR TITLE
Refactor completion

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -222,21 +222,13 @@ module Reline
       return unless config.autocompletion
 
       journey_data = completion_journey_data
-      if just_cursor_moving and journey_data.nil?
-        # Auto complete starts only when edited
-        return
-      end
-      if journey_data
-        result = journey_data.list.drop(1)
-        pointer = journey_data.pointer - 1
-        target = journey_data.list[journey_data.pointer]
-      else
-        pre, target, post = retrieve_completion_block(true)
-        return if target.nil? || target.empty?
+      return unless journey_data
 
-        result = call_completion_proc_with_checking_args(pre, target, post)
-        return if result and result.size == 1 and result[0] == target
-      end
+      target = journey_data.list[journey_data.pointer]
+      result = journey_data.list.drop(1)
+      pointer = journey_data.pointer - 1
+      return if target.empty? || (result == [target] && pointer < 0)
+
       target_width = Reline::Unicode.calculate_width(target)
       x = cursor_pos.x - target_width
       if x < 0

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -41,14 +41,13 @@ class Reline::LineEditor
     NORMAL = :normal
     COMPLETION = :completion
     MENU = :menu
-    JOURNEY = :journey
     MENU_WITH_PERFECT_MATCH = :menu_with_perfect_match
     PERFECT_MATCH = :perfect_match
   end
 
   RenderedScreen = Struct.new(:base_y, :lines, :cursor_y, keyword_init: true)
 
-  CompletionJourneyData = Struct.new(:preposing, :postposing, :list, :pointer)
+  CompletionJourneyState = Struct.new(:line_index, :pre, :target, :post, :list, :pointer)
 
   class MenuInfo
     attr_reader :list
@@ -221,7 +220,7 @@ class Reline::LineEditor
     @waiting_proc = nil
     @waiting_operator_proc = nil
     @waiting_operator_vi_arg = nil
-    @completion_journey_data = nil
+    @completion_journey_state = nil
     @completion_state = CompletionState::NORMAL
     @perfect_matched = nil
     @menu_info = nil
@@ -559,6 +558,8 @@ class Reline::LineEditor
   end
 
   class DialogProcScope
+    CompletionJourneyData = Struct.new(:preposing, :postposing, :list, :pointer)
+
     def initialize(line_editor, config, proc_to_exec, context)
       @line_editor = line_editor
       @config = config
@@ -622,7 +623,7 @@ class Reline::LineEditor
     end
 
     def completion_journey_data
-      @line_editor.instance_variable_get(:@completion_journey_data)
+      @line_editor.dialog_proc_scope_completion_journey_data
     end
 
     def config
@@ -851,9 +852,9 @@ class Reline::LineEditor
     [target, preposing, completed, postposing]
   end
 
-  private def complete(list, just_show_list = false)
+  private def complete(list, just_show_list)
     case @completion_state
-    when CompletionState::NORMAL, CompletionState::JOURNEY
+    when CompletionState::NORMAL
       @completion_state = CompletionState::COMPLETION
     when CompletionState::PERFECT_MATCH
       @dig_perfect_match_proc&.(@perfect_matched)
@@ -893,46 +894,45 @@ class Reline::LineEditor
     end
   end
 
-  private def move_completed_list(list, direction)
-    case @completion_state
-    when CompletionState::NORMAL, CompletionState::COMPLETION,
-         CompletionState::MENU, CompletionState::MENU_WITH_PERFECT_MATCH
-      @completion_state = CompletionState::JOURNEY
-      result = retrieve_completion_block
-      return if result.nil?
-      preposing, target, postposing = result
-      @completion_journey_data = CompletionJourneyData.new(
-        preposing, postposing,
-        [target] + list.select{ |item| item.start_with?(target) }, 0)
-      if @completion_journey_data.list.size == 1
-        @completion_journey_data.pointer = 0
-      else
-        case direction
-        when :up
-          @completion_journey_data.pointer = @completion_journey_data.list.size - 1
-        when :down
-          @completion_journey_data.pointer = 1
-        end
+  def dialog_proc_scope_completion_journey_data
+    return nil unless @completion_journey_state
+    line_index = @completion_journey_state.line_index
+    pre_lines = @buffer_of_lines[0...line_index].map { |line| line + "\n" }
+    post_lines = @buffer_of_lines[(line_index + 1)..-1].map { |line| line + "\n" }
+    DialogProcScope::CompletionJourneyData.new(
+      pre_lines.join + @completion_journey_state.pre,
+      @completion_journey_state.post + post_lines.join,
+      @completion_journey_state.list,
+      @completion_journey_state.pointer
+    )
+  end
+
+  private def move_completed_list(direction)
+    if @completion_journey_state
+      if (delta = { up: -1, down: +1 }[direction])
+        @completion_journey_state.pointer = (@completion_journey_state.pointer + delta) % @completion_journey_state.list.size
       end
-      @completion_state = CompletionState::JOURNEY
     else
-      case direction
-      when :up
-        @completion_journey_data.pointer -= 1
-        if @completion_journey_data.pointer < 0
-          @completion_journey_data.pointer = @completion_journey_data.list.size - 1
-        end
-      when :down
-        @completion_journey_data.pointer += 1
-        if @completion_journey_data.pointer >= @completion_journey_data.list.size
-          @completion_journey_data.pointer = 0
-        end
-      end
+      preposing, target, postposing = retrieve_completion_block
+      return false unless target
+
+      list = call_completion_proc
+      return false unless list.is_a?(Array)
+
+      candidates = list.select{ |item| item.start_with?(target) }
+      return false if candidates.empty?
+
+      pre = preposing.split("\n", -1).last || ''
+      post = postposing.split("\n", -1).first || ''
+      pointer = direction == :up ? candidates.size : 1
+      @completion_journey_state = CompletionJourneyState.new(
+        @line_index, pre, target, post, [target] + candidates, pointer
+      )
     end
-    completed = @completion_journey_data.list[@completion_journey_data.pointer]
-    line_to_pointer = (@completion_journey_data.preposing + completed).split("\n")[@line_index] || String.new(encoding: @encoding)
-    new_line = line_to_pointer + (@completion_journey_data.postposing.split("\n").first || '')
-    set_current_line(new_line, line_to_pointer.bytesize)
+
+    completed = @completion_journey_state.list[@completion_journey_state.pointer]
+    set_current_line(@completion_journey_state.pre + completed + @completion_journey_state.post, @completion_journey_state.pre.bytesize + completed.bytesize)
+    true
   end
 
   private def run_for_operators(key, method_symbol, &block)
@@ -1121,35 +1121,32 @@ class Reline::LineEditor
     @first_char = false
     completion_occurs = false
     if @config.editing_mode_is?(:emacs, :vi_insert) and key.char == "\C-i".ord
-      unless @config.disable_completion
-        result = call_completion_proc
-        if result.is_a?(Array)
-          completion_occurs = true
-          process_insert
-          if @config.autocompletion
-            move_completed_list(result, :down)
-          else
-            complete(result)
+      if !@config.disable_completion
+        process_insert(force: true)
+        if @config.autocompletion
+          @completion_state = CompletionState::NORMAL
+          completion_occurs = move_completed_list(:down)
+        else
+          @completion_journey_state = nil
+          result = call_completion_proc
+          if result.is_a?(Array)
+            completion_occurs = true
+            complete(result, false)
           end
         end
       end
     elsif @config.editing_mode_is?(:emacs, :vi_insert) and key.char == :completion_journey_up
       if not @config.disable_completion and @config.autocompletion
-        result = call_completion_proc
-        if result.is_a?(Array)
-          completion_occurs = true
-          process_insert
-          move_completed_list(result, :up)
-        end
+        process_insert(force: true)
+        @completion_state = CompletionState::NORMAL
+        completion_occurs = move_completed_list(:up)
       end
-    elsif not @config.disable_completion and @config.editing_mode_is?(:vi_insert) and ["\C-p".ord, "\C-n".ord].include?(key.char)
-      unless @config.disable_completion
-        result = call_completion_proc
-        if result.is_a?(Array)
-          completion_occurs = true
-          process_insert
-          move_completed_list(result, "\C-p".ord == key.char ? :up : :down)
-        end
+    elsif @config.editing_mode_is?(:vi_insert) and ["\C-p".ord, "\C-n".ord].include?(key.char)
+      # In vi mode, move completed list even if autocompletion is off
+      if not @config.disable_completion
+        process_insert(force: true)
+        @completion_state = CompletionState::NORMAL
+        completion_occurs = move_completed_list("\C-p".ord == key.char ? :up : :down)
       end
     elsif Symbol === key.char and respond_to?(key.char, true)
       process_key(key.char, key.char)
@@ -1158,7 +1155,7 @@ class Reline::LineEditor
     end
     unless completion_occurs
       @completion_state = CompletionState::NORMAL
-      @completion_journey_data = nil
+      @completion_journey_state = nil
     end
     if @in_pasting
       clear_dialogs
@@ -2042,7 +2039,7 @@ class Reline::LineEditor
   private def em_delete_or_list(key)
     if current_line.empty? or @byte_pointer < current_line.bytesize
       em_delete(key)
-    else # show completed list
+    elsif !@config.autocompletion # show completed list
       result = call_completion_proc
       if result.is_a?(Array)
         complete(result, true)

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -1108,6 +1108,19 @@ begin
       EOC
     end
 
+    def test_force_insert_before_autocomplete
+      start_terminal(20, 20, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --autocomplete}, startup_message: 'Multiline REPL.')
+      write('Sy')
+      write(";St\t\t")
+      close
+      assert_screen(<<~'EOC')
+        Multiline REPL.
+        prompt> Sy;Struct
+                   String
+                   Struct
+      EOC
+    end
+
     def test_simple_dialog_with_scroll_key
       start_terminal(20, 50, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --dialog long,scrollkey}, startup_message: 'Multiline REPL.')
       write('a')


### PR DESCRIPTION
Fixes #611 and #621

Split logic and state of autocompletion and tab completion

## Before
Reline has tab complete and autocomplete.
Tab complete uses
```
@completion_state = NORMAL | COMPLETION | MENU | MENU_WITH_PERFECT_MATCH | PERFECT_MATCH
```
Autocomplete uses
```
@completion_state = NORMAL | JOURNEY
@completion_journey_data
retrieve_completion_block(not stored to ivar, calling every time, causing dialog disappearing bug)
```
It's a separate feature but uses same instance variable `@completion_state` that making hard to fix some bugs.

## After
Tab complete uses
```
@completion_state = NORMAL | COMPLETION | MENU | MENU_WITH_PERFECT_MATCH | PERFECT_MATCH
```
Autocomplete uses
```
@completion_journey_state = CompletionJourneyState.new(line_index, pre, target, post, list, pointer) | nil
```
State is separated. Logic is also separated. Now we can remove redundant proc calls and fix #611 #621

## completion_journey_data
`completion_journey_data` is an API for dialog proc, defined in DialogProcScope. We need to keep compatibility.
It was an instance variable but changed to a method that calculates from `@completion_journey_state`.

## DEFAULT_DIALOG_PROC_AUTOCOMPLETE
Move completion candidate list up logic to LineEditor
All completion logic is in LineEditor. DEFAULT_DIALOG_PROC_AUTOCOMPLETE only needs to create dialog content from completion_journey_data

