### PR TITLE
Fix audoindent including "\v", escape "\v" for rendering

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -773,7 +773,7 @@ class Reline::LineEditor
     if after = @output_modifier_proc&.call("#{before.join("\n")}\n", complete: complete)
       after.lines("\n").map { |l| l.chomp('') }
     else
-      before
+      before.map { |l| Reline::Unicode.escape_for_print(l) }
     end
   end
 
@@ -1196,10 +1196,11 @@ class Reline::LineEditor
     new_indent = @auto_indent_proc.(@buffer_of_lines.take(line_index + 1).push(''), line_index, byte_pointer, add_newline)
     return unless new_indent
 
-    @buffer_of_lines[line_index] = ' ' * new_indent + line.lstrip
+    new_line = ' ' * new_indent + line.lstrip
+    @buffer_of_lines[line_index] = new_line
     if @line_index == line_index
-      old_indent = line[/\A */].size
-      @byte_pointer = [@byte_pointer + new_indent - old_indent, 0].max
+      indent_diff = new_line.bytesize - line.bytesize
+      @byte_pointer = [@byte_pointer + indent_diff, 0].max
     end
   end
 

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -828,6 +828,20 @@ begin
       EOC
     end
 
+    def test_auto_indent_with_various_spaces
+      start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --auto-indent}, startup_message: 'Multiline REPL.')
+      write "(\n\C-v"
+      write "\C-k\n\C-v"
+      write "\C-k)"
+      close
+      assert_screen(<<~EOC)
+        Multiline REPL.
+        prompt> (
+        prompt> ^K
+        prompt> )
+      EOC
+    end
+
     def test_autowrap_in_the_middle_of_a_line
       start_terminal(5, 20, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write("def abcdefg; end\C-b\C-b\C-b\C-b\C-b")


### PR DESCRIPTION
Fixes #625
`line.lstrip` removes `"\v"` `"\t"` `" "` and more spaces. If there are "\v" or "\t", byte_position calculation was wrong.

Change for modify_lines:
Reline::Unicode.calculate_width calculates width of `"\v"` as 2. Default output modifying logic should return two-width character for "\v".