### PR TITLE
Fix default and additional key bindings vanish bug

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -340,7 +340,6 @@ module Reline
 
       unless config.test_mode or config.loaded?
         config.read
-        config.reset_default_key_bindings
         io_gate.set_default_key_bindings(config)
       end
 

--- a/lib/reline/config.rb
+++ b/lib/reline/config.rb
@@ -76,11 +76,7 @@ class Reline::Config
     if editing_mode_is?(:vi_command)
       @editing_mode_label = :vi_insert
     end
-    @additional_key_bindings.keys.each do |key|
-      @additional_key_bindings[key].clear
-    end
     @oneshot_key_bindings.clear
-    reset_default_key_bindings
   end
 
   def editing_mode
@@ -134,6 +130,7 @@ class Reline::Config
   end
 
   def read(file = nil)
+    @loaded = true
     file ||= default_inputrc_path
     begin
       if file.respond_to?(:readlines)
@@ -146,7 +143,6 @@ class Reline::Config
     end
 
     read_lines(lines, file)
-    @loaded = true
     self
   rescue InvalidInputrc => e
     warn e.message
@@ -175,12 +171,6 @@ class Reline::Config
 
   def add_default_key_binding(keystroke, target)
     @key_actors[@keymap_label].default_key_bindings[keystroke] = target
-  end
-
-  def reset_default_key_bindings
-    @key_actors.values.each do |ka|
-      ka.reset_default_key_bindings
-    end
   end
 
   def read_lines(lines, file = nil)

--- a/lib/reline/key_actor/base.rb
+++ b/lib/reline/key_actor/base.rb
@@ -12,8 +12,4 @@ class Reline::KeyActor::Base
   def default_key_bindings
     @default_key_bindings
   end
-
-  def reset_default_key_bindings
-    @default_key_bindings.clear
-  end
 end

--- a/test/reline/test_config.rb
+++ b/test/reline/test_config.rb
@@ -417,6 +417,18 @@ class Reline::Config::Test < Reline::TestCase
     assert_equal expected, @config.key_bindings
   end
 
+  def test_key_bindings_with_reset
+    # @config.reset is called after each readline.
+    # inputrc file is read once, so key binding shouldn't be cleared by @config.reset
+    @config.add_default_key_binding('default'.bytes, 'DEFAULT'.bytes)
+    @config.read_lines(<<~'LINES'.lines)
+      "additional": "ADDITIONAL"
+    LINES
+    @config.reset
+    expected = { 'default'.bytes => 'DEFAULT'.bytes, 'additional'.bytes => 'ADDITIONAL'.bytes }
+    assert_equal expected, @config.key_bindings
+  end
+
   def test_history_size
     @config.read_lines(<<~LINES.lines)
       set history-size 5000

--- a/test/reline/test_within_pipe.rb
+++ b/test/reline/test_within_pipe.rb
@@ -23,7 +23,6 @@ class Reline::WithinPipeTest < Reline::TestCase
     @reader.close
     @output_writer.close
     @config.reset
-    @config.reset_default_key_bindings
     Reline.test_reset
   end
 


### PR DESCRIPTION
When inpurc file exists, default key bindings and additional key bindings were cleared after first `Reline.readline`.

```
irb(main):001> 123 (arrow key works)
=> 123
irb(main):002> 123 (arrow key does not work)
```

## Changes
### Config#read
Changed `config.read` always turns `@loaded` to true. This will make the behavior difference of inputrc file existence small.
Even if inputrc file does not exist, we can still think null file is loaded. This will also avoid attempt loading invalid inputrc file many times.

### Config#reset
Config is loaded only once and sets additional_key_bindings. We can't clear additional_key_bindings. We don't need to clear default_key_bindings too.