### PR TITLE
Support `menu-complete-backward` command for upward navigation

### DIFF
--- a/test/reline/test_key_actor_emacs.rb
+++ b/test/reline/test_key_actor_emacs.rb
@@ -789,6 +789,52 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
     assert_line_around_cursor('foo_ba', '')
   end
 
+  def test_autocompletion_with_upward_navigation
+    @config.autocompletion = true
+    @line_editor.completion_proc = proc { |word|
+      %w{
+        Readline
+        Regexp
+        RegexpError
+      }.map { |i|
+        i.encode(@encoding)
+      }
+    }
+    input_keys('Re')
+    assert_line_around_cursor('Re', '')
+    input_keys("\C-i", false)
+    assert_line_around_cursor('Readline', '')
+    input_keys("\C-i", false)
+    assert_line_around_cursor('Regexp', '')
+    @line_editor.input_key(Reline::Key.new(:completion_journey_up, :completion_journey_up, false))
+    assert_line_around_cursor('Readline', '')
+  ensure
+    @config.autocompletion = false
+  end
+
+  def test_autocompletion_with_upward_navigation_and_menu_complete_backward
+    @config.autocompletion = true
+    @line_editor.completion_proc = proc { |word|
+      %w{
+        Readline
+        Regexp
+        RegexpError
+      }.map { |i|
+        i.encode(@encoding)
+      }
+    }
+    input_keys('Re')
+    assert_line_around_cursor('Re', '')
+    input_keys("\C-i", false)
+    assert_line_around_cursor('Readline', '')
+    input_keys("\C-i", false)
+    assert_line_around_cursor('Regexp', '')
+    @line_editor.input_key(Reline::Key.new(:menu_complete_backward, :menu_complete_backward, false))
+    assert_line_around_cursor('Readline', '')
+  ensure
+    @config.autocompletion = false
+  end
+
   def test_completion_with_indent
     @line_editor.completion_proc = proc { |word|
       %w{

--- a/test/reline/test_key_actor_vi.rb
+++ b/test/reline/test_key_actor_vi.rb
@@ -627,6 +627,52 @@ class Reline::KeyActor::ViInsert::Test < Reline::TestCase
     assert_line_around_cursor('foo_bar', '')
   end
 
+  def test_autocompletion_with_upward_navigation
+    @config.autocompletion = true
+    @line_editor.completion_proc = proc { |word|
+      %w{
+        Readline
+        Regexp
+        RegexpError
+      }.map { |i|
+        i.encode(@encoding)
+      }
+    }
+    input_keys('Re')
+    assert_line_around_cursor('Re', '')
+    input_keys("\C-i", false)
+    assert_line_around_cursor('Readline', '')
+    input_keys("\C-i", false)
+    assert_line_around_cursor('Regexp', '')
+    @line_editor.input_key(Reline::Key.new(:completion_journey_up, :completion_journey_up, false))
+    assert_line_around_cursor('Readline', '')
+  ensure
+    @config.autocompletion = false
+  end
+
+  def test_autocompletion_with_upward_navigation_and_menu_complete_backward
+    @config.autocompletion = true
+    @line_editor.completion_proc = proc { |word|
+      %w{
+        Readline
+        Regexp
+        RegexpError
+      }.map { |i|
+        i.encode(@encoding)
+      }
+    }
+    input_keys('Re')
+    assert_line_around_cursor('Re', '')
+    input_keys("\C-i", false)
+    assert_line_around_cursor('Readline', '')
+    input_keys("\C-i", false)
+    assert_line_around_cursor('Regexp', '')
+    @line_editor.input_key(Reline::Key.new(:menu_complete_backward, :menu_complete_backward, false))
+    assert_line_around_cursor('Readline', '')
+  ensure
+    @config.autocompletion = false
+  end
+
   def test_completion_with_disable_completion
     @config.disable_completion = true
     @line_editor.completion_proc = proc { |word|


### PR DESCRIPTION
Fixes #675

This commit extracts the upward navigation condition in `LineEditor#input_key` to a new private method, and adds a new alias. This change allows Reline to support upward navigation in when a user has configured `inputrc` to map Shift-Tab to `menu-complete-backward`, a common setting in Bash (>= 4.x).

Instead of special-casing upward navigation in `LineEditor#input_key`, we now allow it to be processed by the branch that calls `process_key`. The extracted method no longer includes the editing mode check since this check is already made by `#wrap_method_call` by the time `#completion_journey_up` (or `#menu_complete_backward`) is called. Since upward navigation is happening in a method other than `#input_key` now, the `completion_occurs` variable that used to be local to `#input_key` is changed to an instance variable so that the new method can change its value. (I see many examples of mutating such instance variables in `LineEditor`, so I assumed this would be an uncontroversial change consistent with the coding practices already in place.)

Test coverage of this change has been added to the emacs and vi `KeyActor` tests. (They are a bit wordy, so I could try to DRY them up if it matters to y'all.)

Many thanks to @ima1zumi for their very helpful comments on #675 which encouraged me to contribute this work!