### PR TITLE
Always call finalize and deprep

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -365,19 +365,10 @@ module Reline
         io_gate.move_cursor_column(0)
       rescue Errno::EIO
         # Maybe the I/O has been closed.
-      rescue StandardError => e
+      ensure
         line_editor.finalize
         io_gate.deprep(otio)
-        raise e
-      rescue Exception
-        # Including Interrupt
-        line_editor.finalize
-        io_gate.deprep(otio)
-        raise
       end
-
-      line_editor.finalize
-      io_gate.deprep(otio)
     end
 
     # GNU Readline waits for "keyseq-timeout" milliseconds to see if the ESC


### PR DESCRIPTION
We should use ensure to ensure `finalize` and `deprep` always called.
If we don't use ensure, these cleanup can be skipped if `->{return}.call` or `throw` is used.

This seems to reduce SystemStackError of #667
But does not solve it. `ruby -Ilib -rreline -e "Thread.new{p Reline.readline'>'};sleep 0.1; p Reline.readline'>'` still raise SystemStackError