### PR TITLE
Fix prompt width calculation bug

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -387,7 +387,7 @@ class Reline::LineEditor
           next cached
         end
         *wrapped_prompts, code_line_prompt = split_by_width(prompt, width).first.compact
-        wrapped_lines = split_by_width(line, width, offset: calculate_width(code_line_prompt)).first.compact
+        wrapped_lines = split_by_width(line, width, offset: calculate_width(code_line_prompt, true)).first.compact
         wrapped_prompts.map { |p| [p, ''] } + [[code_line_prompt, wrapped_lines.first]] + wrapped_lines.drop(1).map { |c| ['', c] }
       end
     end

--- a/test/reline/yamatanooroti/multiline_repl
+++ b/test/reline/yamatanooroti/multiline_repl
@@ -12,7 +12,7 @@ opt = OptionParser.new
 opt.on('--dynamic-prompt') {
   Reline.prompt_proc = proc { |lines|
     lines.each_with_index.map { |l, i|
-      '[%04d]> ' % i
+      "\e[1m[%04d]>\e[m " % i
     }
   }
 }
@@ -222,7 +222,7 @@ rescue
 end
 
 begin
-  prompt = ENV['RELINE_TEST_PROMPT'] || 'prompt> '
+  prompt = ENV['RELINE_TEST_PROMPT'] || "\e[1mprompt>\e[m "
   puts 'Multiline REPL.'
   while code = Reline.readmultiline(prompt, true) { |code| TerminationChecker.terminated?(code) }
     case code.chomp


### PR DESCRIPTION
Fix this bug (reline-0.5.3). Prompt width calculation was wrong when it contains escape sequence.
![prompt_miscalculation_wordwrap_bug](https://github.com/ruby/reline/assets/1780201/8a442213-0c88-4fd8-a347-72e5f5ec4864)
