### PR TITLE
Fix completion dialog position when completed part is word wrapped

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -225,17 +225,20 @@ module Reline
       journey_data = completion_journey_data
       return unless journey_data
 
-      target = journey_data.list[journey_data.pointer]
+      target = journey_data.list.first
+      completed = journey_data.list[journey_data.pointer]
       result = journey_data.list.drop(1)
       pointer = journey_data.pointer - 1
-      return if target.empty? || (result == [target] && pointer < 0)
+      return if completed.empty? || (result == [completed] && pointer < 0)
 
       target_width = Reline::Unicode.calculate_width(target)
-      x = cursor_pos.x - target_width
-      if x < 0
-        x = screen_width + x
+      completed_width = Reline::Unicode.calculate_width(completed)
+      if cursor_pos.x <= completed_width - target_width
+        # When target is rendered on the line above cursor position
+        x = screen_width - completed_width
         y = -1
       else
+        x = [cursor_pos.x - completed_width, 0].max
         y = 0
       end
       cursor_pos_to_render = Reline::CursorPos.new(x, y)

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -1173,7 +1173,36 @@ begin
       assert_screen(<<~'EOC')
         Multiline REPL.
         prompt>           St
-        r             String
+        r
+        String
+        Struct
+      EOC
+    end
+
+    def test_autocomplete_target_at_end_of_line
+      start_terminal(20, 20, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --autocomplete}, startup_message: 'Multiline REPL.')
+      write('         ')
+      write('Str')
+      write("\C-i")
+      close
+      assert_screen(<<~'EOC')
+        Multiline REPL.
+        prompt>          Str
+        ing           String
+                      Struct
+      EOC
+    end
+
+    def test_autocomplete_completed_input_is_wrapped
+      start_terminal(20, 20, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --autocomplete}, startup_message: 'Multiline REPL.')
+      write('        ')
+      write('Str')
+      write("\C-i")
+      close
+      assert_screen(<<~'EOC')
+        Multiline REPL.
+        prompt>         Stri
+        ng            String
                       Struct
       EOC
     end


### PR DESCRIPTION
When completion target is very long, completed text completely overlaps with dialog
![before_long_completion](https://github.com/ruby/reline/assets/1780201/67fdb8f1-1dc9-4446-b2b4-09fef5a5ac4d)
This pull request fix it
![after_long_completion](https://github.com/ruby/reline/assets/1780201/0d9631bc-dfea-48d5-ac5b-17bb1b4ede4d)



## Description

The original intention of `y = -1` is to render dialog on the cursor line when the completed part (`oobar`) is word wrapped. It looks good in this case.
![target_not_wrapped](https://github.com/ruby/reline/assets/1780201/763549f3-24d2-4167-9577-58fcc1093edd)

When completion target is word wrapped but completed part `loor` is not word wrapped
![before_wrapped](https://github.com/ruby/reline/assets/1780201/ed8aaa9a-d851-421c-b9ad-a10570565a42)
Completed part might be completely hidden by dialog.
![before_wrapped_with_doc](https://github.com/ruby/reline/assets/1780201/33668dac-0c32-4e43-9934-292cf2187ddd)

In such case, this pull request will set dialog position to left edge, just below cursor.
![after_wrapped](https://github.com/ruby/reline/assets/1780201/10530191-66d9-49d2-a857-7f9934d546ad)

