### PR TITLE
Change Reline::ANSI to a general io

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -264,7 +264,6 @@ module Reline
           raise ArgumentError.new('#readmultiline needs block to confirm multiline termination')
         end
 
-        Reline.update_iogate
         io_gate.with_raw_input do
           inner_readline(prompt, add_hist, true, &confirm_multiline_termination)
         end
@@ -287,7 +286,6 @@ module Reline
 
     def readline(prompt = '', add_hist = false)
       @mutex.synchronize do
-        Reline.update_iogate
         io_gate.with_raw_input do
           inner_readline(prompt, add_hist, false)
         end
@@ -474,7 +472,7 @@ module Reline
     end
 
     private def may_req_ambiguous_char_width
-      @ambiguous_width = 2 if io_gate.dumb? or !STDOUT.tty?
+      @ambiguous_width = 2 if io_gate.dumb? || !STDIN.tty? || !STDOUT.tty?
       return if defined? @ambiguous_width
       io_gate.move_cursor_column(0)
       begin
@@ -567,18 +565,6 @@ module Reline
 
   def self.line_editor
     core.line_editor
-  end
-
-  def self.update_iogate
-    return if core.config.test_mode
-
-    # Need to change IOGate when `$stdout.tty?` change from false to true by `$stdout.reopen`
-    # Example: rails/spring boot the application in non-tty, then run console in tty.
-    if ENV['TERM'] != 'dumb' && core.io_gate.dumb? && $stdout.tty?
-      require 'reline/io/ansi'
-      remove_const(:IOGate)
-      const_set(:IOGate, Reline::ANSI.new)
-    end
   end
 end
 

--- a/lib/reline/io.rb
+++ b/lib/reline/io.rb
@@ -19,11 +19,7 @@ module Reline
             io
           end
         else
-          if $stdout.tty?
-            Reline::ANSI.new
-          else
-            Reline::Dumb.new
-          end
+          Reline::ANSI.new
         end
       end
     end

--- a/lib/reline/io/ansi.rb
+++ b/lib/reline/io/ansi.rb
@@ -174,11 +174,9 @@ class Reline::ANSI < Reline::IO
       Reline.core.line_editor.handle_signal
     end
     c = @input.getbyte
-    (c == 0x16 && @input.raw(min: 0, time: 0, &:getbyte)) || c
+    (c == 0x16 && @input.tty? && @input.raw(min: 0, time: 0, &:getbyte)) || c
   rescue Errno::EIO
     # Maybe the I/O has been closed.
-    nil
-  rescue Errno::ENOTTY
     nil
   end
 
@@ -239,12 +237,12 @@ class Reline::ANSI < Reline::IO
   def set_screen_size(rows, columns)
     @input.winsize = [rows, columns]
     self
-  rescue Errno::ENOTTY
+  rescue Errno::ENOTTY, Errno::ENODEV
     self
   end
 
   def cursor_pos
-    begin
+    if @input.tty? && @output.tty?
       res = +''
       m = nil
       @input.raw do |stdin|
@@ -263,7 +261,7 @@ class Reline::ANSI < Reline::IO
       end
       column = m[:column].to_i - 1
       row = m[:row].to_i - 1
-    rescue Errno::ENOTTY
+    else
       begin
         buf = @output.pread(@output.pos, 0)
         row = buf.count("\n")

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -969,6 +969,18 @@ begin
       EOC
     end
 
+    def test_nontty
+      omit if Reline.core.io_gate.win?
+      cmd = %Q{ruby -e 'puts(%Q{ello\C-ah\C-e})' | ruby -I#{@pwd}/lib -rreline -e 'p Reline.readline(%{> })' | ruby -e 'print STDIN.read'}
+      start_terminal(40, 50, ['bash', '-c', cmd])
+      sleep 1
+      close rescue nil
+      assert_screen(<<~'EOC')
+        > hello
+        "hello"
+      EOC
+    end
+
     def test_eof_with_newline
       omit if Reline.core.io_gate.win?
       cmd = %Q{ruby -e 'print(%Q{abc def \\e\\r})' | ruby -I#{@pwd}/lib -rreline -e 'p Reline.readline(%{> })'}


### PR DESCRIPTION
Fixes #537, #616 and #690, the behavior will be more similar to Readline's behavior.

`Reline::ANSI` already partially supports non-tty env, but not fully. This pull request changes `Reline::ANSI` to a general io that supports both tty and non-tty environment.
This pull request will change to always use Reline::ANSI. `Reline::Dumb` is only used for testing when TERM=dumb is set.
