### PR TITLE
Refactor waiting_proc and waiting_operator_proc 

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -938,7 +938,7 @@ class Reline::LineEditor
     if @vi_waiting_operator
       if VI_MOTIONS.include?(method_symbol)
         old_byte_pointer = @byte_pointer
-        @vi_arg ||= @vi_waiting_operator_arg
+        @vi_arg = (@vi_arg || 1) * @vi_waiting_operator_arg
         block.(true)
         unless @waiting_proc
           byte_pointer_diff = @byte_pointer - old_byte_pointer
@@ -2324,6 +2324,7 @@ class Reline::LineEditor
     if @vi_waiting_operator
       set_current_line('', 0) if @vi_waiting_operator == :vi_change_meta_confirm && arg.nil?
       @vi_waiting_operator = nil
+      @vi_waiting_operator_arg = nil
     else
       @drop_terminate_spaces = true
       @vi_waiting_operator = :vi_change_meta_confirm
@@ -2341,6 +2342,7 @@ class Reline::LineEditor
     if @vi_waiting_operator
       set_current_line('', 0) if @vi_waiting_operator == :vi_delete_meta_confirm && arg.nil?
       @vi_waiting_operator = nil
+      @vi_waiting_operator_arg = nil
     else
       @vi_waiting_operator = :vi_delete_meta_confirm
       @vi_waiting_operator_arg = arg || 1
@@ -2360,6 +2362,7 @@ class Reline::LineEditor
   private def vi_yank(key, arg: 1)
     if @vi_waiting_operator
       @vi_waiting_operator = nil
+      @vi_waiting_operator_arg = nil
     else
       @vi_waiting_operator = :vi_yank_confirm
       @vi_waiting_operator_arg = arg

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -218,8 +218,8 @@ class Reline::LineEditor
     @vi_clipboard = ''
     @vi_arg = nil
     @waiting_proc = nil
-    @waiting_operator_proc = nil
-    @waiting_operator_vi_arg = nil
+    @vi_waiting_operator = nil
+    @vi_waiting_operator_arg = nil
     @completion_journey_state = nil
     @completion_state = CompletionState::NORMAL
     @perfect_matched = nil
@@ -935,37 +935,23 @@ class Reline::LineEditor
   end
 
   private def run_for_operators(key, method_symbol, &block)
-    if @waiting_operator_proc
+    if @vi_waiting_operator
       if VI_MOTIONS.include?(method_symbol)
         old_byte_pointer = @byte_pointer
-        @vi_arg = @waiting_operator_vi_arg if @waiting_operator_vi_arg&.> 1
+        @vi_arg ||= @vi_waiting_operator_arg
         block.(true)
         unless @waiting_proc
           byte_pointer_diff = @byte_pointer - old_byte_pointer
           @byte_pointer = old_byte_pointer
-          @waiting_operator_proc.(byte_pointer_diff)
-        else
-          old_waiting_proc = @waiting_proc
-          old_waiting_operator_proc = @waiting_operator_proc
-          current_waiting_operator_proc = @waiting_operator_proc
-          @waiting_proc = proc { |k|
-            old_byte_pointer = @byte_pointer
-            old_waiting_proc.(k)
-            byte_pointer_diff = @byte_pointer - old_byte_pointer
-            @byte_pointer = old_byte_pointer
-            current_waiting_operator_proc.(byte_pointer_diff)
-            @waiting_operator_proc = old_waiting_operator_proc
-          }
+          send(@vi_waiting_operator, byte_pointer_diff)
+          cleanup_waiting
         end
       else
         # Ignores operator when not motion is given.
         block.(false)
+        cleanup_waiting
       end
-      @waiting_operator_proc = nil
-      @waiting_operator_vi_arg = nil
-      if @vi_arg
-        @vi_arg = nil
-      end
+      @vi_arg = nil
     else
       block.(false)
     end
@@ -982,7 +968,7 @@ class Reline::LineEditor
   end
 
   def wrap_method_call(method_symbol, method_obj, key, with_operator = false)
-    if @config.editing_mode_is?(:emacs, :vi_insert) and @waiting_proc.nil? and @waiting_operator_proc.nil?
+    if @config.editing_mode_is?(:emacs, :vi_insert) and @vi_waiting_operator.nil?
       not_insertion = method_symbol != :ed_insert
       process_insert(force: not_insertion)
     end
@@ -1001,16 +987,28 @@ class Reline::LineEditor
     end
   end
 
+  private def cleanup_waiting
+    @waiting_proc = nil
+    @vi_waiting_operator = nil
+    @vi_waiting_operator_arg = nil
+    @searching_prompt = nil
+    @drop_terminate_spaces = false
+  end
+
   private def process_key(key, method_symbol)
-    if @waiting_proc
-      if key.is_a?(Symbol)
-        @waiting_proc = nil
-        @searching_prompt = nil
-      else
-        @waiting_proc.call(key)
-        @kill_ring.process
-        return
+    if key.is_a?(Symbol)
+      cleanup_waiting
+    elsif @waiting_proc
+      old_byte_pointer = @byte_pointer
+      @waiting_proc.call(key)
+      if @vi_waiting_operator
+        byte_pointer_diff = @byte_pointer - old_byte_pointer
+        @byte_pointer = old_byte_pointer
+        send(@vi_waiting_operator, byte_pointer_diff)
+        cleanup_waiting
       end
+      @kill_ring.process
+      return
     end
 
     if method_symbol and respond_to?(method_symbol, true)
@@ -2322,46 +2320,59 @@ class Reline::LineEditor
     @byte_pointer = 0
   end
 
-  private def vi_change_meta(key, arg: 1)
-    @drop_terminate_spaces = true
-    @waiting_operator_proc = proc { |byte_pointer_diff|
-      if byte_pointer_diff > 0
-        line, cut = byteslice!(current_line, @byte_pointer, byte_pointer_diff)
-      elsif byte_pointer_diff < 0
-        line, cut = byteslice!(current_line, @byte_pointer + byte_pointer_diff, -byte_pointer_diff)
-      end
-      set_current_line(line)
-      copy_for_vi(cut)
-      @byte_pointer += byte_pointer_diff if byte_pointer_diff < 0
-      @config.editing_mode = :vi_insert
-      @drop_terminate_spaces = false
-    }
-    @waiting_operator_vi_arg = arg
+  private def vi_change_meta(key, arg: nil)
+    if @vi_waiting_operator
+      set_current_line('', 0) if @vi_waiting_operator == :vi_change_meta_confirm && arg.nil?
+      @vi_waiting_operator = nil
+    else
+      @drop_terminate_spaces = true
+      @vi_waiting_operator = :vi_change_meta_confirm
+      @vi_waiting_operator_arg = arg || 1
+    end
   end
 
-  private def vi_delete_meta(key, arg: 1)
-    @waiting_operator_proc = proc { |byte_pointer_diff|
-      if byte_pointer_diff > 0
-        line, cut = byteslice!(current_line, @byte_pointer, byte_pointer_diff)
-      elsif byte_pointer_diff < 0
-        line, cut = byteslice!(current_line, @byte_pointer + byte_pointer_diff, -byte_pointer_diff)
-      end
-      copy_for_vi(cut)
-      set_current_line(line || '', @byte_pointer + (byte_pointer_diff < 0 ? byte_pointer_diff : 0))
-    }
-    @waiting_operator_vi_arg = arg
+  private def vi_change_meta_confirm(byte_pointer_diff)
+    vi_delete_meta_confirm(byte_pointer_diff)
+    @config.editing_mode = :vi_insert
+    @drop_terminate_spaces = false
+  end
+
+  private def vi_delete_meta(key, arg: nil)
+    if @vi_waiting_operator
+      set_current_line('', 0) if @vi_waiting_operator == :vi_delete_meta_confirm && arg.nil?
+      @vi_waiting_operator = nil
+    else
+      @vi_waiting_operator = :vi_delete_meta_confirm
+      @vi_waiting_operator_arg = arg || 1
+    end
+  end
+
+  private def vi_delete_meta_confirm(byte_pointer_diff)
+    if byte_pointer_diff > 0
+      line, cut = byteslice!(current_line, @byte_pointer, byte_pointer_diff)
+    elsif byte_pointer_diff < 0
+      line, cut = byteslice!(current_line, @byte_pointer + byte_pointer_diff, -byte_pointer_diff)
+    end
+    copy_for_vi(cut)
+    set_current_line(line || '', @byte_pointer + (byte_pointer_diff < 0 ? byte_pointer_diff : 0))
   end
 
   private def vi_yank(key, arg: 1)
-    @waiting_operator_proc = proc { |byte_pointer_diff|
-      if byte_pointer_diff > 0
-        cut = current_line.byteslice(@byte_pointer, byte_pointer_diff)
-      elsif byte_pointer_diff < 0
-        cut = current_line.byteslice(@byte_pointer + byte_pointer_diff, -byte_pointer_diff)
-      end
-      copy_for_vi(cut)
-    }
-    @waiting_operator_vi_arg = arg
+    if @vi_waiting_operator
+      @vi_waiting_operator = nil
+    else
+      @vi_waiting_operator = :vi_yank_confirm
+      @vi_waiting_operator_arg = arg
+    end
+  end
+
+  private def vi_yank_confirm(byte_pointer_diff)
+    if byte_pointer_diff > 0
+      cut = current_line.byteslice(@byte_pointer, byte_pointer_diff)
+    elsif byte_pointer_diff < 0
+      cut = current_line.byteslice(@byte_pointer + byte_pointer_diff, -byte_pointer_diff)
+    end
+    copy_for_vi(cut)
   end
 
   private def vi_list_or_eof(key)

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -2359,13 +2359,14 @@ class Reline::LineEditor
     set_current_line(line || '', @byte_pointer + (byte_pointer_diff < 0 ? byte_pointer_diff : 0))
   end
 
-  private def vi_yank(key, arg: 1)
+  private def vi_yank(key, arg: nil)
     if @vi_waiting_operator
+      copy_for_vi(current_line) if @vi_waiting_operator == :vi_yank_confirm && arg.nil?
       @vi_waiting_operator = nil
       @vi_waiting_operator_arg = nil
     else
       @vi_waiting_operator = :vi_yank_confirm
-      @vi_waiting_operator_arg = arg
+      @vi_waiting_operator_arg = arg || 1
     end
   end
 

--- a/test/reline/test_key_actor_emacs.rb
+++ b/test/reline/test_key_actor_emacs.rb
@@ -1265,10 +1265,10 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
 
   def test_incremental_search_history_cancel_by_symbol_key
     # ed_prev_char should move cursor left and cancel incremental search
-    input_keys("abc\C-rdef")
+    input_keys("abc\C-r")
     input_key_by_symbol(:ed_prev_char)
-    input_keys("g")
-    assert_line_around_cursor('abg', 'c')
+    input_keys('d')
+    assert_line_around_cursor('abd', 'c')
   end
 
   # Unicode emoji test

--- a/test/reline/test_key_actor_emacs.rb
+++ b/test/reline/test_key_actor_emacs.rb
@@ -1263,6 +1263,14 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
     assert_line_around_cursor('', '')
   end
 
+  def test_incremental_search_history_cancel_by_symbol_key
+    # ed_prev_char should move cursor left and cancel incremental search
+    input_keys("abc\C-rdef")
+    input_key_by_symbol(:ed_prev_char)
+    input_keys("g")
+    assert_line_around_cursor('abg', 'c')
+  end
+
   # Unicode emoji test
   def test_ed_insert_for_include_zwj_emoji
     omit "This test is for UTF-8 but the locale is #{Reline.core.encoding}" if Reline.core.encoding != Encoding::UTF_8

--- a/test/reline/test_key_actor_vi.rb
+++ b/test/reline/test_key_actor_vi.rb
@@ -725,15 +725,27 @@ class Reline::KeyActor::ViInsert::Test < Reline::TestCase
     assert_line_around_cursor('foo  hog', 'e  baz')
   end
 
+  def test_vi_waiting_operator_with_waiting_proc
+    input_keys("foo foo foo foo foo\C-[0")
+    input_keys('2d3fo')
+    assert_line_around_cursor('', ' foo foo')
+    input_keys('fo')
+    assert_line_around_cursor(' f', 'oo foo')
+  end
 
   def test_vi_waiting_operator_cancel
     input_keys("aaa bbb ccc\C-[02w")
     assert_line_around_cursor('aaa bbb ', 'ccc')
     # dc dy should cancel delete_meta
+    input_keys('dch')
+    input_keys('dyh')
     # cd cy should cancel change_meta
+    input_keys('cdh')
+    input_keys('cyh')
     # yd yc should cancel yank_meta
-    # p should not paste yanked text because yank_meta is canceled
-    input_keys('dchdyhcdhcyhydhPychP')
+    # P should not paste yanked text because yank_meta is canceled
+    input_keys('ydhP')
+    input_keys('ychP')
     assert_line_around_cursor('aa', 'a bbb ccc')
   end
 

--- a/test/reline/test_key_actor_vi.rb
+++ b/test/reline/test_key_actor_vi.rb
@@ -693,14 +693,14 @@ class Reline::KeyActor::ViInsert::Test < Reline::TestCase
   end
 
   def test_vi_delete_meta_with_arg
-    input_keys("aaa bbb ccc\C-[02w")
-    assert_line_around_cursor('aaa bbb ', 'ccc')
+    input_keys("aaa bbb ccc ddd\C-[03w")
+    assert_line_around_cursor('aaa bbb ccc ', 'ddd')
     input_keys('2dl')
-    assert_line_around_cursor('aaa bbb ', 'c')
+    assert_line_around_cursor('aaa bbb ccc ', 'd')
     input_keys('d2h')
-    assert_line_around_cursor('aaa bb', 'c')
+    assert_line_around_cursor('aaa bbb cc', 'd')
     input_keys('2d3h')
-    assert_line_around_cursor('aaa', 'c')
+    assert_line_around_cursor('aaa ', 'd')
     input_keys('dd')
     assert_line_around_cursor('', '')
   end
@@ -731,10 +731,10 @@ class Reline::KeyActor::ViInsert::Test < Reline::TestCase
     assert_line_around_cursor('aaa bbb ', 'ccc')
     # dc dy should cancel delete_meta
     # cd cy should cancel change_meta
-    # yd yc yy should cancel yank_meta
+    # yd yc should cancel yank_meta
     # p should not paste yanked text because yank_meta is canceled
-    input_keys('dchdyhcdhcyhydhychyyhp')
-    assert_line_around_cursor('a', 'aa bbb ccc')
+    input_keys('dchdyhcdhcyhydhPychP')
+    assert_line_around_cursor('aa', 'a bbb ccc')
   end
 
   def test_cancel_waiting_with_symbol_key

--- a/test/reline/test_key_actor_vi.rb
+++ b/test/reline/test_key_actor_vi.rb
@@ -760,12 +760,16 @@ class Reline::KeyActor::ViInsert::Test < Reline::TestCase
   end
 
   def test_vi_yank
-    input_keys("foo bar\C-[0")
-    assert_line_around_cursor('', 'foo bar')
+    input_keys("foo bar\C-[2h")
+    assert_line_around_cursor('foo ', 'bar')
     input_keys('y3l')
-    assert_line_around_cursor('', 'foo bar')
+    assert_line_around_cursor('foo ', 'bar')
     input_keys('P')
-    assert_line_around_cursor('fo', 'ofoo bar')
+    assert_line_around_cursor('foo ba', 'rbar')
+    input_keys('3h3yhP')
+    assert_line_around_cursor('foofo', 'o barbar')
+    input_keys('yyP')
+    assert_line_around_cursor('foofofoofoo barba', 'ro barbar')
   end
 
   def test_vi_end_word_with_operator


### PR DESCRIPTION
Test will conflict with #645

Fixes #605 

## waiting_proc
Most waiting_proc will be cancelled when ARROW keys (and other symbol key) is pressed, but Reline did not implement cancel
```
# Method that uses waiting_proc and cancel when ARROW is pressed
incremental_search_history
vi_replace_char
vi_next_char
vi_to_next_char
vi_prev_char
vi_to_prev_char
# Exceptional case that readline inserts escape sequence when ARROW is pressed
ed_quoted_insert
```
Fixes except ed_quoted_insert.


## waiting_operator_proc
Vi mode's waiting_operator_proc was complex.
```
c: vi_change_meta
d: vi_delete_meta
y: vi_yank
```

Reline's problem with waiting_operator
- `df_` does not terminate delete_meta
- `dd` should clear line
- `cc` should clear line
- `dc` `dy` `cd` `cy` `yd` `yc` `yy` should cancel waiting_operator
- For `3d5h`, 5 should be used as `@vi_arg` but Reline does not
- ARROW key should cancel waiting_operator

Fixes all of them.
