### PR TITLE
Refactored Default Key Bindings

### DIFF
--- a/lib/reline/key_actor/emacs.rb
+++ b/lib/reline/key_actor/emacs.rb
@@ -49,7 +49,7 @@ class Reline::KeyActor::Emacs < Reline::KeyActor::Base
     #  23 ^W
     :em_kill_region,
     #  24 ^X
-    :ed_sequence_lead_in,
+    :ed_unassigned,
     #  25 ^Y
     :em_yank,
     #  26 ^Z
@@ -319,7 +319,7 @@ class Reline::KeyActor::Emacs < Reline::KeyActor::Base
     # 158 M-^^
     :ed_unassigned,
     # 159 M-^_
-    :em_copy_prev_word,
+    :ed_unassigned,
     # 160 M-SPACE
     :em_set_mark,
     # 161 M-!
@@ -415,7 +415,7 @@ class Reline::KeyActor::Emacs < Reline::KeyActor::Base
     # 206 M-N
     :vi_search_next,
     # 207 M-O
-    :ed_sequence_lead_in,
+    :ed_unassigned,
     # 208 M-P
     :vi_search_prev,
     # 209 M-Q
@@ -431,15 +431,15 @@ class Reline::KeyActor::Emacs < Reline::KeyActor::Base
     # 214 M-V
     :ed_unassigned,
     # 215 M-W
-    :em_copy_region,
+    :ed_unassigned,
     # 216 M-X
-    :ed_command,
+    :ed_unassigned,
     # 217 M-Y
     :em_yank_pop,
     # 218 M-Z
     :ed_unassigned,
     # 219 M-[
-    :ed_sequence_lead_in,
+    :ed_unassigned,
     # 220 M-\
     :ed_unassigned,
     # 221 M-]
@@ -495,9 +495,9 @@ class Reline::KeyActor::Emacs < Reline::KeyActor::Base
     # 246 M-v
     :ed_unassigned,
     # 247 M-w
-    :em_copy_region,
+    :ed_unassigned,
     # 248 M-x
-    :ed_command,
+    :ed_unassigned,
     # 249 M-y
     :ed_unassigned,
     # 250 M-z

--- a/lib/reline/key_actor/emacs.rb
+++ b/lib/reline/key_actor/emacs.rb
@@ -321,7 +321,7 @@ class Reline::KeyActor::Emacs < Reline::KeyActor::Base
     # 159 M-^_
     :em_copy_prev_word,
     # 160 M-SPACE
-    :ed_unassigned,
+    :em_set_mark,
     # 161 M-!
     :ed_unassigned,
     # 162 M-"
@@ -435,7 +435,7 @@ class Reline::KeyActor::Emacs < Reline::KeyActor::Base
     # 216 M-X
     :ed_command,
     # 217 M-Y
-    :ed_unassigned,
+    :em_yank_pop,
     # 218 M-Z
     :ed_unassigned,
     # 219 M-[

--- a/lib/reline/key_actor/vi_command.rb
+++ b/lib/reline/key_actor/vi_command.rb
@@ -17,7 +17,7 @@ class Reline::KeyActor::ViCommand < Reline::KeyActor::Base
     #   7 ^G
     :ed_unassigned,
     #   8 ^H
-    :ed_unassigned,
+    :ed_prev_char,
     #   9 ^I
     :ed_unassigned,
     #  10 ^J
@@ -41,7 +41,7 @@ class Reline::KeyActor::ViCommand < Reline::KeyActor::Base
     #  19 ^S
     :ed_ignore,
     #  20 ^T
-    :ed_unassigned,
+    :ed_transpose_chars,
     #  21 ^U
     :vi_kill_line_prev,
     #  22 ^V
@@ -51,7 +51,7 @@ class Reline::KeyActor::ViCommand < Reline::KeyActor::Base
     #  24 ^X
     :ed_unassigned,
     #  25 ^Y
-    :ed_unassigned,
+    :em_yank,
     #  26 ^Z
     :ed_unassigned,
     #  27 ^[
@@ -255,7 +255,7 @@ class Reline::KeyActor::ViCommand < Reline::KeyActor::Base
     # 126 ~
     :vi_change_case,
     # 127 ^?
-    :ed_unassigned,
+    :em_delete_prev_char,
     # 128 M-^@
     :ed_unassigned,
     # 129 M-^A

--- a/lib/reline/key_actor/vi_command.rb
+++ b/lib/reline/key_actor/vi_command.rb
@@ -75,7 +75,7 @@ class Reline::KeyActor::ViCommand < Reline::KeyActor::Base
     #  36 $
     :ed_move_to_end,
     #  37 %
-    :vi_match,
+    :ed_unassigned,
     #  38 &
     :ed_unassigned,
     #  39 '
@@ -89,11 +89,11 @@ class Reline::KeyActor::ViCommand < Reline::KeyActor::Base
     #  43 +
     :ed_next_history,
     #  44 ,
-    :vi_repeat_prev_char,
+    :ed_unassigned,
     #  45 -
     :ed_prev_history,
     #  46 .
-    :vi_redo,
+    :ed_unassigned,
     #  47 /
     :vi_search_prev,
     #  48 0
@@ -117,9 +117,9 @@ class Reline::KeyActor::ViCommand < Reline::KeyActor::Base
     #  57 9
     :ed_argument_digit,
     #  58 :
-    :ed_command,
+    :ed_unassigned,
     #  59 ;
-    :vi_repeat_next_char,
+    :ed_unassigned,
     #  60 <
     :ed_unassigned,
     #  61 =
@@ -157,21 +157,21 @@ class Reline::KeyActor::ViCommand < Reline::KeyActor::Base
     #  77 M
     :ed_unassigned,
     #  78 N
-    :vi_repeat_search_prev,
+    :ed_unassigned,
     #  79 O
-    :ed_sequence_lead_in,
+    :ed_unassigned,
     #  80 P
     :vi_paste_prev,
     #  81 Q
     :ed_unassigned,
     #  82 R
-    :vi_replace_mode,
+    :ed_unassigned,
     #  83 S
-    :vi_substitute_line,
+    :ed_unassigned,
     #  84 T
     :vi_to_prev_char,
     #  85 U
-    :vi_undo_line,
+    :ed_unassigned,
     #  86 V
     :ed_unassigned,
     #  87 W
@@ -179,11 +179,11 @@ class Reline::KeyActor::ViCommand < Reline::KeyActor::Base
     #  88 X
     :ed_delete_prev_char,
     #  89 Y
-    :vi_yank_end,
+    :ed_unassigned,
     #  90 Z
     :ed_unassigned,
     #  91 [
-    :ed_sequence_lead_in,
+    :ed_unassigned,
     #  92 \
     :ed_unassigned,
     #  93 ]
@@ -191,7 +191,7 @@ class Reline::KeyActor::ViCommand < Reline::KeyActor::Base
     #  94 ^
     :vi_first_print,
     #  95 _
-    :vi_history_word,
+    :ed_unassigned,
     #  96 `
     :ed_unassigned,
     #  97 a
@@ -221,7 +221,7 @@ class Reline::KeyActor::ViCommand < Reline::KeyActor::Base
     # 109 m
     :ed_unassigned,
     # 110 n
-    :vi_repeat_search_next,
+    :ed_unassigned,
     # 111 o
     :ed_unassigned,
     # 112 p
@@ -231,11 +231,11 @@ class Reline::KeyActor::ViCommand < Reline::KeyActor::Base
     # 114 r
     :vi_replace_char,
     # 115 s
-    :vi_substitute_char,
+    :ed_unassigned,
     # 116 t
     :vi_to_next_char,
     # 117 u
-    :vi_undo,
+    :ed_unassigned,
     # 118 v
     :vi_histedit,
     # 119 w
@@ -253,7 +253,7 @@ class Reline::KeyActor::ViCommand < Reline::KeyActor::Base
     # 125 }
     :ed_unassigned,
     # 126 ~
-    :vi_change_case,
+    :ed_unassigned,
     # 127 ^?
     :em_delete_prev_char,
     # 128 M-^@
@@ -415,7 +415,7 @@ class Reline::KeyActor::ViCommand < Reline::KeyActor::Base
     # 206 M-N
     :ed_unassigned,
     # 207 M-O
-    :ed_sequence_lead_in,
+    :ed_unassigned,
     # 208 M-P
     :ed_unassigned,
     # 209 M-Q
@@ -439,7 +439,7 @@ class Reline::KeyActor::ViCommand < Reline::KeyActor::Base
     # 218 M-Z
     :ed_unassigned,
     # 219 M-[
-    :ed_sequence_lead_in,
+    :ed_unassigned,
     # 220 M-\
     :ed_unassigned,
     # 221 M-]

--- a/lib/reline/key_actor/vi_insert.rb
+++ b/lib/reline/key_actor/vi_insert.rb
@@ -41,7 +41,7 @@ class Reline::KeyActor::ViInsert < Reline::KeyActor::Base
     #  19 ^S
     :vi_search_next,
     #  20 ^T
-    :ed_insert,
+    :ed_transpose_chars,
     #  21 ^U
     :vi_kill_line_prev,
     #  22 ^V
@@ -51,7 +51,7 @@ class Reline::KeyActor::ViInsert < Reline::KeyActor::Base
     #  24 ^X
     :ed_insert,
     #  25 ^Y
-    :ed_insert,
+    :em_yank,
     #  26 ^Z
     :ed_insert,
     #  27 ^[

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -1538,6 +1538,7 @@ class Reline::LineEditor
     @byte_pointer = 0
   end
   alias_method :beginning_of_line, :ed_move_to_beg
+  alias_method :vi_zero, :ed_move_to_beg
 
   private def ed_move_to_end(key)
     @byte_pointer = 0
@@ -2321,10 +2322,6 @@ class Reline::LineEditor
       end
     end
     copy_for_vi(deleted)
-  end
-
-  private def vi_zero(key)
-    @byte_pointer = 0
   end
 
   private def vi_change_meta(key, arg: nil)

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -33,8 +33,6 @@ class Reline::LineEditor
     vi_next_big_word
     vi_prev_big_word
     vi_end_big_word
-    vi_repeat_next_char
-    vi_repeat_prev_char
   }
 
   module CompletionState


### PR DESCRIPTION
I checked [GNU Readline documentation](https://tiswww.case.edu/php/chet/readline/readline.html) and defined key bindings for existing features to match Readline.

Also, I removed key bindings that have key bindings defined but no methods defined.

Removed key bindings:
- em_copy_prev_word
- ed_sequence_lead_in
- em_copy_region
- ed_command
- vi_match
- vi_repeat_prev_char
- vi_redo
- vi_repeat_search_prev
- vi_replace_mode
- vi_substitute_line
- vi_undo_line
- vi_yank_end
- vi_history_word
- vi_repeat_search_next
- vi_substitute_char
- vi_undo
- vi_change_case