### PR TITLE
Avoid reading `.inputrc` repeatedly

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -335,7 +335,7 @@ module Reline
         end
       end
 
-      unless config.test_mode
+      unless config.test_mode or config.loaded?
         config.read
         config.reset_default_key_bindings
         io_gate.set_default_key_bindings(config)

--- a/lib/reline/config.rb
+++ b/lib/reline/config.rb
@@ -69,6 +69,7 @@ class Reline::Config
     @test_mode = false
     @autocompletion = false
     @convert_meta = true if seven_bit_encoding?(Reline::IOGate.encoding)
+    @loaded = false
   end
 
   def reset
@@ -96,6 +97,10 @@ class Reline::Config
 
   def keymap
     @key_actors[@keymap_label]
+  end
+
+  def loaded?
+    @loaded
   end
 
   def inputrc_path
@@ -141,6 +146,7 @@ class Reline::Config
     end
 
     read_lines(lines, file)
+    @loaded = true
     self
   rescue InvalidInputrc => e
     warn e.message


### PR DESCRIPTION
Closes: https://github.com/ruby/reline/issues/693

I added a flag to prevent `.inputrc` from being read repeatedly after loading.