### PR TITLE
Fix vi_to_column which was broken

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -540,10 +540,6 @@ class Reline::LineEditor
     new_lines.size - y
   end
 
-  def current_row
-    wrapped_lines.flatten[wrapped_cursor_y]
-  end
-
   def upper_space_height(wrapped_cursor_y)
     wrapped_cursor_y - screen_scroll_top
   end
@@ -2483,18 +2479,11 @@ class Reline::LineEditor
   end
 
   private def vi_to_column(key, arg: 0)
-    current_row_width = calculate_width(current_row)
-    @byte_pointer, = current_line.grapheme_clusters.inject([0, 0]) { |total, gc|
-      # total has [byte_size, cursor]
+    # Implementing behavior of vi, not Readline's vi-mode.
+    @byte_pointer, = current_line.grapheme_clusters.inject([0, 0]) { |(total_byte_size, total_width), gc|
       mbchar_width = Reline::Unicode.get_mbchar_width(gc)
-      if (total.last + mbchar_width) >= arg
-        break total
-      elsif (total.last + mbchar_width) >= current_row_width
-        break total
-      else
-        total = [total.first + gc.bytesize, total.last + mbchar_width]
-        total
-      end
+      break [total_byte_size, total_width] if (total_width + mbchar_width) >= arg
+      [total_byte_size + gc.bytesize, total_width + mbchar_width]
     }
   end
 

--- a/test/reline/test_key_actor_vi.rb
+++ b/test/reline/test_key_actor_vi.rb
@@ -711,6 +711,20 @@ class Reline::KeyActor::ViInsert::Test < Reline::TestCase
     assert_line_around_cursor('', '   abcde  ABCDE  ')
   end
 
+  def test_vi_to_column
+    input_keys("a一二三\C-[0")
+    input_keys('1|')
+    assert_line_around_cursor('', 'a一二三')
+    input_keys('2|')
+    assert_line_around_cursor('a', '一二三')
+    input_keys('3|')
+    assert_line_around_cursor('a', '一二三')
+    input_keys('4|')
+    assert_line_around_cursor('a一', '二三')
+    input_keys('9|')
+    assert_line_around_cursor('a一二', '三')
+  end
+
   def test_vi_delete_meta
     input_keys("aaa bbb ccc ddd eee\C-[02w")
     assert_line_around_cursor('aaa bbb ', 'ccc ddd eee')


### PR DESCRIPTION
```ruby
def current_row
  wrapped_lines.flatten[wrapped_cursor_y]
end
```
`wrapped_cursor_y` does not exist, and raises NoMethodError.

Old implementation of `vi_to_column` is counting width. vi does it, Readline's vi-mode does not. It only counts string size.

I Removed the condition `(total.last + mbchar_width) >= current_row_width` because it is not needed in both vi and Readline's behavior.