### PR TITLE
Implement the redo command

### DIFF
--- a/lib/reline/key_actor/emacs.rb
+++ b/lib/reline/key_actor/emacs.rb
@@ -15,7 +15,7 @@ class Reline::KeyActor::Emacs < Reline::KeyActor::Base
     #   6 ^F
     :ed_next_char,
     #   7 ^G
-    :ed_unassigned,
+    :redo,
     #   8 ^H
     :em_delete_prev_char,
     #   9 ^I
@@ -55,7 +55,7 @@ class Reline::KeyActor::Emacs < Reline::KeyActor::Base
     #  26 ^Z
     :ed_ignore,
     #  27 ^[
-    :redo,
+    :ed_unassigned,
     #  28 ^\
     :ed_ignore,
     #  29 ^]

--- a/lib/reline/key_actor/emacs.rb
+++ b/lib/reline/key_actor/emacs.rb
@@ -15,7 +15,7 @@ class Reline::KeyActor::Emacs < Reline::KeyActor::Base
     #   6 ^F
     :ed_next_char,
     #   7 ^G
-    :redo,
+    :ed_unassigned,
     #   8 ^H
     :em_delete_prev_char,
     #   9 ^I
@@ -319,7 +319,7 @@ class Reline::KeyActor::Emacs < Reline::KeyActor::Base
     # 158 M-^^
     :ed_unassigned,
     # 159 M-^_
-    :ed_unassigned,
+    :redo,
     # 160 M-SPACE
     :em_set_mark,
     # 161 M-!

--- a/lib/reline/key_actor/emacs.rb
+++ b/lib/reline/key_actor/emacs.rb
@@ -55,7 +55,7 @@ class Reline::KeyActor::Emacs < Reline::KeyActor::Base
     #  26 ^Z
     :ed_ignore,
     #  27 ^[
-    :ed_unassigned,
+    :redo,
     #  28 ^\
     :ed_ignore,
     #  29 ^]

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -1138,10 +1138,7 @@ class Reline::LineEditor
       @completion_journey_state = nil
     end
 
-    unless @undoing
-      @past_lines = @past_lines[0..@position]
-      push_past_lines
-    end
+    push_past_lines unless @undoing
     @undoing = false
 
     if @in_pasting
@@ -1168,6 +1165,7 @@ class Reline::LineEditor
     if @old_buffer_of_lines == @buffer_of_lines
       @past_lines[@position] = [@buffer_of_lines.dup, @byte_pointer, @line_index]
     else
+      @past_lines = @past_lines[0..@position]
       @position += 1
       @past_lines.push([@buffer_of_lines.dup, @byte_pointer, @line_index])
     end

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -1157,8 +1157,6 @@ class Reline::LineEditor
 
   def save_old_buffer
     @old_buffer_of_lines = @buffer_of_lines.dup
-    @old_byte_pointer = @byte_pointer.dup
-    @old_line_index = @line_index.dup
   end
 
   def push_input_lines

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -250,7 +250,7 @@ class Reline::LineEditor
     @resized = false
     @cache = {}
     @rendered_screen = RenderedScreen.new(base_y: 0, lines: [], cursor_y: 0)
-    @past_lines = [[[""], 0, 0]]
+    @input_lines = [[[""], 0, 0]]
     @position = 0
     @undoing = false
     reset_line
@@ -1138,7 +1138,7 @@ class Reline::LineEditor
       @completion_journey_state = nil
     end
 
-    push_past_lines unless @undoing
+    push_input_lines unless @undoing
     @undoing = false
 
     if @in_pasting
@@ -1161,21 +1161,21 @@ class Reline::LineEditor
     @old_line_index = @line_index.dup
   end
 
-  def push_past_lines
+  def push_input_lines
     if @old_buffer_of_lines == @buffer_of_lines
-      @past_lines[@position] = [@buffer_of_lines.dup, @byte_pointer, @line_index]
+      @input_lines[@position] = [@buffer_of_lines.dup, @byte_pointer, @line_index]
     else
-      @past_lines = @past_lines[0..@position]
+      @input_lines = @input_lines[0..@position]
       @position += 1
-      @past_lines.push([@buffer_of_lines.dup, @byte_pointer, @line_index])
+      @input_lines.push([@buffer_of_lines.dup, @byte_pointer, @line_index])
     end
-    trim_past_lines
+    trim_input_lines
   end
 
-  MAX_PAST_LINES = 100
-  def trim_past_lines
-    if @past_lines.size > MAX_PAST_LINES
-      @past_lines.shift
+  MAX_INPUT_LINES = 100
+  def trim_input_lines
+    if @input_lines.size > MAX_INPUT_LINES
+      @input_lines.shift
       @position -= 1
     end
   end
@@ -1358,7 +1358,7 @@ class Reline::LineEditor
     @buffer_of_lines[@line_index, 1] = lines
     @line_index += lines.size - 1
     @byte_pointer = @buffer_of_lines[@line_index].bytesize - post.bytesize
-    push_past_lines
+    push_input_lines
   end
 
   def insert_text(text)
@@ -2540,17 +2540,17 @@ class Reline::LineEditor
     return if @position <= 0
 
     @position -= 1
-    target_lines, target_cursor_x, target_cursor_y = @past_lines[@position]
+    target_lines, target_cursor_x, target_cursor_y = @input_lines[@position]
     set_current_lines(target_lines.dup, target_cursor_x, target_cursor_y)
   end
 
   private def redo(_key)
     @undoing = true
 
-    return if @position >= @past_lines.size - 1
+    return if @position >= @input_lines.size - 1
 
     @position += 1
-    target_lines, target_cursor_x, target_cursor_y = @past_lines[@position]
+    target_lines, target_cursor_x, target_cursor_y = @input_lines[@position]
     set_current_lines(target_lines.dup, target_cursor_x, target_cursor_y)
   end
 end

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -252,7 +252,6 @@ class Reline::LineEditor
     @rendered_screen = RenderedScreen.new(base_y: 0, lines: [], cursor_y: 0)
     @past_lines = []
     @undoing = false
-    @next_lines = []
     reset_line
   end
 
@@ -1138,10 +1137,7 @@ class Reline::LineEditor
       @completion_journey_state = nil
     end
 
-    unless @undoing
-      push_past_lines
-      @next_lines = []
-    end
+    push_past_lines unless @undoing
     @undoing = false
 
     if @in_pasting
@@ -1175,18 +1171,6 @@ class Reline::LineEditor
   def trim_past_lines
     if @past_lines.size > MAX_PAST_LINES
       @past_lines.shift
-    end
-  end
-
-  def push_next_lines
-    @next_lines.push([@buffer_of_lines, @byte_pointer, @line_index])
-    trim_next_lines
-  end
-
-  MAX_NEXT_LINES = 100
-  def trim_next_lines
-    if @next_lines.size > MAX_NEXT_LINES
-      @next_lines.shift
     end
   end
 
@@ -2545,27 +2529,13 @@ class Reline::LineEditor
   end
 
   private def undo(_key)
-    @undoing = true
-
     return if @past_lines.empty?
 
-    push_next_lines
+    @undoing = true
 
     target_lines, target_cursor_x, target_cursor_y = @past_lines.last
     set_current_lines(target_lines, target_cursor_x, target_cursor_y)
 
     @past_lines.pop
-  end
-
-  private def redo(_key)
-    @undoing = true
-
-    return if @next_lines.empty?
-
-    @past_lines.push([@buffer_of_lines, @byte_pointer, @line_index])
-    target_lines, target_cursor_x, target_cursor_y = @next_lines.last
-    set_current_lines(target_lines, target_cursor_x, target_cursor_y)
-
-    @next_lines.pop
   end
 end

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -251,7 +251,7 @@ class Reline::LineEditor
     @cache = {}
     @rendered_screen = RenderedScreen.new(base_y: 0, lines: [], cursor_y: 0)
     @input_lines = [[[""], 0, 0]]
-    @position = 0
+    @input_lines_position = 0
     @undoing = false
     reset_line
   end
@@ -1163,10 +1163,10 @@ class Reline::LineEditor
 
   def push_input_lines
     if @old_buffer_of_lines == @buffer_of_lines
-      @input_lines[@position] = [@buffer_of_lines.dup, @byte_pointer, @line_index]
+      @input_lines[@input_lines_position] = [@buffer_of_lines.dup, @byte_pointer, @line_index]
     else
-      @input_lines = @input_lines[0..@position]
-      @position += 1
+      @input_lines = @input_lines[0..@input_lines_position]
+      @input_lines_position += 1
       @input_lines.push([@buffer_of_lines.dup, @byte_pointer, @line_index])
     end
     trim_input_lines
@@ -1176,7 +1176,7 @@ class Reline::LineEditor
   def trim_input_lines
     if @input_lines.size > MAX_INPUT_LINES
       @input_lines.shift
-      @position -= 1
+      @input_lines_position -= 1
     end
   end
 
@@ -2537,20 +2537,20 @@ class Reline::LineEditor
   private def undo(_key)
     @undoing = true
 
-    return if @position <= 0
+    return if @input_lines_position <= 0
 
-    @position -= 1
-    target_lines, target_cursor_x, target_cursor_y = @input_lines[@position]
+    @input_lines_position -= 1
+    target_lines, target_cursor_x, target_cursor_y = @input_lines[@input_lines_position]
     set_current_lines(target_lines.dup, target_cursor_x, target_cursor_y)
   end
 
   private def redo(_key)
     @undoing = true
 
-    return if @position >= @input_lines.size - 1
+    return if @input_lines_position >= @input_lines.size - 1
 
-    @position += 1
-    target_lines, target_cursor_x, target_cursor_y = @input_lines[@position]
+    @input_lines_position += 1
+    target_lines, target_cursor_x, target_cursor_y = @input_lines[@input_lines_position]
     set_current_lines(target_lines.dup, target_cursor_x, target_cursor_y)
   end
 end

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -1166,7 +1166,7 @@ class Reline::LineEditor
 
   def push_past_lines
     if @old_buffer_of_lines == @buffer_of_lines
-      @past_lines[-1] = [@buffer_of_lines.dup, @byte_pointer, @line_index]
+      @past_lines[@position] = [@buffer_of_lines.dup, @byte_pointer, @line_index]
     else
       @position += 1
       @past_lines.push([@buffer_of_lines.dup, @byte_pointer, @line_index])

--- a/test/reline/test_key_actor_emacs.rb
+++ b/test/reline/test_key_actor_emacs.rb
@@ -1505,4 +1505,108 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
     input_keys("\C-_", false)
     assert_line_around_cursor('a', '')
   end
+
+  def test_redo
+    input_keys("aあb", false)
+    assert_line_around_cursor('aあb', '')
+    input_keys("\C-[", false)
+    assert_line_around_cursor('aあb', '')
+    input_keys("\C-_", false)
+    assert_line_around_cursor('aあ', '')
+    input_keys("\C-_", false)
+    assert_line_around_cursor('a', '')
+    input_keys("\C-[", false)
+    assert_line_around_cursor('aあ', '')
+    input_keys("\C-[", false)
+    assert_line_around_cursor('aあb', '')
+    input_keys("\C-_", false)
+    assert_line_around_cursor('aあ', '')
+    input_keys("c", false)
+    assert_line_around_cursor('aあc', '')
+    input_keys("\C-[", false)
+    assert_line_around_cursor('aあc', '')
+  end
+
+  def test_redo_with_cursor_position
+    input_keys("abc\C-b\C-h", false)
+    assert_line_around_cursor('a', 'c')
+    input_keys("\C-[", false)
+    assert_line_around_cursor('a', 'c')
+    input_keys("\C-_", false)
+    assert_line_around_cursor('ab', 'c')
+    input_keys("\C-[", false)
+    assert_line_around_cursor('a', 'c')
+  end
+
+  def test_redo_with_multiline
+    @line_editor.multiline_on
+    @line_editor.confirm_multiline_termination_proc = proc {}
+    input_keys("1\n2\n3", false)
+    assert_whole_lines(["1", "2", "3"])
+    assert_line_index(2)
+    assert_line_around_cursor('3', '')
+
+    input_keys("\C-_", false)
+    assert_whole_lines(["1", "2", ""])
+    assert_line_index(2)
+    assert_line_around_cursor('', '')
+
+    input_keys("\C-_", false)
+    assert_whole_lines(["1", "2"])
+    assert_line_index(1)
+    assert_line_around_cursor('2', '')
+
+    input_keys("\C-[", false)
+    assert_whole_lines(["1", "2", ""])
+    assert_line_index(2)
+    assert_line_around_cursor('', '')
+
+    input_keys("\C-[", false)
+    assert_whole_lines(["1", "2", "3"])
+    assert_line_index(2)
+    assert_line_around_cursor('3', '')
+
+    input_keys("\C-p\C-h\C-h", false)
+    assert_whole_lines(["1", "3"])
+    assert_line_index(0)
+    assert_line_around_cursor('1', '')
+
+    input_keys("\C-n", false)
+    assert_whole_lines(["1", "3"])
+    assert_line_index(1)
+    assert_line_around_cursor('3', '')
+
+    input_keys("\C-_", false)
+    assert_whole_lines(["1", "", "3"])
+    assert_line_index(1)
+    assert_line_around_cursor('', '')
+
+    input_keys("\C-_", false)
+    assert_whole_lines(["1", "2", "3"])
+    assert_line_index(1)
+    assert_line_around_cursor('2', '')
+
+    input_keys("\C-[", false)
+    assert_whole_lines(["1", "", "3"])
+    assert_line_index(1)
+    assert_line_around_cursor('', '')
+
+    input_keys("\C-[", false)
+    assert_whole_lines(["1", "3"])
+    assert_line_index(1)
+    assert_line_around_cursor('3', '')
+  end
+
+  def test_redo_with_many_times
+    str = "a" + "b" * 99 + "c"
+    input_keys(str, false)
+    100.times { input_keys("\C-_", false) }
+    assert_line_around_cursor('a', '')
+    input_keys("\C-_", false)
+    assert_line_around_cursor('a', '')
+    100.times { input_keys("\C-[", false) }
+    assert_line_around_cursor(str, '')
+    input_keys("\C-[", false)
+    assert_line_around_cursor(str, '')
+  end
 end

--- a/test/reline/test_key_actor_emacs.rb
+++ b/test/reline/test_key_actor_emacs.rb
@@ -1509,32 +1509,32 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
   def test_redo
     input_keys("aあb", false)
     assert_line_around_cursor('aあb', '')
-    input_keys("\C-[", false)
+    input_keys("\C-g", false)
     assert_line_around_cursor('aあb', '')
     input_keys("\C-_", false)
     assert_line_around_cursor('aあ', '')
     input_keys("\C-_", false)
     assert_line_around_cursor('a', '')
-    input_keys("\C-[", false)
+    input_keys("\C-g", false)
     assert_line_around_cursor('aあ', '')
-    input_keys("\C-[", false)
+    input_keys("\C-g", false)
     assert_line_around_cursor('aあb', '')
     input_keys("\C-_", false)
     assert_line_around_cursor('aあ', '')
     input_keys("c", false)
     assert_line_around_cursor('aあc', '')
-    input_keys("\C-[", false)
+    input_keys("\C-g", false)
     assert_line_around_cursor('aあc', '')
   end
 
   def test_redo_with_cursor_position
     input_keys("abc\C-b\C-h", false)
     assert_line_around_cursor('a', 'c')
-    input_keys("\C-[", false)
+    input_keys("\C-g", false)
     assert_line_around_cursor('a', 'c')
     input_keys("\C-_", false)
     assert_line_around_cursor('ab', 'c')
-    input_keys("\C-[", false)
+    input_keys("\C-g", false)
     assert_line_around_cursor('a', 'c')
   end
 
@@ -1556,12 +1556,12 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
     assert_line_index(1)
     assert_line_around_cursor('2', '')
 
-    input_keys("\C-[", false)
+    input_keys("\C-g", false)
     assert_whole_lines(["1", "2", ""])
     assert_line_index(2)
     assert_line_around_cursor('', '')
 
-    input_keys("\C-[", false)
+    input_keys("\C-g", false)
     assert_whole_lines(["1", "2", "3"])
     assert_line_index(2)
     assert_line_around_cursor('3', '')
@@ -1586,12 +1586,12 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
     assert_line_index(1)
     assert_line_around_cursor('2', '')
 
-    input_keys("\C-[", false)
+    input_keys("\C-g", false)
     assert_whole_lines(["1", "", "3"])
     assert_line_index(1)
     assert_line_around_cursor('', '')
 
-    input_keys("\C-[", false)
+    input_keys("\C-g", false)
     assert_whole_lines(["1", "3"])
     assert_line_index(1)
     assert_line_around_cursor('3', '')
@@ -1604,9 +1604,9 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
     assert_line_around_cursor('a', '')
     input_keys("\C-_", false)
     assert_line_around_cursor('a', '')
-    100.times { input_keys("\C-[", false) }
+    100.times { input_keys("\C-g", false) }
     assert_line_around_cursor(str, '')
-    input_keys("\C-[", false)
+    input_keys("\C-g", false)
     assert_line_around_cursor(str, '')
   end
 end

--- a/test/reline/test_key_actor_emacs.rb
+++ b/test/reline/test_key_actor_emacs.rb
@@ -1509,32 +1509,32 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
   def test_redo
     input_keys("aあb", false)
     assert_line_around_cursor('aあb', '')
-    input_keys("\C-g", false)
+    input_keys("\M-\C-_", false)
     assert_line_around_cursor('aあb', '')
     input_keys("\C-_", false)
     assert_line_around_cursor('aあ', '')
     input_keys("\C-_", false)
     assert_line_around_cursor('a', '')
-    input_keys("\C-g", false)
+    input_keys("\M-\C-_", false)
     assert_line_around_cursor('aあ', '')
-    input_keys("\C-g", false)
+    input_keys("\M-\C-_", false)
     assert_line_around_cursor('aあb', '')
     input_keys("\C-_", false)
     assert_line_around_cursor('aあ', '')
     input_keys("c", false)
     assert_line_around_cursor('aあc', '')
-    input_keys("\C-g", false)
+    input_keys("\M-\C-_", false)
     assert_line_around_cursor('aあc', '')
   end
 
   def test_redo_with_cursor_position
     input_keys("abc\C-b\C-h", false)
     assert_line_around_cursor('a', 'c')
-    input_keys("\C-g", false)
+    input_keys("\M-\C-_", false)
     assert_line_around_cursor('a', 'c')
     input_keys("\C-_", false)
     assert_line_around_cursor('ab', 'c')
-    input_keys("\C-g", false)
+    input_keys("\M-\C-_", false)
     assert_line_around_cursor('a', 'c')
   end
 
@@ -1556,12 +1556,12 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
     assert_line_index(1)
     assert_line_around_cursor('2', '')
 
-    input_keys("\C-g", false)
+    input_keys("\M-\C-_", false)
     assert_whole_lines(["1", "2", ""])
     assert_line_index(2)
     assert_line_around_cursor('', '')
 
-    input_keys("\C-g", false)
+    input_keys("\M-\C-_", false)
     assert_whole_lines(["1", "2", "3"])
     assert_line_index(2)
     assert_line_around_cursor('3', '')
@@ -1586,12 +1586,12 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
     assert_line_index(1)
     assert_line_around_cursor('2', '')
 
-    input_keys("\C-g", false)
+    input_keys("\M-\C-_", false)
     assert_whole_lines(["1", "", "3"])
     assert_line_index(1)
     assert_line_around_cursor('', '')
 
-    input_keys("\C-g", false)
+    input_keys("\M-\C-_", false)
     assert_whole_lines(["1", "3"])
     assert_line_index(1)
     assert_line_around_cursor('3', '')
@@ -1604,9 +1604,9 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
     assert_line_around_cursor('a', '')
     input_keys("\C-_", false)
     assert_line_around_cursor('a', '')
-    100.times { input_keys("\C-g", false) }
+    100.times { input_keys("\M-\C-_", false) }
     assert_line_around_cursor(str, '')
-    input_keys("\C-g", false)
+    input_keys("\M-\C-_", false)
     assert_line_around_cursor(str, '')
   end
 end

--- a/test/reline/test_key_actor_emacs.rb
+++ b/test/reline/test_key_actor_emacs.rb
@@ -1498,7 +1498,7 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
   end
 
   def test_undo_with_many_times
-    str = "a" + "b" * 100
+    str = "a" + "b" * 99
     input_keys(str, false)
     100.times { input_keys("\C-_", false) }
     assert_line_around_cursor('a', '')
@@ -1598,7 +1598,7 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
   end
 
   def test_redo_with_many_times
-    str = "a" + "b" * 99 + "c"
+    str = "a" + "b" * 98 + "c"
     input_keys(str, false)
     100.times { input_keys("\C-_", false) }
     assert_line_around_cursor('a', '')

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -575,7 +575,7 @@ begin
       write("abc")
       write("\e[200~def hoge\r\t3\rend\e[201~")
       write("\C-_")
-      write("\C-g")
+      write("\M-\C-_")
       close
       assert_screen(<<~EOC)
         Multiline REPL.

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -569,21 +569,22 @@ begin
       EOC
     end
 
-    def test_bracketed_paste_with_redo
-      omit if Reline.core.io_gate.win?
-      start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
-      write("abc")
-      write("\e[200~def hoge\r\t3\rend\e[201~")
-      write("\C-_")
-      write("\C-[")
-      close
-      assert_screen(<<~EOC)
-        Multiline REPL.
-        prompt> abcdef hoge
-        prompt>   3
-        prompt> end
-      EOC
-    end
+    # TODO: It seems that this feature works correctly in development environment, but this test does not pass.
+    # def test_bracketed_paste_with_redo
+    #   omit if Reline.core.io_gate.win?
+    #   start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
+    #   write("abc")
+    #   write("\e[200~def hoge\r\t3\rend\e[201~")
+    #   write("\C-_")
+    #   write("\C-[")
+    #   close
+    #   assert_screen(<<~EOC)
+    #     Multiline REPL.
+    #     prompt> abcdef hoge
+    #     prompt>   3
+    #     prompt> end
+    #   EOC
+    # end
 
     def test_backspace_until_returns_to_initial
       start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -569,6 +569,22 @@ begin
       EOC
     end
 
+    def test_bracketed_paste_with_redo
+      omit if Reline.core.io_gate.win?
+      start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
+      write("abc")
+      write("\e[200~def hoge\r\t3\rend\e[201~")
+      write("\C-_")
+      write("\C-[")
+      close
+      assert_screen(<<~EOC)
+        Multiline REPL.
+        prompt> abcdef hoge
+        prompt>   3
+        prompt> end
+      EOC
+    end
+
     def test_backspace_until_returns_to_initial
       start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write("ABC")

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -569,22 +569,21 @@ begin
       EOC
     end
 
-    # TODO: It seems that this feature works correctly in development environment, but this test does not pass.
-    # def test_bracketed_paste_with_redo
-    #   omit if Reline.core.io_gate.win?
-    #   start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
-    #   write("abc")
-    #   write("\e[200~def hoge\r\t3\rend\e[201~")
-    #   write("\C-_")
-    #   write("\C-[")
-    #   close
-    #   assert_screen(<<~EOC)
-    #     Multiline REPL.
-    #     prompt> abcdef hoge
-    #     prompt>   3
-    #     prompt> end
-    #   EOC
-    # end
+    def test_bracketed_paste_with_redo
+      omit if Reline.core.io_gate.win?
+      start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
+      write("abc")
+      write("\e[200~def hoge\r\t3\rend\e[201~")
+      write("\C-_")
+      write("\C-g")
+      close
+      assert_screen(<<~EOC)
+        Multiline REPL.
+        prompt> abcdef hoge
+        prompt>   3
+        prompt> end
+      EOC
+    end
 
     def test_backspace_until_returns_to_initial
       start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')


### PR DESCRIPTION
## Overview
Implemented the redo method to enable reverting undone actions on a per-action basis.

## Implementation Approach
By defining `@position`, I was able to implement the redo command using only `@past_lines`, which was originally defined for the undo command. By saving the current line state in `@past_lines`, the entire mechanism was simplified. Specifically, it works as follows:

* Normal input: Delete all elements after the current position in `@past_lines`, push the input into `@past_lines`, and increase `@position` by 1.
* Cursor movement: Update only the cursor position in `@past_lines`.
* Undo: Decrease `@position` by 1 and return `@past_lines[position]`.
* Redo: Increase `@position` by 1 and return `@past_lines[position]`.