### PR TITLE
Implement bracketed paste insert

### DIFF
--- a/lib/reline/config.rb
+++ b/lib/reline/config.rb
@@ -70,6 +70,7 @@ class Reline::Config
     @autocompletion = false
     @convert_meta = true if seven_bit_encoding?(Reline::IOGate.encoding)
     @loaded = false
+    @enable_bracketed_paste = true
   end
 
   def reset

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -284,7 +284,7 @@ class Reline::LineEditor
           indent1 = @auto_indent_proc.(@buffer_of_lines.take(@line_index - 1).push(''), @line_index - 1, 0, true)
           indent2 = @auto_indent_proc.(@buffer_of_lines.take(@line_index), @line_index - 1, @buffer_of_lines[@line_index - 1].bytesize, false)
           indent = indent2 || indent1
-          @buffer_of_lines[@line_index - 1] = ' ' * indent + @buffer_of_lines[@line_index - 1].gsub(/\A */, '')
+          @buffer_of_lines[@line_index - 1] = ' ' * indent + @buffer_of_lines[@line_index - 1].gsub(/\A\s*/, '')
         )
         process_auto_indent @line_index, add_newline: true
       else
@@ -1329,6 +1329,16 @@ class Reline::LineEditor
   def confirm_multiline_termination
     temp_buffer = @buffer_of_lines.dup
     @confirm_multiline_termination_proc.(temp_buffer.join("\n") + "\n")
+  end
+
+  def insert_pasted_text(text)
+    pre = @buffer_of_lines[@line_index].byteslice(0, @byte_pointer)
+    post = @buffer_of_lines[@line_index].byteslice(@byte_pointer..)
+    lines = (pre + text.gsub(/\r\n?/, "\n") + post).split("\n", -1)
+    lines << '' if lines.empty?
+    @buffer_of_lines[@line_index, 1] = lines
+    @line_index += lines.size - 1
+    @byte_pointer = @buffer_of_lines[@line_index].bytesize - post.bytesize
   end
 
   def insert_text(text)

--- a/lib/reline/unicode.rb
+++ b/lib/reline/unicode.rb
@@ -43,11 +43,13 @@ class Reline::Unicode
 
   def self.escape_for_print(str)
     str.chars.map! { |gr|
-      escaped = EscapedPairs[gr.ord]
-      if escaped && gr != -"\n" && gr != -"\t"
-        escaped
-      else
+      case gr
+      when -"\n"
         gr
+      when -"\t"
+        -'  '
+      else
+        EscapedPairs[gr.ord] || gr
       end
     }.join
   end

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -543,15 +543,10 @@ begin
       EOC
     end
 
-    def test_enable_bracketed_paste
+    def test_bracketed_paste
       omit if Reline.core.io_gate.win?
-      write_inputrc <<~LINES
-        set enable-bracketed-paste on
-      LINES
       start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
-      write("\e[200~,")
-      write("def hoge\n  3\nend")
-      write("\e[200~.")
+      write("\e[200~def hoge\r\t3\rend\e[201~")
       close
       assert_screen(<<~EOC)
         Multiline REPL.


### PR DESCRIPTION
Closes #631
## Description
Implemented bracketed paste. Directly inserts pasted text.

This will speedup paste (1100 lines in 8sec → 2600 lines in 8sec)
Stops tab-complete while pasting code that includes tab
Code using tab indentation can be pasted to reline

## Bracketed paste implementation
Reline had a code for bracketed paste but it seems not working.
(Escape sequence for bracketed paste start and end was also wrong)
```
irb(main):001> puts "\e[?2004h";gets
(paste text `text` here and press enter)
^[[200~text^[[201~
=> "\e[200~text\e[201~\n" # this is the correct start and end sequence
```

## Readline compatibility
Readline(>= 8.1) enables bracketed paste by default. `set enable-bracketed-paste off` will disable it.
Readline accepts bracketed paste input `"\e[200~text\e[201~"` even if it's disabled in inputrc.

## inputrc read
Changed inputrc read timing. Reline should read inputrc before `io_gate.prep`
