### PR TITLE
Add mode_string to prompt calculation dependencies

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -85,7 +85,7 @@ class Reline::LineEditor
     end
   end
 
-  private def check_multiline_prompt(buffer)
+  private def check_multiline_prompt(buffer, mode_string)
     if @vi_arg
       prompt = "(arg: #{@vi_arg}) "
     elsif @searching_prompt
@@ -97,7 +97,6 @@ class Reline::LineEditor
       prompt_list = @prompt_proc.(buffer).map { |pr| pr.gsub("\n", "\\n") }
       prompt_list.map!{ prompt } if @vi_arg or @searching_prompt
       prompt_list = [prompt] if prompt_list.empty?
-      mode_string = check_mode_string
       prompt_list = prompt_list.map{ |pr| mode_string + pr } if mode_string
       prompt = prompt_list[@line_index]
       prompt = prompt_list[0] if prompt.nil?
@@ -109,7 +108,6 @@ class Reline::LineEditor
       end
       prompt_list
     else
-      mode_string = check_mode_string
       prompt = mode_string + prompt if mode_string
       [prompt] * buffer.size
     end
@@ -319,8 +317,8 @@ class Reline::LineEditor
   end
 
   def prompt_list
-    with_cache(__method__, whole_lines, @vi_arg, @searching_prompt) do |lines|
-      check_multiline_prompt(lines)
+    with_cache(__method__, whole_lines, check_mode_string, @vi_arg, @searching_prompt) do |lines, mode_string|
+      check_multiline_prompt(lines, mode_string)
     end
   end
 

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -197,9 +197,12 @@ begin
       LINES
       start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write(":a\n\C-[k")
+      write("i\n:a")
+      write("\C-[h")
       close
       assert_screen(<<~EOC)
-        Multiline REPL.
+        (ins)prompt> :a
+        => :a
         (ins)prompt> :a
         => :a
         (cmd)prompt> :a


### PR DESCRIPTION
`show-mode-in-prompt` was broken in v0.5.0.pre.1

Fixes it by adding prompt_mode to prompt list calculation dependencies.

To enable `show-mode-in-prompt`, add this to `.inputrc`
```
set editing-mode vi
set show-mode-in-prompt on
set vi-ins-mode-string (ins)
set vi-cmd-mode-string (cmd)
```