### PR TITLE
Add name defined in readline to completion key bindings C-i C-p C-n

### DIFF
--- a/lib/reline/key_actor/emacs.rb
+++ b/lib/reline/key_actor/emacs.rb
@@ -19,7 +19,7 @@ class Reline::KeyActor::Emacs < Reline::KeyActor::Base
     #   8 ^H
     :em_delete_prev_char,
     #   9 ^I
-    :ed_unassigned,
+    :complete,
     #  10 ^J
     :ed_newline,
     #  11 ^K

--- a/lib/reline/key_actor/vi_insert.rb
+++ b/lib/reline/key_actor/vi_insert.rb
@@ -19,7 +19,7 @@ class Reline::KeyActor::ViInsert < Reline::KeyActor::Base
     #   8 ^H
     :vi_delete_prev_char,
     #   9 ^I
-    :ed_insert,
+    :complete,
     #  10 ^J
     :ed_newline,
     #  11 ^K
@@ -29,11 +29,11 @@ class Reline::KeyActor::ViInsert < Reline::KeyActor::Base
     #  13 ^M
     :ed_newline,
     #  14 ^N
-    :ed_insert,
+    :menu_complete,
     #  15 ^O
     :ed_insert,
     #  16 ^P
-    :ed_insert,
+    :menu_complete_backward,
     #  17 ^Q
     :ed_ignore,
     #  18 ^R

--- a/test/reline/test_key_actor_emacs.rb
+++ b/test/reline/test_key_actor_emacs.rb
@@ -787,9 +787,22 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
     input_keys('b')
     input_keys("\C-i", false)
     assert_line_around_cursor('foo_ba', '')
+    input_keys("\C-h")
+    input_key_by_symbol(:complete)
+    assert_line_around_cursor('foo_ba', '')
+    input_keys("\C-h", false)
+    input_key_by_symbol(:menu_complete)
+    assert_line_around_cursor('foo_bar', '')
+    input_key_by_symbol(:menu_complete)
+    assert_line_around_cursor('foo_baz', '')
+    input_keys("\C-h", false)
+    input_key_by_symbol(:menu_complete_backward)
+    assert_line_around_cursor('foo_baz', '')
+    input_key_by_symbol(:menu_complete_backward)
+    assert_line_around_cursor('foo_bar', '')
   end
 
-  def test_autocompletion_with_upward_navigation
+  def test_autocompletion
     @config.autocompletion = true
     @line_editor.completion_proc = proc { |word|
       %w{
@@ -806,31 +819,14 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
     assert_line_around_cursor('Readline', '')
     input_keys("\C-i", false)
     assert_line_around_cursor('Regexp', '')
-    @line_editor.input_key(Reline::Key.new(:completion_journey_up, :completion_journey_up, false))
+    input_key_by_symbol(:completion_journey_up)
     assert_line_around_cursor('Readline', '')
-  ensure
-    @config.autocompletion = false
-  end
-
-  def test_autocompletion_with_upward_navigation_and_menu_complete_backward
-    @config.autocompletion = true
-    @line_editor.completion_proc = proc { |word|
-      %w{
-        Readline
-        Regexp
-        RegexpError
-      }.map { |i|
-        i.encode(@encoding)
-      }
-    }
-    input_keys('Re')
-    assert_line_around_cursor('Re', '')
-    input_keys("\C-i", false)
-    assert_line_around_cursor('Readline', '')
-    input_keys("\C-i", false)
+    input_key_by_symbol(:complete)
     assert_line_around_cursor('Regexp', '')
-    @line_editor.input_key(Reline::Key.new(:menu_complete_backward, :menu_complete_backward, false))
+    input_key_by_symbol(:menu_complete_backward)
     assert_line_around_cursor('Readline', '')
+    input_key_by_symbol(:menu_complete)
+    assert_line_around_cursor('Regexp', '')
   ensure
     @config.autocompletion = false
   end


### PR DESCRIPTION
This pull request moves hardcoded \C-i \C-p \C-n to line_editor's method. Just like we did it to `completion_journey_up`.

vi: \C-n is menu-complete. moves completion even if autocomplete is off.
vi: \C-p is menu-complete-backward. moves completion backward even if autocomplete is off.
\C-i is complete. when autocomplete is enabled, it is menu-complete. unless, it is tab complete
shift-tab is completion-journey-up, a bit different from menu-complete-backward (disabled when autocomplete is off)

## Naming
Readline can configure `complete`, `menu-complete` and `menu-complete-backward`. Uses the same name to make it configurable in irbrc. The old `complete` method is renamed to `perform_completion`.
