### PR TITLE
Avoid STDIN.winsize called in `require "reline"`

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -75,7 +75,7 @@ class Reline::LineEditor
   def initialize(config, encoding)
     @config = config
     @completion_append_character = ''
-    @screen_size = Reline::IOGate.get_screen_size
+    @screen_size = [0, 0] # Should be initialized with actual winsize in LineEditor#reset
     reset_variables(encoding: encoding)
   end
 


### PR DESCRIPTION
`require 'reline'` is calling `STDIN.winsize` since reline-0.5.0
This pull request will fixes it.

Fixes the `STDIN.winsize` called in part of #690
