### PR TITLE
Completely support full-width characters in differential rendering

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -414,8 +414,13 @@ class Reline::LineEditor
         @output.write "#{Reline::IOGate::RESET_COLOR}#{' ' * width}"
       else
         x, w, content = new_items[level]
-        content = Reline::Unicode.take_range(content, base_x - x, width) unless x == base_x && w == width
-        Reline::IOGate.move_cursor_column base_x
+        cover_begin = base_x != 0 && new_levels[base_x - 1] == level
+        cover_end = new_levels[base_x + width] == level
+        pos = 0
+        unless x == base_x && w == width
+          content, pos = Reline::Unicode.take_mbchar_range(content, base_x - x, width, cover_begin: cover_begin, cover_end: cover_end, padding: true)
+        end
+        Reline::IOGate.move_cursor_column x + pos
         @output.write "#{Reline::IOGate::RESET_COLOR}#{content}#{Reline::IOGate::RESET_COLOR}"
       end
       base_x += width
@@ -699,13 +704,6 @@ class Reline::LineEditor
 
   DIALOG_DEFAULT_HEIGHT = 20
 
-  private def padding_space_with_escape_sequences(str, width)
-    padding_width = width - calculate_width(str, true)
-    # padding_width should be only positive value. But macOS and Alacritty returns negative value.
-    padding_width = 0 if padding_width < 0
-    str + (' ' * padding_width)
-  end
-
   private def dialog_range(dialog, dialog_y)
     x_range = dialog.column...dialog.column + dialog.width
     y_range = dialog_y + dialog.vertical_offset...dialog_y + dialog.vertical_offset + dialog.contents.size
@@ -778,7 +776,7 @@ class Reline::LineEditor
     dialog.contents = contents.map.with_index do |item, i|
       line_sgr = i == pointer ? enhanced_sgr : default_sgr
       str_width = dialog.width - (scrollbar_pos.nil? ? 0 : @block_elem_width)
-      str = padding_space_with_escape_sequences(Reline::Unicode.take_range(item, 0, str_width), str_width)
+      str, = Reline::Unicode.take_mbchar_range(item, 0, str_width, padding: true)
       colored_content = "#{line_sgr}#{str}"
       if scrollbar_pos
         if scrollbar_pos <= (i * 2) and (i * 2 + 1) < (scrollbar_pos + bar_height)

--- a/test/reline/test_line_editor.rb
+++ b/test/reline/test_line_editor.rb
@@ -112,6 +112,36 @@ class Reline::LineEditor
       end
     end
 
+    def test_multibyte
+      base = [0, 12, '一二三一二三']
+      left = [0, 3, 'LLL']
+      right = [9, 3, 'RRR']
+      front = [3, 6, 'FFFFFF']
+      # 一 FFFFFF 三
+      # 一二三一二三
+      assert_output '[COL_2]二三一二' do
+        @line_editor.render_line_differential([base, front], [base, nil])
+      end
+
+      # LLLFFFFFF 三
+      # LLL 三一二三
+      assert_output '[COL_3] 三一二' do
+        @line_editor.render_line_differential([base, left, front], [base, left, nil])
+      end
+
+      # 一 FFFFFFRRR
+      # 一二三一 RRR
+      assert_output '[COL_2]二三一 ' do
+        @line_editor.render_line_differential([base, right, front], [base, right, nil])
+      end
+
+      # LLLFFFFFFRRR
+      # LLL 三一 RRR
+      assert_output '[COL_3] 三一 ' do
+        @line_editor.render_line_differential([base, left, right, front], [base, left, right, nil])
+      end
+    end
+
     def test_complicated
       state_a = [nil, [19, 7, 'bbbbbbb'], [15, 8, 'cccccccc'], [10, 5, 'ddddd'], [18, 4, 'eeee'], [1, 3, 'fff'], [17, 2, 'gg'], [7, 1, 'h']]
       state_b = [[5, 9, 'aaaaaaaaa'], nil, [15, 8, 'cccccccc'], nil, [18, 4, 'EEEE'], [25, 4, 'ffff'], [17, 2, 'gg'], [2, 2, 'hh']]

--- a/test/reline/test_unicode.rb
+++ b/test/reline/test_unicode.rb
@@ -46,8 +46,8 @@ class Reline::Unicode::Test < Reline::TestCase
   def test_take_range
     assert_equal 'cdef', Reline::Unicode.take_range('abcdefghi', 2, 4)
     assert_equal 'あde', Reline::Unicode.take_range('abあdef', 2, 4)
-    assert_equal 'zerocdef', Reline::Unicode.take_range("ab\1zero\2cdef", 2, 4)
-    assert_equal 'bzerocde', Reline::Unicode.take_range("ab\1zero\2cdef", 1, 4)
+    assert_equal "\1zero\2cdef", Reline::Unicode.take_range("ab\1zero\2cdef", 2, 4)
+    assert_equal "b\1zero\2cde", Reline::Unicode.take_range("ab\1zero\2cdef", 1, 4)
     assert_equal "\e[31mcd\e[42mef", Reline::Unicode.take_range("\e[31mabcd\e[42mefg", 2, 4)
     assert_equal "\e]0;1\acd", Reline::Unicode.take_range("ab\e]0;1\acd", 2, 3)
     assert_equal 'いう', Reline::Unicode.take_range('あいうえお', 2, 4)
@@ -66,5 +66,27 @@ class Reline::Unicode::Test < Reline::TestCase
     assert_equal 4, Reline::Unicode.calculate_width("ab\e]0;1\acd", true)
     assert_equal 10, Reline::Unicode.calculate_width('あいうえお')
     assert_equal 10, Reline::Unicode.calculate_width('あいうえお', true)
+  end
+
+  def test_take_mbchar_range
+    assert_equal ['cdef', 2, 4], Reline::Unicode.take_mbchar_range('abcdefghi', 2, 4)
+    assert_equal ['cdef', 2, 4], Reline::Unicode.take_mbchar_range('abcdefghi', 2, 4, padding: true)
+    assert_equal ['cdef', 2, 4], Reline::Unicode.take_mbchar_range('abcdefghi', 2, 4, cover_begin: true)
+    assert_equal ['cdef', 2, 4], Reline::Unicode.take_mbchar_range('abcdefghi', 2, 4, cover_end: true)
+    assert_equal ['いう', 2, 4], Reline::Unicode.take_mbchar_range('あいうえお', 2, 4)
+    assert_equal ['いう', 2, 4], Reline::Unicode.take_mbchar_range('あいうえお', 2, 4, padding: true)
+    assert_equal ['いう', 2, 4], Reline::Unicode.take_mbchar_range('あいうえお', 2, 4, cover_begin: true)
+    assert_equal ['いう', 2, 4], Reline::Unicode.take_mbchar_range('あいうえお', 2, 4, cover_end: true)
+    assert_equal ['う', 4, 2], Reline::Unicode.take_mbchar_range('あいうえお', 3, 4)
+    assert_equal [' う ', 3, 4], Reline::Unicode.take_mbchar_range('あいうえお', 3, 4, padding: true)
+    assert_equal ['いう', 2, 4], Reline::Unicode.take_mbchar_range('あいうえお', 3, 4, cover_begin: true)
+    assert_equal ['うえ', 4, 4], Reline::Unicode.take_mbchar_range('あいうえお', 3, 4, cover_end: true)
+    assert_equal ['いう ', 2, 5], Reline::Unicode.take_mbchar_range('あいうえお', 3, 4, cover_begin: true, padding: true)
+    assert_equal [' うえ', 3, 5], Reline::Unicode.take_mbchar_range('あいうえお', 3, 4, cover_end: true, padding: true)
+    assert_equal [' うえお   ', 3, 10], Reline::Unicode.take_mbchar_range('あいうえお', 3, 10, padding: true)
+    assert_equal [" \e[41mうえお\e[0m   ", 3, 10], Reline::Unicode.take_mbchar_range("あい\e[41mうえお", 3, 10, padding: true)
+    assert_equal ["\e[41m \e[42mい\e[43m ", 1, 4], Reline::Unicode.take_mbchar_range("\e[41mあ\e[42mい\e[43mう", 1, 4, padding: true)
+    assert_equal ["\e[31mc\1ABC\2d\e[0mef", 2, 4], Reline::Unicode.take_mbchar_range("\e[31mabc\1ABC\2d\e[0mefghi", 2, 4)
+    assert_equal ["\e[41m \e[42mい\e[43m ", 1, 4], Reline::Unicode.take_mbchar_range("\e[41mあ\e[42mい\e[43mう", 1, 4, padding: true)
   end
 end


### PR DESCRIPTION
When dialog is cleared, we need to restore the text that was hidden behind dialogs.

To implement restoring full width characters hidden behind dialog, `Reline::Unicode.take_range` lacks of feature.
It does not provide where to render the string. column information is missing.
```ruby
Reline::Unicode.take_range('一二三四五a', 2, 5) #=> '二三' # should render at column=2
Reline::Unicode.take_range('a一二三四五', 2, 5) #=> '二三' # should render at column=3
```

Sometimes we need other cut variation depending on adjacent dialog position.
The image below shows a variation of `take_range('一二三四五六七八九', 5, 8, option)`
<img width="391" alt="dialog_restore" src="https://user-images.githubusercontent.com/1780201/225972452-f60df623-ba68-442d-b4c4-544d481b1534.png">


So I add `Reline::Unicode.take_mbchar_range` that has option `cover_begin, cover_end, padding` and make it return the actual cut position.
```ruby
take_mbchar_range('一二三', 1, 4) #=> ['二', 2, 2]
take_mbchar_range('一二三', 1, 4, cover_begin: true) #=> ['一二', 0, 4]
take_mbchar_range('一二三', 1, 4, cover_end: true) #=> ['二三', 2, 4]
take_mbchar_range('一二三', 1, 4, padding: true) #=> [' 二 ', 1, 4]
take_mbchar_range('一二三', 1, 4, cover_begin: true, padding: true) #=> ['一二 ', 0, 5]
take_mbchar_range('一二三', 1, 4, cover_end: true, padding: true) #=> [' 二三', 1, 5]

# Padding space can have different background color
take_mbchar_range("#{RED_BACKGROUND}一#{BLUE_BACKGROUND}二#{GREEN_BACKGROUND}三", 1, 4, padding: true)
#=> "#{RED_BACKGROUND} #{BLUE_BACKGROUND}二#{GREEN_BACKGROUND} "