### PR TITLE
Implement changing editing mode

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -2630,4 +2630,12 @@ class Reline::LineEditor
     @mark_pointer = new_pointer
   end
   alias_method :exchange_point_and_mark, :em_exchange_mark
+
+  private def emacs_editing_mode(key)
+    @config.editing_mode = :emacs
+  end
+
+  private def vi_editing_mode(key)
+    @config.editing_mode = :vi_insert
+  end
 end

--- a/test/reline/test_key_actor_emacs.rb
+++ b/test/reline/test_key_actor_emacs.rb
@@ -1436,4 +1436,9 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
     input_keys("\C-f\C-u", false)
     assert_line_around_cursor('', '')
   end
+
+  def test_vi_editing_mode
+    @line_editor.__send__(:vi_editing_mode, nil)
+    assert(@config.editing_mode_is?(:vi_insert))
+  end
 end

--- a/test/reline/test_key_actor_vi.rb
+++ b/test/reline/test_key_actor_vi.rb
@@ -911,4 +911,9 @@ class Reline::KeyActor::ViInsert::Test < Reline::TestCase
       input_keys("test = { foo: bar }\C-[BBBldt}b")
     end
   end
+
+  def test_emacs_editing_mode
+    @line_editor.__send__(:emacs_editing_mode, nil)
+    assert(@config.editing_mode_is?(:emacs))
+  end
 end


### PR DESCRIPTION
I implemented Readline’s emacs-editing-mode (C-e) and vi-editing-mode (M-C-j, M-C-m) to switch editing modes. The keymap was aligned with Readline's behavior. But `M-C-m` was used in the yamatanooroti tests, so I decided not to map it.