### PR TITLE
Implement the undo command

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -353,11 +353,9 @@ module Reline
             line_editor.set_pasting_state(io_gate.in_pasting?)
             inputs.each do |key|
               if key.char == :bracketed_paste_start
-                line_editor.save_old_buffer
                 text = io_gate.read_bracketed_paste
                 line_editor.insert_pasted_text(text)
                 line_editor.scroll_into_view
-                line_editor.save_past_lines
               else
                 line_editor.update(key)
               end

--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -353,9 +353,11 @@ module Reline
             line_editor.set_pasting_state(io_gate.in_pasting?)
             inputs.each do |key|
               if key.char == :bracketed_paste_start
+                line_editor.save_old_buffer
                 text = io_gate.read_bracketed_paste
                 line_editor.insert_pasted_text(text)
                 line_editor.scroll_into_view
+                line_editor.save_past_lines
               else
                 line_editor.update(key)
               end

--- a/lib/reline/key_actor/emacs.rb
+++ b/lib/reline/key_actor/emacs.rb
@@ -63,7 +63,7 @@ class Reline::KeyActor::Emacs < Reline::KeyActor::Base
     #  30 ^^
     :ed_unassigned,
     #  31 ^_
-    :ed_unassigned,
+    :undo,
     #  32 SPACE
     :ed_insert,
     #  33 !

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -275,7 +275,7 @@ class Reline::LineEditor
     @resized = false
     @cache = {}
     @rendered_screen = RenderedScreen.new(base_y: 0, lines: [], cursor_y: 0)
-    @past_lines = [["", 0, 0]]
+    @past_lines = []
     @using_delete_command = false
     reset_line
   end
@@ -1190,7 +1190,7 @@ class Reline::LineEditor
   MAX_PAST_LINES = 100
   def save_past_lines
     if @old_buffer_of_lines != @buffer_of_lines
-      if !@using_delete_command && @buffer_of_lines == @past_lines.last.first
+      if !@past_lines.empty? && !@using_delete_command && @buffer_of_lines == @past_lines.last.first
         # When deleting, @buffer_of_lines and @past_lines.last.first become the same.
         # If it is the same as the previous state, consider it undone and do not add to past_lines.
         @past_lines.pop

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -948,7 +948,8 @@ class Reline::LineEditor
         unless @waiting_proc
           byte_pointer_diff = @byte_pointer - old_byte_pointer
           @byte_pointer = old_byte_pointer
-          send(@vi_waiting_operator, byte_pointer_diff)
+          method_obj = method(@vi_waiting_operator)
+          wrap_method_call(@vi_waiting_operator, method_obj, byte_pointer_diff)
           cleanup_waiting
         end
       else
@@ -1009,7 +1010,8 @@ class Reline::LineEditor
       if @vi_waiting_operator
         byte_pointer_diff = @byte_pointer - old_byte_pointer
         @byte_pointer = old_byte_pointer
-        send(@vi_waiting_operator, byte_pointer_diff)
+        method_obj = method(@vi_waiting_operator)
+        wrap_method_call(@vi_waiting_operator, method_obj, byte_pointer_diff)
         cleanup_waiting
       end
       @kill_ring.process

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -1376,6 +1376,7 @@ class Reline::LineEditor
   end
 
   def insert_pasted_text(text)
+    save_old_buffer
     pre = @buffer_of_lines[@line_index].byteslice(0, @byte_pointer)
     post = @buffer_of_lines[@line_index].byteslice(@byte_pointer..)
     lines = (pre + text.gsub(/\r\n?/, "\n") + post).split("\n", -1)
@@ -1383,6 +1384,7 @@ class Reline::LineEditor
     @buffer_of_lines[@line_index, 1] = lines
     @line_index += lines.size - 1
     @byte_pointer = @buffer_of_lines[@line_index].bytesize - post.bytesize
+    save_past_lines
   end
 
   def insert_text(text)

--- a/test/reline/test_key_actor_emacs.rb
+++ b/test/reline/test_key_actor_emacs.rb
@@ -1437,4 +1437,61 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
     @line_editor.__send__(:vi_editing_mode, nil)
     assert(@config.editing_mode_is?(:vi_insert))
   end
+
+  def test_undo
+    input_keys("aあb\C-h\C-h\C-h", false)
+    assert_line_around_cursor('', '')
+    input_keys("\C-_", false)
+    assert_line_around_cursor('a', '')
+    input_keys("\C-_", false)
+    assert_line_around_cursor('aあ', '')
+    input_keys("\C-_", false)
+    assert_line_around_cursor('aあb', '')
+    input_keys("\C-_", false)
+    assert_line_around_cursor('aあ', '')
+    input_keys("\C-_", false)
+    assert_line_around_cursor('a', '')
+    input_keys("\C-_", false)
+    assert_line_around_cursor('', '')
+  end
+
+  def test_undo_with_cursor_position
+    input_keys("abc\C-b\C-h", false)
+    assert_line_around_cursor('a', 'c')
+    input_keys("\C-_", false)
+    assert_line_around_cursor('ab', 'c')
+    input_keys("あいう\C-b\C-h", false)
+    assert_line_around_cursor('abあ', 'うc')
+    input_keys("\C-_", false)
+    assert_line_around_cursor('abあい', 'うc')
+  end
+
+  def test_undo_with_multiline
+    @line_editor.multiline_on
+    @line_editor.confirm_multiline_termination_proc = proc {}
+    input_keys("1\n2\n3", false)
+    assert_whole_lines(["1", "2", "3"])
+    assert_line_index(2)
+    assert_line_around_cursor('3', '')
+    input_keys("\C-p\C-h\C-h", false)
+    assert_whole_lines(["1", "3"])
+    assert_line_index(0)
+    assert_line_around_cursor('1', '')
+    input_keys("\C-_", false)
+    assert_whole_lines(["1", "", "3"])
+    assert_line_index(1)
+    assert_line_around_cursor('', '')
+    input_keys("\C-_", false)
+    assert_whole_lines(["1", "2", "3"])
+    assert_line_index(1)
+    assert_line_around_cursor('2', '')
+    input_keys("\C-_", false)
+    assert_whole_lines(["1", "2", ""])
+    assert_line_index(2)
+    assert_line_around_cursor('', '')
+    input_keys("\C-_", false)
+    assert_whole_lines(["1", "2"])
+    assert_line_index(1)
+    assert_line_around_cursor('2', '')
+  end
 end

--- a/test/reline/test_key_actor_emacs.rb
+++ b/test/reline/test_key_actor_emacs.rb
@@ -1439,6 +1439,8 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
   end
 
   def test_undo
+    input_keys("\C-_", false)
+    assert_line_around_cursor('', '')
     input_keys("aあb\C-h\C-h\C-h", false)
     assert_line_around_cursor('', '')
     input_keys("\C-_", false)

--- a/test/reline/test_key_actor_emacs.rb
+++ b/test/reline/test_key_actor_emacs.rb
@@ -1496,4 +1496,13 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
     assert_line_index(1)
     assert_line_around_cursor('2', '')
   end
+
+  def test_undo_with_many_times
+    str = "a" + "b" * 100
+    input_keys(str, false)
+    100.times { input_keys("\C-_", false) }
+    assert_line_around_cursor('a', '')
+    input_keys("\C-_", false)
+    assert_line_around_cursor('a', '')
+  end
 end

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -556,6 +556,18 @@ begin
       EOC
     end
 
+    def test_bracketed_paste_with_undo
+      omit if Reline.core.io_gate.win?
+      start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
+      write("\e[200~def hoge\r\t3\rend\e[201~")
+      write("\C-_")
+      close
+      assert_screen(<<~EOC)
+        Multiline REPL.
+        prompt>
+      EOC
+    end
+
     def test_backspace_until_returns_to_initial
       start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write("ABC")

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -559,12 +559,13 @@ begin
     def test_bracketed_paste_with_undo
       omit if Reline.core.io_gate.win?
       start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
+      write("abc")
       write("\e[200~def hoge\r\t3\rend\e[201~")
       write("\C-_")
       close
       assert_screen(<<~EOC)
         Multiline REPL.
-        prompt>
+        prompt> abc
       EOC
     end
 


### PR DESCRIPTION
## Overview
Implemented the undo method to enable undoing actions on a per-action basis.

## Implementation Approach
Executing undo allows reverting to the previous action. The behavior slightly differs from GNU Readline's undo. While GNU Readline groups character insertions within a certain timeframe, I found this to be unintuitive. Inspired by Zsh Line Editor, I made it so that continuous character inputs can be undone one character at a time.

To decide whether to save an operation history, it was necessary to know whether the action was an insertion or a deletion, as the conditions for saving differ between the two. Hence, I added `DELETE_COMMANDS`. Additionally, I refactored so that keys with any `method_symbol` would pass through `wrap_method_call`.
