### PR TITLE
Do not send color reset sequence when GeneralIO is used

### DIFF
--- a/lib/reline/ansi.rb
+++ b/lib/reline/ansi.rb
@@ -3,6 +3,8 @@ require 'io/wait'
 require_relative 'terminfo'
 
 class Reline::ANSI
+  RESET_COLOR = "\e[0m"
+
   CAPNAME_KEY_BINDINGS = {
     'khome' => :ed_move_to_beg,
     'kend'  => :ed_move_to_end,

--- a/lib/reline/general_io.rb
+++ b/lib/reline/general_io.rb
@@ -1,6 +1,8 @@
 require 'io/wait'
 
 class Reline::GeneralIO
+  RESET_COLOR = '' # Do not send color reset sequence
+
   def self.reset(encoding: nil)
     @@pasting = false
     if encoding

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -372,12 +372,12 @@ class Reline::LineEditor
         # do nothing
       elsif level == :blank
         Reline::IOGate.move_cursor_column base_x
-        @output.write "\e[0m#{' ' * width}"
+        @output.write "#{Reline::IOGate::RESET_COLOR}#{' ' * width}"
       else
         x, w, content = new_items[level]
         content = Reline::Unicode.take_range(content, base_x - x, width) unless x == base_x && w == width
         Reline::IOGate.move_cursor_column base_x
-        @output.write "\e[0m#{content}\e[0m"
+        @output.write "#{Reline::IOGate::RESET_COLOR}#{content}#{Reline::IOGate::RESET_COLOR}"
       end
       base_x += width
     end

--- a/lib/reline/windows.rb
+++ b/lib/reline/windows.rb
@@ -1,6 +1,8 @@
 require 'fiddle/import'
 
 class Reline::Windows
+  RESET_COLOR = "\e[0m"
+
   def self.encoding
     Encoding::UTF_8
   end

--- a/test/reline/test_line_editor.rb
+++ b/test/reline/test_line_editor.rb
@@ -4,6 +4,18 @@ require 'stringio'
 
 class Reline::LineEditor
   class RenderLineDifferentialTest < Reline::TestCase
+    module TestIO
+      RESET_COLOR = "\e[0m"
+
+      def self.move_cursor_column(col)
+        @output << "[COL_#{col}]"
+      end
+
+      def self.erase_after_cursor
+        @output << '[ERASE]'
+      end
+    end
+
     def setup
       verbose, $VERBOSE = $VERBOSE, nil
       @line_editor = Reline::LineEditor.new(nil, Encoding::UTF_8)
@@ -12,14 +24,8 @@ class Reline::LineEditor
       @line_editor.instance_variable_set(:@screen_size, [24, 80])
       @line_editor.instance_variable_set(:@output, @output)
       Reline.send(:remove_const, :IOGate)
-      Reline.const_set(:IOGate, Object.new)
+      Reline.const_set(:IOGate, TestIO)
       Reline::IOGate.instance_variable_set(:@output, @output)
-      def (Reline::IOGate).move_cursor_column(col)
-        @output << "[COL_#{col}]"
-      end
-      def (Reline::IOGate).erase_after_cursor
-        @output << '[ERASE]'
-      end
     ensure
       $VERBOSE = verbose
     end


### PR DESCRIPTION
Reline didn't send ansi color sequence before if TERM=dumb, but now it sends color reset sequence `"\e[0m"`.

Fixing this, IRB does not need to remove `"\e[0m" from output in integration test.
