### PR TITLE
Implement `show-all-if-ambiguous` feature

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -880,10 +880,12 @@ class Reline::LineEditor
           @completion_state = CompletionState::PERFECT_MATCH
         else
           @completion_state = CompletionState::MENU_WITH_PERFECT_MATCH
+          complete(list, true) if @config.show_all_if_ambiguous
         end
         @perfect_matched = completed
       else
         @completion_state = CompletionState::MENU
+        complete(list, true) if @config.show_all_if_ambiguous
       end
       if not just_show_list and target < completed
         @buffer_of_lines[@line_index] = (preposing + completed + completion_append_character.to_s + postposing).split("\n")[@line_index] || String.new(encoding: @encoding)

--- a/test/reline/yamatanooroti/multiline_repl
+++ b/test/reline/yamatanooroti/multiline_repl
@@ -143,6 +143,11 @@ opt.on('--complete') {
     %w{String ScriptError SyntaxError Signal}.select{ |c| c.start_with?(target) }
   }
 }
+opt.on('--complete-menu-with-perfect-match') {
+  Reline.completion_proc = lambda { |target, preposing = nil, postposing = nil|
+    %w{abs abs2}.select{ |c| c.start_with?(target) }
+  }
+}
 opt.on('--autocomplete') {
   Reline.autocompletion = true
   Reline.completion_proc = lambda { |target, preposing = nil, postposing = nil|

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -1006,6 +1006,47 @@ begin
       EOC
     end
 
+    def test_completion_menu_is_displayed_horizontally
+      start_terminal(20, 50, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --complete}, startup_message: 'Multiline REPL.')
+      write("S\t\t")
+      close
+      assert_screen(<<~'EOC')
+        Multiline REPL.
+        prompt> S
+        ScriptError  String
+        Signal       SyntaxError
+      EOC
+    end
+
+    def test_show_all_if_ambiguous_on
+      write_inputrc <<~LINES
+        set show-all-if-ambiguous on
+      LINES
+      start_terminal(20, 50, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --complete}, startup_message: 'Multiline REPL.')
+      write("S\t")
+      close
+      assert_screen(<<~'EOC')
+        Multiline REPL.
+        prompt> S
+        ScriptError  String
+        Signal       SyntaxError
+      EOC
+    end
+
+    def test_show_all_if_ambiguous_on_and_menu_with_perfect_match
+      write_inputrc <<~LINES
+        set show-all-if-ambiguous on
+      LINES
+      start_terminal(20, 50, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --complete-menu-with-perfect-match}, startup_message: 'Multiline REPL.')
+      write("a\t")
+      close
+      assert_screen(<<~'EOC')
+        Multiline REPL.
+        prompt> abs
+        abs   abs2
+      EOC
+    end
+
     def test_simple_dialog
       iterate_over_face_configs do |config_name, config_file|
         start_terminal(20, 50, %W{ruby -I#{@pwd}/lib -r#{config_file.path} #{@pwd}/test/reline/yamatanooroti/multiline_repl --dialog simple}, startup_message: 'Multiline REPL.')


### PR DESCRIPTION
This feature displays all possible completions with a single tab press if autocomplete is disabled and multiple completions are available. It does not alter behavior when autocomplete is enabled.

> `show-all-if-ambiguous`
> This alters the default behavior of the completion functions. If set to ‘on’, words which have more than one possible completion cause the matches to be listed immediately instead of ringing the bell. The default value is ‘off’.

https://tiswww.case.edu/php/chet/readline/readline.html

To use this feature, add these lines to your `.inputrc` file and start `irb` with `--noautocomplete`:
```.inputrc
set show-all-if-ambiguous on
```