### PR TITLE
Long line performance

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -1542,11 +1542,7 @@ class Reline::LineEditor
   alias_method :vi_zero, :ed_move_to_beg
 
   private def ed_move_to_end(key)
-    @byte_pointer = 0
-    while @byte_pointer < current_line.bytesize
-      byte_size = Reline::Unicode.get_next_mbchar_size(current_line, @byte_pointer)
-      @byte_pointer += byte_size
-    end
+    @byte_pointer = current_line.bytesize
   end
   alias_method :end_of_line, :ed_move_to_end
 

--- a/lib/reline/unicode.rb
+++ b/lib/reline/unicode.rb
@@ -145,7 +145,13 @@ class Reline::Unicode
         lines.last << NON_PRINTING_END
       when csi
         lines.last << csi
-        seq << csi
+        unless in_zero_width
+          if csi == -"\e[m" || csi == -"\e[0m"
+            seq.clear
+          else
+            seq << csi
+          end
+        end
       when osc
         lines.last << osc
         seq << osc

--- a/test/reline/test_unicode.rb
+++ b/test/reline/test_unicode.rb
@@ -38,6 +38,11 @@ class Reline::Unicode::Test < Reline::TestCase
     assert_equal [["ab\e]0;1\ac", nil, "\e]0;1\ad"], 2], Reline::Unicode.split_by_width("ab\e]0;1\acd", 3)
   end
 
+  def test_split_by_width_csi_reset_sgr_optimization
+    assert_equal [["\e[1ma\e[mb\e[2mc", nil, "\e[2md\e[0me\e[3mf", nil, "\e[3mg"], 3], Reline::Unicode.split_by_width("\e[1ma\e[mb\e[2mcd\e[0me\e[3mfg", 3)
+    assert_equal [["\e[1ma\1\e[mzero\e[0m\2\e[2mb", nil, "\e[1m\e[2mc"], 2], Reline::Unicode.split_by_width("\e[1ma\1\e[mzero\e[0m\2\e[2mbc", 2)
+  end
+
   def test_take_range
     assert_equal 'cdef', Reline::Unicode.take_range('abcdefghi', 2, 4)
     assert_equal 'あde', Reline::Unicode.take_range('abあdef', 2, 4)


### PR DESCRIPTION
When input line is very long, for example, after pasting `[1,1,1,1,1,1,1,1,...(thousands of items)...,1,1,1]` to IRB, Some cursor move operation and rendering is slow.

Performance of pasting long text will be improved in bracketed-paste #655.
This pull request improves performance of re-rendering long text.

## Reproduce
```
$ ruby -e "print ([1]*4000).inspect" | pbcopy
$ irb
irb(main):001> [paste long input here]
...(wait a few seconds)
Press C-l to see rerender time (about 0.25s → about 0.01s)
Press C-a C-e to see ed_move_to_end time (about 10s → about 0.01s)
```

## ed_move_to_end
I just forgot to erase the old while loop.

## split_by_width
When the input is `1,1,1,1,1,1,1....`, colorized code will be `[BLUE]1[RESET],[BLUE]1[RESET],...`
Reline::Unicode.split_by_width will split into
```ruby
[
  "[BLUE]1[RESET],[BLUE]1[RESET],",
  "[BLUE][RESET][BLUE][RESET][BLUE]1[RESET],[BLUE]1[RESET],",
  "[BLUE][RESET][BLUE][RESET][BLUE][RESET][BLUE][RESET][BLUE]1[RESET],[BLUE]1[RESET],",
  "[BLUE][RESET][BLUE][RESET][BLUE][RESET][BLUE][RESET][BLUE][RESET][BLUE][RESET][BLUE]1[RESET],[BLUE]1[RESET],"
]
```
This is because split_by_width does not understand actual CSI sequence and just concats it.
We can clear the concatenated sequences if the CSI is `"\e[m"` or `"\e[0m"` that resets color and text style.

