### PR TITLE
Disable dialog proc if TERM=dumb

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -331,8 +331,10 @@ module Reline
       line_editor.auto_indent_proc = auto_indent_proc
       line_editor.dig_perfect_match_proc = dig_perfect_match_proc
       pre_input_hook&.call
-      @dialog_proc_list.each_pair do |name_sym, d|
-        line_editor.add_dialog_proc(name_sym, d.dialog_proc, d.context)
+      unless Reline::IOGate == Reline::GeneralIO
+        @dialog_proc_list.each_pair do |name_sym, d|
+          line_editor.add_dialog_proc(name_sym, d.dialog_proc, d.context)
+        end
       end
 
       unless config.test_mode


### PR DESCRIPTION
When TERM=dumb (test-mode), escape sequence of completion dialog is printed. Reline didn't print it in `ver <= 0.4.2`.
This pull request disables adding dialog when TERM=dumb to make the test-mode difference between Reline versions.

This why TERM=dumb completion dialog was disabled in Reline < 0.4.2
```ruby
class Reline::GeneralIO
  def self.get_screen_size
    [1, 1] # Rendering dialog is skipped because there is no space to render completion dialog
  end
end
```
In master branch, using `screen_size=[1,1]` is not suitable for testing. Using screen_size=[1,1] in master branch will be
```
$ TERM=dumb irb
i
```
Printing only one character to make the output fit in [1,1] is an expected behavior. (I'm not sure printing `i` is correct)