### PR TITLE
Remove useless pasting tests

### DIFF
--- a/lib/reline/general_io.rb
+++ b/lib/reline/general_io.rb
@@ -102,14 +102,6 @@ class Reline::GeneralIO
     @@pasting
   end
 
-  def self.start_pasting
-    @@pasting = true
-  end
-
-  def self.finish_pasting
-    @@pasting = false
-  end
-
   def self.prep
   end
 

--- a/test/reline/helper.rb
+++ b/test/reline/helper.rb
@@ -78,14 +78,6 @@ module Reline
   end
 end
 
-def start_pasting
-  Reline::GeneralIO.start_pasting
-end
-
-def finish_pasting
-  Reline::GeneralIO.finish_pasting
-end
-
 class Reline::TestCase < Test::Unit::TestCase
   private def convert_str(input, options = {}, normalized = nil)
     return nil if input.nil?

--- a/test/reline/test_key_actor_vi.rb
+++ b/test/reline/test_key_actor_vi.rb
@@ -764,22 +764,6 @@ class Reline::KeyActor::ViInsert::Test < Reline::TestCase
     assert_line_around_cursor('', 'bar')
   end
 
-  def test_pasting
-    start_pasting
-    input_keys('ab')
-    finish_pasting
-    input_keys('c')
-    assert_line_around_cursor('abc', '')
-  end
-
-  def test_pasting_fullwidth
-    start_pasting
-    input_keys('あ')
-    finish_pasting
-    input_keys('い')
-    assert_line_around_cursor('あい', '')
-  end
-
   def test_ed_delete_next_char_at_eol
     input_keys('"あ"')
     assert_line_around_cursor('"あ"', '')


### PR DESCRIPTION
The pasting tests hadn't been working since as early as v0.2.0 (iit passes regardless the pasting state). Since what it tried to cover is already gone for such a long time, I think it's better to write new ones if needed then to keep them around.

And since these tests are gone, the helper methods for just them are also gone.