### PR TITLE
Input with eof and no newline bugfix

### DIFF
--- a/lib/reline/ansi.rb
+++ b/lib/reline/ansi.rb
@@ -278,7 +278,7 @@ class Reline::ANSI
         buf = @@output.pread(@@output.pos, 0)
         row = buf.count("\n")
         column = buf.rindex("\n") ? (buf.size - buf.rindex("\n")) - 1 : 0
-      rescue Errno::ESPIPE
+      rescue Errno::ESPIPE, IOError
         # Just returns column 1 for ambiguous width because this I/O is not
         # tty and can't seek.
         row = 0

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -1110,6 +1110,7 @@ class Reline::LineEditor
       end
     end
     if key.char.nil?
+      process_insert(force: true)
       if @first_char
         @eof = true
       end

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -916,15 +916,27 @@ begin
       EOC
     end
 
-    def test_with_newline
+    def test_eof_with_newline
       omit if Reline.core.io_gate.win?
       cmd = %Q{ruby -e 'print(%Q{abc def \\e\\r})' | ruby -I#{@pwd}/lib -rreline -e 'p Reline.readline(%{> })'}
       start_terminal(40, 50, ['bash', '-c', cmd])
       sleep 1
-      close
+      close rescue nil
       assert_screen(<<~'EOC')
         > abc def
         "abc def "
+      EOC
+    end
+
+    def test_eof_without_newline
+      omit if Reline.core.io_gate.win?
+      cmd = %Q{ruby -e 'print(%{hello})' | ruby -I#{@pwd}/lib -rreline -e 'p Reline.readline(%{> })'}
+      start_terminal(40, 50, ['bash', '-c', cmd])
+      sleep 1
+      close rescue nil
+      assert_screen(<<~'EOC')
+        > hello
+        "hello"
       EOC
     end
 


### PR DESCRIPTION
Fix the bug below
```
# with readline-ext
$ printf "hello" | ruby -rreadline -e "p Readline.readline('>')"
>hello
"hello"

# with Reline master
$ printf "hello" | ruby -Ilib -rreline -e "p Reline.readline('>')"
>
""
```

The string `"hello"` is stored in `@continuous_insertion_buffer`, need to force input before finishing read.

In some environment (in my M2 Mac), `pread` raises IOError, so `rescue Errno::ESPIPE, IOError` change in `ansi.rb` is needed to test it.