### PR TITLE
Remove not implemented variables

### DIFF
--- a/lib/reline/config.rb
+++ b/lib/reline/config.rb
@@ -8,31 +8,12 @@ class Reline::Config
   end
 
   VARIABLE_NAMES = %w{
-    bind-tty-special-chars
-    blink-matching-paren
-    byte-oriented
     completion-ignore-case
     convert-meta
     disable-completion
-    enable-keypad
-    expand-tilde
-    history-preserve-point
     history-size
-    horizontal-scroll-mode
-    input-meta
     keyseq-timeout
-    mark-directories
-    mark-modified-lines
-    mark-symlinked-directories
-    match-hidden-files
-    meta-flag
-    output-meta
-    page-completions
-    prefer-visible-bell
-    print-completions-horizontally
     show-all-if-ambiguous
-    show-all-if-unmodified
-    visible-stats
     show-mode-in-prompt
     vi-cmd-mode-string
     vi-ins-mode-string


### PR DESCRIPTION
Perhaps these were described as TODO comments, but it is difficult to see that these functions are not available, so they should be removed.

- bind-tty-special-chars
- blink-matching-paren
- byte-oriented
- enable-keypad
- expand-tilde
- history-preserve-point
- horizontal-scroll-mode
- input-meta
- mark-directories
- mark-modified-lines
- mark-symlinked-directories
- match-hidden-files
- meta-flag
- output-meta
- page-completions
- prefer-visible-bell
- print-completions-horizontally
- show-all-if-unmodified
- visible-stats


I confirmed that grep does not hit with either hyphens or underscores.

```
git grep -e bind-tty-special-chars -e blink-matching-paren -e byte-oriented -e enable-keypad -e expand-tilde -e history-preserve-point -e horizontal-scroll-mode -e input-meta -e mark-directories -e mark-modified-lines -e mark-symlinked-directories -e match-hidden-files -e meta-flag -e output-meta -e page-completions -e prefer-visible-bell -e print-completions-horizontally -e show-all-if-unmodified -e visible-stats
```

```
git grep -e bind_tty_special_chars -e blink_matching_paren -e byte_oriented -e enable_keypad -e expand_tilde -e history_preserve_point -e horizontal_scroll_mode -e input_meta -e mark_directories -e mark_modified_lines -e mark_symlinked_directories -e match_hidden_files -e meta_flag -e output_meta -e page_completions -e prefer_visible_bell -e print_completions_horizontally -e show_all_if_unmodified -e visible_stats
```