### PR TITLE
Make mutated string in yamatanooroti explicitly mutable

### DIFF
--- a/test/reline/yamatanooroti/multiline_repl
+++ b/test/reline/yamatanooroti/multiline_repl
@@ -183,7 +183,7 @@ opt.on('--autocomplete-long') {
 opt.on('--autocomplete-super-long') {
   Reline.autocompletion = true
   Reline.completion_proc = lambda { |target, preposing = nil, postposing = nil|
-    c = 'A'
+    c = +'A'
     2000.times.map{ s = "Str_#{c}"; c.succ!; s }.select{ |c| c.start_with?(target) }
   }
 }


### PR DESCRIPTION
This avoids the frozen literal warning in Ruby 3.4.