### PR TITLE
Unite key bindings, key mapping and multibyte buffer

### DIFF
--- a/lib/reline/key_actor.rb
+++ b/lib/reline/key_actor.rb
@@ -2,6 +2,7 @@ module Reline::KeyActor
 end
 
 require 'reline/key_actor/base'
+require 'reline/key_actor/composite'
 require 'reline/key_actor/emacs'
 require 'reline/key_actor/vi_command'
 require 'reline/key_actor/vi_insert'

--- a/lib/reline/key_actor/base.rb
+++ b/lib/reline/key_actor/base.rb
@@ -1,15 +1,36 @@
 class Reline::KeyActor::Base
-  MAPPING = Array.new(256)
-
-  def get_method(key)
-    self.class::MAPPING[key]
-  end
-
   def initialize
-    @default_key_bindings = {}
+    @matching_bytes = {}
+    @key_bindings = {}
   end
 
-  def default_key_bindings
-    @default_key_bindings
+  def add_mappings(mappings)
+    add([27], :ed_ignore)
+    128.times do |key|
+      func = mappings[key]
+      meta_func = mappings[key | 0b10000000]
+      add([key], func) unless func == :ed_unassigned
+      add([27, key], meta_func) unless meta_func == :ed_unassigned
+    end
+  end
+
+  def add(key, func)
+    (1...key.size).each do |size|
+      @matching_bytes[key.take(size)] = true
+    end
+    @key_bindings[key] = func
+  end
+
+  def matching?(key)
+    @matching_bytes[key]
+  end
+
+  def get(key)
+    @key_bindings[key]
+  end
+
+  def clear
+    @matching_bytes.clear
+    @key_bindings.clear
   end
 end

--- a/lib/reline/key_actor/composite.rb
+++ b/lib/reline/key_actor/composite.rb
@@ -1,0 +1,17 @@
+class Reline::KeyActor::Composite
+  def initialize(key_actors)
+    @key_actors = key_actors
+  end
+
+  def matching?(key)
+    @key_actors.any? { |key_actor| key_actor.matching?(key) }
+  end
+
+  def get(key)
+    @key_actors.each do |key_actor|
+      func = key_actor.get(key)
+      return func if func
+    end
+    nil
+  end
+end

--- a/lib/reline/key_actor/emacs.rb
+++ b/lib/reline/key_actor/emacs.rb
@@ -1,5 +1,5 @@
-class Reline::KeyActor::Emacs < Reline::KeyActor::Base
-  MAPPING = [
+module Reline::KeyActor
+  EMACS_MAPPING = [
     #   0 ^@
     :em_set_mark,
     #   1 ^A

--- a/lib/reline/key_actor/vi_command.rb
+++ b/lib/reline/key_actor/vi_command.rb
@@ -1,5 +1,5 @@
-class Reline::KeyActor::ViCommand < Reline::KeyActor::Base
-  MAPPING = [
+module Reline::KeyActor
+  VI_COMMAND_MAPPING = [
     #   0 ^@
     :ed_unassigned,
     #   1 ^A

--- a/lib/reline/key_actor/vi_insert.rb
+++ b/lib/reline/key_actor/vi_insert.rb
@@ -1,5 +1,5 @@
-class Reline::KeyActor::ViInsert < Reline::KeyActor::Base
-  MAPPING = [
+module Reline::KeyActor
+  VI_INSERT_MAPPING = [
     #   0 ^@
     :ed_unassigned,
     #   1 ^A

--- a/lib/reline/key_stroke.rb
+++ b/lib/reline/key_stroke.rb
@@ -3,143 +3,80 @@ class Reline::KeyStroke
   CSI_PARAMETER_BYTES_RANGE = 0x30..0x3f
   CSI_INTERMEDIATE_BYTES_RANGE = (0x20..0x2f)
 
-  def initialize(config)
+  def initialize(config, encoding)
     @config = config
-  end
-
-  def compress_meta_key(ary)
-    return ary unless @config.convert_meta
-    ary.inject([]) { |result, key|
-      if result.size > 0 and result.last == "\e".ord
-        result[result.size - 1] = Reline::Key.new(key, key | 0b10000000, true)
-      else
-        result << key
-      end
-      result
-    }
-  end
-
-  def start_with?(me, other)
-    compressed_me = compress_meta_key(me)
-    compressed_other = compress_meta_key(other)
-    i = 0
-    loop do
-      my_c = compressed_me[i]
-      other_c = compressed_other[i]
-      other_is_last = (i + 1) == compressed_other.size
-      me_is_last = (i + 1) == compressed_me.size
-      if my_c != other_c
-        if other_c == "\e".ord and other_is_last and my_c.is_a?(Reline::Key) and my_c.with_meta
-          return true
-        else
-          return false
-        end
-      elsif other_is_last
-        return true
-      elsif me_is_last
-        return false
-      end
-      i += 1
-    end
-  end
-
-  def equal?(me, other)
-    case me
-    when Array
-      compressed_me = compress_meta_key(me)
-      compressed_other = compress_meta_key(other)
-      compressed_me.size == compressed_other.size and [compressed_me, compressed_other].transpose.all?{ |i| equal?(i[0], i[1]) }
-    when Integer
-      if other.is_a?(Reline::Key)
-        if other.combined_char == "\e".ord
-          false
-        else
-          other.combined_char == me
-        end
-      else
-        me == other
-      end
-    when Reline::Key
-      if other.is_a?(Integer)
-        me.combined_char == other
-      else
-        me == other
-      end
-    end
+    @encoding = encoding
   end
 
   def match_status(input)
-    key_mapping.keys.select { |lhs|
-      start_with?(lhs, input)
-    }.tap { |it|
-      return :matched  if it.size == 1 && equal?(it[0], input)
-      return :matching if it.size == 1 && !equal?(it[0], input)
-      return :matched  if it.max_by(&:size)&.size&.< input.size
-      return :matching if it.size > 1
-    }
-    if key_mapping.keys.any? { |lhs| start_with?(input, lhs) }
+    matched = key_mapping.get(input)
+    if key_mapping.matching?(input)
+      matched ? :matching_matched : :matching
+    elsif matched
       :matched
+    elsif input[0] == ESC_BYTE
+      match_unknown_escape_sequence(input, vi_mode: @config.editing_mode_is?(:vi_insert, :vi_command))
     else
-      match_unknown_escape_sequence(input).first
+      s = input.map(&:chr).join.force_encoding(@encoding)
+      if s.valid_encoding?
+        s.size == 1 ? :matched : :unmatched
+      else
+        # invalid byte sequence can be matching (part of multi-byte character) or matched (broken input to be ignored)
+        :matching_matched
+      end
     end
   end
 
+  def valid_char_bytes?(bytes)
+    bytes.map(&:chr).join.force_encoding(@encoding)
+  end
+
   def expand(input)
-    lhs = key_mapping.keys.select { |item| start_with?(input, item) }.sort_by(&:size).last
-    unless lhs
-      status, size = match_unknown_escape_sequence(input)
-      case status
+    matched_bytes = []
+    (1..input.size).each do |i|
+      bytes = input.take(i)
+      case match_status(bytes)
       when :matched
-        return [:ed_unassigned] + expand(input.drop(size))
-      when :matching
-        return [:ed_unassigned]
-      else
-        return input
+        matched_bytes = bytes
+        break
+      when :matching_matched
+        matched_bytes = bytes
       end
     end
-    rhs = key_mapping[lhs]
 
-    case rhs
-    when String
-      rhs_bytes = rhs.bytes
-      expand(expand(rhs_bytes) + expand(input.drop(lhs.size)))
-    when Symbol
-      [rhs] + expand(input.drop(lhs.size))
-    when Array
-      rhs
-    end
+    func = key_mapping.get(matched_bytes)
+    return [func, matched_bytes, input.drop(matched_bytes.size)] if func || matched_bytes[0] == ESC_BYTE
+
+    s = input.map(&:chr).join.force_encoding(@encoding)
+    s = nil unless s.valid_encoding?
+    [s, input, []]
   end
 
   private
 
-  # returns match status of CSI/SS3 sequence and matched length
-  def match_unknown_escape_sequence(input)
+  # returns match status of CSI/SS3 sequence
+  def match_unknown_escape_sequence(input, vi_mode: false)
     idx = 0
-    return [:unmatched, nil] unless input[idx] == ESC_BYTE
+    return :unmatched unless input[idx] == ESC_BYTE
     idx += 1
     idx += 1 if input[idx] == ESC_BYTE
 
     case input[idx]
     when nil
-      return [:matching, nil]
+      return :matching
     when 91 # == '['.ord
-      # CSI sequence
+      # CSI sequence `ESC [ ... char`
       idx += 1
       idx += 1 while idx < input.size && CSI_PARAMETER_BYTES_RANGE.cover?(input[idx])
       idx += 1 while idx < input.size && CSI_INTERMEDIATE_BYTES_RANGE.cover?(input[idx])
-      input[idx] ? [:matched, idx + 1] : [:matching, nil]
     when 79 # == 'O'.ord
-      # SS3 sequence
-      input[idx + 1] ? [:matched, idx + 2] : [:matching, nil]
+      # SS3 sequence `ESC O char`
+      idx += 1
     else
-      if idx == 1
-        # `ESC char`, make it :unmatched so that it will be handled correctly in `read_2nd_character_of_key_sequence`
-        [:unmatched, nil]
-      else
-        # `ESC ESC char`
-        [:matched, idx + 1]
-      end
+      # `ESC char` or `ESC ESC char`
+      return :unmatched if vi_mode
     end
+    input[idx + 1] ? :unmatched : input[idx] ? :matched : :matching
   end
 
   def key_mapping

--- a/test/reline/test_config.rb
+++ b/test/reline/test_config.rb
@@ -22,6 +22,15 @@ class Reline::Config::Test < Reline::TestCase
     @config.reset
   end
 
+  def additional_key_bindings(keymap_label)
+    @config.instance_variable_get(:@additional_key_bindings)[keymap_label].instance_variable_get(:@key_bindings)
+  end
+
+  def registered_key_bindings(keys)
+    key_bindings = @config.key_bindings
+    keys.to_h { |key| [key, key_bindings.get(key)] }
+  end
+
   def test_read_lines
     @config.read_lines(<<~LINES.lines)
       set bell-style on
@@ -99,14 +108,17 @@ class Reline::Config::Test < Reline::TestCase
     assert_equal nil, @config.convert_meta
   end
 
-  def test_comment_line
-    @config.read_lines([" #a: error\n"])
-    assert_not_include @config.key_bindings, nil
-  end
-
   def test_invalid_keystroke
-    @config.read_lines(["a: error\n"])
-    assert_not_include @config.key_bindings, nil
+    @config.read_lines(<<~LINES.lines)
+      #"a": comment
+      a: error
+      "b": no-error
+    LINES
+    key_bindings = additional_key_bindings(:emacs)
+    assert_not_include key_bindings, 'a'.bytes
+    assert_not_include key_bindings, nil
+    assert_not_include key_bindings, []
+    assert_include key_bindings, 'b'.bytes
   end
 
   def test_bind_key
@@ -243,9 +255,9 @@ class Reline::Config::Test < Reline::TestCase
       $endif
       "\xC": "O"
     LINES
-    keys = [0x1, 0x3, 0x4, 0x6, 0x7, 0xC]
-    key_bindings = keys.to_h { |k| [[k.ord], ['O'.ord]] }
-    assert_equal(key_bindings, @config.instance_variable_get(:@additional_key_bindings)[:emacs])
+    keys = [[0x1], [0x3], [0x4], [0x6], [0x7], [0xC]]
+    key_bindings = keys.to_h { |k| [k, ['O'.ord]] }
+    assert_equal(key_bindings, additional_key_bindings(:emacs))
   end
 
   def test_unclosed_if
@@ -284,9 +296,9 @@ class Reline::Config::Test < Reline::TestCase
       $endif
     LINES
 
-    assert_equal({[5] => :history_search_backward}, @config.instance_variable_get(:@additional_key_bindings)[:emacs])
-    assert_equal({}, @config.instance_variable_get(:@additional_key_bindings)[:vi_insert])
-    assert_equal({}, @config.instance_variable_get(:@additional_key_bindings)[:vi_command])
+    assert_equal({[5] => :history_search_backward}, additional_key_bindings(:emacs))
+    assert_equal({}, additional_key_bindings(:vi_insert))
+    assert_equal({}, additional_key_bindings(:vi_command))
   end
 
   def test_else
@@ -298,9 +310,9 @@ class Reline::Config::Test < Reline::TestCase
       $endif
     LINES
 
-    assert_equal({[6] => :history_search_forward}, @config.instance_variable_get(:@additional_key_bindings)[:emacs])
-    assert_equal({}, @config.instance_variable_get(:@additional_key_bindings)[:vi_insert])
-    assert_equal({}, @config.instance_variable_get(:@additional_key_bindings)[:vi_command])
+    assert_equal({[6] => :history_search_forward}, additional_key_bindings(:emacs))
+    assert_equal({}, additional_key_bindings(:vi_insert))
+    assert_equal({}, additional_key_bindings(:vi_command))
   end
 
   def test_if_with_invalid_mode
@@ -312,9 +324,9 @@ class Reline::Config::Test < Reline::TestCase
       $endif
     LINES
 
-    assert_equal({[6] => :history_search_forward}, @config.instance_variable_get(:@additional_key_bindings)[:emacs])
-    assert_equal({}, @config.instance_variable_get(:@additional_key_bindings)[:vi_insert])
-    assert_equal({}, @config.instance_variable_get(:@additional_key_bindings)[:vi_command])
+    assert_equal({[6] => :history_search_forward}, additional_key_bindings(:emacs))
+    assert_equal({}, additional_key_bindings(:vi_insert))
+    assert_equal({}, additional_key_bindings(:vi_command))
   end
 
   def test_mode_label_differs_from_keymap_label
@@ -329,9 +341,9 @@ class Reline::Config::Test < Reline::TestCase
         "\C-e": history-search-backward
       $endif
     LINES
-    assert_equal({[5] => :history_search_backward}, @config.instance_variable_get(:@additional_key_bindings)[:emacs])
-    assert_equal({}, @config.instance_variable_get(:@additional_key_bindings)[:vi_insert])
-    assert_equal({}, @config.instance_variable_get(:@additional_key_bindings)[:vi_command])
+    assert_equal({[5] => :history_search_backward}, additional_key_bindings(:emacs))
+    assert_equal({}, additional_key_bindings(:vi_insert))
+    assert_equal({}, additional_key_bindings(:vi_command))
   end
 
   def test_if_without_else_condition
@@ -342,9 +354,9 @@ class Reline::Config::Test < Reline::TestCase
       $endif
     LINES
 
-    assert_equal({}, @config.instance_variable_get(:@additional_key_bindings)[:emacs])
-    assert_equal({[5] => :history_search_backward}, @config.instance_variable_get(:@additional_key_bindings)[:vi_insert])
-    assert_equal({}, @config.instance_variable_get(:@additional_key_bindings)[:vi_command])
+    assert_equal({}, additional_key_bindings(:emacs))
+    assert_equal({[5] => :history_search_backward}, additional_key_bindings(:vi_insert))
+    assert_equal({}, additional_key_bindings(:vi_command))
   end
 
   def test_default_key_bindings
@@ -355,7 +367,7 @@ class Reline::Config::Test < Reline::TestCase
     LINES
 
     expected = { 'abcd'.bytes => 'ABCD'.bytes, 'ijkl'.bytes => 'IJKL'.bytes }
-    assert_equal expected, @config.key_bindings
+    assert_equal expected, registered_key_bindings(expected.keys)
   end
 
   def test_additional_key_bindings
@@ -365,7 +377,7 @@ class Reline::Config::Test < Reline::TestCase
     LINES
 
     expected = { 'ef'.bytes => 'EF'.bytes, 'gh'.bytes => 'GH'.bytes }
-    assert_equal expected, @config.key_bindings
+    assert_equal expected, registered_key_bindings(expected.keys)
   end
 
   def test_additional_key_bindings_with_nesting_and_comment_out
@@ -377,7 +389,7 @@ class Reline::Config::Test < Reline::TestCase
     LINES
 
     expected = { 'ef'.bytes => 'EF'.bytes, 'gh'.bytes => 'GH'.bytes }
-    assert_equal expected, @config.key_bindings
+    assert_equal expected, registered_key_bindings(expected.keys)
   end
 
   def test_additional_key_bindings_for_other_keymap
@@ -392,7 +404,7 @@ class Reline::Config::Test < Reline::TestCase
     LINES
 
     expected = { 'cd'.bytes => 'CD'.bytes }
-    assert_equal expected, @config.key_bindings
+    assert_equal expected, registered_key_bindings(expected.keys)
   end
 
   def test_additional_key_bindings_for_auxiliary_emacs_keymaps
@@ -414,7 +426,7 @@ class Reline::Config::Test < Reline::TestCase
       "\C-xef".bytes => 'EF'.bytes,
       "\egh".bytes => 'GH'.bytes,
     }
-    assert_equal expected, @config.key_bindings
+    assert_equal expected, registered_key_bindings(expected.keys)
   end
 
   def test_key_bindings_with_reset
@@ -426,7 +438,7 @@ class Reline::Config::Test < Reline::TestCase
     LINES
     @config.reset
     expected = { 'default'.bytes => 'DEFAULT'.bytes, 'additional'.bytes => 'ADDITIONAL'.bytes }
-    assert_equal expected, @config.key_bindings
+    assert_equal expected, registered_key_bindings(expected.keys)
   end
 
   def test_history_size

--- a/test/reline/test_key_actor_emacs.rb
+++ b/test/reline/test_key_actor_emacs.rb
@@ -1,6 +1,6 @@
 require_relative 'helper'
 
-class Reline::KeyActor::Emacs::Test < Reline::TestCase
+class Reline::KeyActor::EmacsTest < Reline::TestCase
   def setup
     Reline.send(:test_mode)
     @prompt = '> '
@@ -157,18 +157,18 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
   end
 
   def test_em_kill_line
-    @line_editor.input_key(Reline::Key.new(:em_kill_line, :em_kill_line, false))
+    input_key_by_symbol(:em_kill_line)
     assert_line_around_cursor('', '')
     input_keys('abc')
-    @line_editor.input_key(Reline::Key.new(:em_kill_line, :em_kill_line, false))
+    input_key_by_symbol(:em_kill_line)
     assert_line_around_cursor('', '')
     input_keys('abc')
     input_keys("\C-b", false)
-    @line_editor.input_key(Reline::Key.new(:em_kill_line, :em_kill_line, false))
+    input_key_by_symbol(:em_kill_line)
     assert_line_around_cursor('', '')
     input_keys('abc')
     input_keys("\C-a", false)
-    @line_editor.input_key(Reline::Key.new(:em_kill_line, :em_kill_line, false))
+    input_key_by_symbol(:em_kill_line)
     assert_line_around_cursor('', '')
   end
 
@@ -273,12 +273,12 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
   def test_key_delete
     input_keys('abc')
     assert_line_around_cursor('abc', '')
-    @line_editor.input_key(Reline::Key.new(:key_delete, :key_delete, false))
+    input_key_by_symbol(:key_delete)
     assert_line_around_cursor('abc', '')
   end
 
   def test_key_delete_does_not_end_editing
-    @line_editor.input_key(Reline::Key.new(:key_delete, :key_delete, false))
+    input_key_by_symbol(:key_delete)
     assert_line_around_cursor('', '')
     refute(@line_editor.finished?)
   end
@@ -287,7 +287,7 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
     input_keys('abc')
     input_keys("\C-b", false)
     assert_line_around_cursor('ab', 'c')
-    @line_editor.input_key(Reline::Key.new(:key_delete, :key_delete, false))
+    input_key_by_symbol(:key_delete)
     assert_line_around_cursor('ab', '')
   end
 
@@ -731,10 +731,10 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
     input_keys("\C-b", false)
     assert_line_around_cursor('foo', 'o')
     assert_equal(nil, @line_editor.instance_variable_get(:@menu_info))
-    @line_editor.input_key(Reline::Key.new(:em_delete_or_list, :em_delete_or_list, false))
+    input_key_by_symbol(:em_delete_or_list)
     assert_line_around_cursor('foo', '')
     assert_equal(nil, @line_editor.instance_variable_get(:@menu_info))
-    @line_editor.input_key(Reline::Key.new(:em_delete_or_list, :em_delete_or_list, false))
+    input_key_by_symbol(:em_delete_or_list)
     assert_line_around_cursor('foo', '')
     assert_equal(%w{foo_foo foo_bar foo_baz}, @line_editor.instance_variable_get(:@menu_info).list)
   end
@@ -1409,11 +1409,11 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
   end
 
   def test_halfwidth_kana_width_dakuten
-    input_raw_keys('ｶﾞｷﾞｹﾞｺﾞ')
+    input_keys('ｶﾞｷﾞｹﾞｺﾞ')
     assert_line_around_cursor('ｶﾞｷﾞｹﾞｺﾞ', '')
     input_keys("\C-b\C-b", false)
     assert_line_around_cursor('ｶﾞｷﾞ', 'ｹﾞｺﾞ')
-    input_raw_keys('ｸﾞ', false)
+    input_keys('ｸﾞ', false)
     assert_line_around_cursor('ｶﾞｷﾞｸﾞ', 'ｹﾞｺﾞ')
   end
 

--- a/test/reline/test_key_actor_vi.rb
+++ b/test/reline/test_key_actor_vi.rb
@@ -1,6 +1,6 @@
 require_relative 'helper'
 
-class Reline::KeyActor::ViInsert::Test < Reline::TestCase
+class Reline::KeyActor::ViInsertTest < Reline::TestCase
   def setup
     Reline.send(:test_mode)
     @prompt = '> '
@@ -19,63 +19,63 @@ class Reline::KeyActor::ViInsert::Test < Reline::TestCase
 
   def test_vi_command_mode
     input_keys("\C-[")
-    assert_instance_of(Reline::KeyActor::ViCommand, @config.editing_mode)
+    assert_equal(:vi_command, @config.editing_mode)
   end
 
   def test_vi_command_mode_with_input
     input_keys("abc\C-[")
-    assert_instance_of(Reline::KeyActor::ViCommand, @config.editing_mode)
+    assert_equal(:vi_command, @config.editing_mode)
     assert_line_around_cursor('ab', 'c')
   end
 
   def test_vi_insert
-    assert_instance_of(Reline::KeyActor::ViInsert, @config.editing_mode)
+    assert_equal(:vi_insert, @config.editing_mode)
     input_keys('i')
     assert_line_around_cursor('i', '')
-    assert_instance_of(Reline::KeyActor::ViInsert, @config.editing_mode)
+    assert_equal(:vi_insert, @config.editing_mode)
     input_keys("\C-[")
     assert_line_around_cursor('', 'i')
-    assert_instance_of(Reline::KeyActor::ViCommand, @config.editing_mode)
+    assert_equal(:vi_command, @config.editing_mode)
     input_keys('i')
     assert_line_around_cursor('', 'i')
-    assert_instance_of(Reline::KeyActor::ViInsert, @config.editing_mode)
+    assert_equal(:vi_insert, @config.editing_mode)
   end
 
   def test_vi_add
-    assert_instance_of(Reline::KeyActor::ViInsert, @config.editing_mode)
+    assert_equal(:vi_insert, @config.editing_mode)
     input_keys('a')
     assert_line_around_cursor('a', '')
-    assert_instance_of(Reline::KeyActor::ViInsert, @config.editing_mode)
+    assert_equal(:vi_insert, @config.editing_mode)
     input_keys("\C-[")
     assert_line_around_cursor('', 'a')
-    assert_instance_of(Reline::KeyActor::ViCommand, @config.editing_mode)
+    assert_equal(:vi_command, @config.editing_mode)
     input_keys('a')
     assert_line_around_cursor('a', '')
-    assert_instance_of(Reline::KeyActor::ViInsert, @config.editing_mode)
+    assert_equal(:vi_insert, @config.editing_mode)
   end
 
   def test_vi_insert_at_bol
     input_keys('I')
     assert_line_around_cursor('I', '')
-    assert_instance_of(Reline::KeyActor::ViInsert, @config.editing_mode)
+    assert_equal(:vi_insert, @config.editing_mode)
     input_keys("12345\C-[hh")
     assert_line_around_cursor('I12', '345')
-    assert_instance_of(Reline::KeyActor::ViCommand, @config.editing_mode)
+    assert_equal(:vi_command, @config.editing_mode)
     input_keys('I')
     assert_line_around_cursor('', 'I12345')
-    assert_instance_of(Reline::KeyActor::ViInsert, @config.editing_mode)
+    assert_equal(:vi_insert, @config.editing_mode)
   end
 
   def test_vi_add_at_eol
     input_keys('A')
     assert_line_around_cursor('A', '')
-    assert_instance_of(Reline::KeyActor::ViInsert, @config.editing_mode)
+    assert_equal(:vi_insert, @config.editing_mode)
     input_keys("12345\C-[hh")
     assert_line_around_cursor('A12', '345')
-    assert_instance_of(Reline::KeyActor::ViCommand, @config.editing_mode)
+    assert_equal(:vi_command, @config.editing_mode)
     input_keys('A')
     assert_line_around_cursor('A12345', '')
-    assert_instance_of(Reline::KeyActor::ViInsert, @config.editing_mode)
+    assert_equal(:vi_insert, @config.editing_mode)
   end
 
   def test_ed_insert_one
@@ -644,7 +644,7 @@ class Reline::KeyActor::ViInsert::Test < Reline::TestCase
     assert_line_around_cursor('Readline', '')
     input_keys("\C-i", false)
     assert_line_around_cursor('Regexp', '')
-    @line_editor.input_key(Reline::Key.new(:completion_journey_up, :completion_journey_up, false))
+    input_key_by_symbol(:completion_journey_up)
     assert_line_around_cursor('Readline', '')
   ensure
     @config.autocompletion = false
@@ -667,7 +667,7 @@ class Reline::KeyActor::ViInsert::Test < Reline::TestCase
     assert_line_around_cursor('Readline', '')
     input_keys("\C-i", false)
     assert_line_around_cursor('Regexp', '')
-    @line_editor.input_key(Reline::Key.new(:menu_complete_backward, :menu_complete_backward, false))
+    input_key_by_symbol(:menu_complete_backward)
     assert_line_around_cursor('Readline', '')
   ensure
     @config.autocompletion = false
@@ -901,11 +901,11 @@ class Reline::KeyActor::ViInsert::Test < Reline::TestCase
     assert_line_around_cursor('abc', '')
     input_keys("\C-[0C")
     assert_line_around_cursor('', '')
-    assert_instance_of(Reline::KeyActor::ViInsert, @config.editing_mode)
+    assert_equal(:vi_insert, @config.editing_mode)
   end
 
   def test_vi_motion_operators
-    assert_instance_of(Reline::KeyActor::ViInsert, @config.editing_mode)
+    assert_equal(:vi_insert, @config.editing_mode)
 
     assert_nothing_raised do
       input_keys("test = { foo: bar }\C-[BBBldt}b")

--- a/test/reline/test_key_stroke.rb
+++ b/test/reline/test_key_stroke.rb
@@ -23,35 +23,35 @@ class Reline::KeyStroke::Test < Reline::TestCase
     }.each_pair do |key, func|
       config.add_default_key_binding(key.bytes, func.bytes)
     end
-    stroke = Reline::KeyStroke.new(config)
-    assert_equal(:matching, stroke.match_status("a".bytes))
-    assert_equal(:matching, stroke.match_status("ab".bytes))
+    stroke = Reline::KeyStroke.new(config, Encoding::UTF_8)
+    assert_equal(:matching_matched, stroke.match_status("a".bytes))
+    assert_equal(:matching_matched, stroke.match_status("ab".bytes))
     assert_equal(:matched, stroke.match_status("abc".bytes))
-    assert_equal(:matched, stroke.match_status("abz".bytes))
-    assert_equal(:matched, stroke.match_status("abx".bytes))
-    assert_equal(:matched, stroke.match_status("ac".bytes))
-    assert_equal(:matched, stroke.match_status("aa".bytes))
+    assert_equal(:unmatched, stroke.match_status("abz".bytes))
+    assert_equal(:unmatched, stroke.match_status("abcx".bytes))
+    assert_equal(:unmatched, stroke.match_status("aa".bytes))
     assert_equal(:matched, stroke.match_status("x".bytes))
-    assert_equal(:unmatched, stroke.match_status("m".bytes))
-    assert_equal(:matched, stroke.match_status("abzwabk".bytes))
+    assert_equal(:unmatched, stroke.match_status("xa".bytes))
   end
 
   def test_match_unknown
     config = Reline::Config.new
     config.add_default_key_binding("\e[9abc".bytes, 'x')
-    stroke = Reline::KeyStroke.new(config)
+    stroke = Reline::KeyStroke.new(config, Encoding::UTF_8)
     sequences = [
-      "\e[9abc",
       "\e[9d",
       "\e[A", # Up
       "\e[1;1R", # Cursor position report
       "\e[15~", # F5
       "\eOP", # F1
-      "\e\e[A" # Option+Up
+      "\e\e[A", # Option+Up
+      "\eX",
+      "\e\eX"
     ]
     sequences.each do |seq|
       assert_equal(:matched, stroke.match_status(seq.bytes))
-      (1...seq.size).each do |i|
+      assert_equal(:unmatched, stroke.match_status(seq.bytes + [32]))
+      (2...seq.size).each do |i|
         assert_equal(:matching, stroke.match_status(seq.bytes.take(i)))
       end
     end
@@ -61,16 +61,18 @@ class Reline::KeyStroke::Test < Reline::TestCase
     config = Reline::Config.new
     {
       'abc' => '123',
+      'ab' => '456'
     }.each_pair do |key, func|
       config.add_default_key_binding(key.bytes, func.bytes)
     end
-    stroke = Reline::KeyStroke.new(config)
-    assert_equal('123'.bytes, stroke.expand('abc'.bytes))
+    stroke = Reline::KeyStroke.new(config, Encoding::UTF_8)
+    assert_equal(['123'.bytes, 'abc'.bytes, 'de'.bytes], stroke.expand('abcde'.bytes))
+    assert_equal(['456'.bytes, 'ab'.bytes, 'de'.bytes], stroke.expand('abde'.bytes))
     # CSI sequence
-    assert_equal([:ed_unassigned] + 'bc'.bytes, stroke.expand("\e[1;2;3;4;5abc".bytes))
-    assert_equal([:ed_unassigned] + 'BC'.bytes, stroke.expand("\e\e[ABC".bytes))
+    assert_equal([nil, "\e[1;2;3;4;5a".bytes, 'bc'.bytes], stroke.expand("\e[1;2;3;4;5abc".bytes))
+    assert_equal([nil, "\e\e[A".bytes, 'BC'.bytes], stroke.expand("\e\e[ABC".bytes))
     # SS3 sequence
-    assert_equal([:ed_unassigned] + 'QR'.bytes, stroke.expand("\eOPQR".bytes))
+    assert_equal([nil, "\eOP".bytes, 'QR'.bytes], stroke.expand("\eOPQR".bytes))
   end
 
   def test_oneshot_key_bindings
@@ -80,7 +82,7 @@ class Reline::KeyStroke::Test < Reline::TestCase
     }.each_pair do |key, func|
       config.add_default_key_binding(key.bytes, func.bytes)
     end
-    stroke = Reline::KeyStroke.new(config)
+    stroke = Reline::KeyStroke.new(config, Encoding::UTF_8)
     assert_equal(:unmatched, stroke.match_status('zzz'.bytes))
     assert_equal(:matched, stroke.match_status('abc'.bytes))
   end
@@ -88,17 +90,14 @@ class Reline::KeyStroke::Test < Reline::TestCase
   def test_with_reline_key
     config = Reline::Config.new
     {
-      [
-        Reline::Key.new(100, 228, true), # Alt+d
-        Reline::Key.new(97, 97, false) # a
-      ] => 'abc',
+      "\eda".bytes => 'abc', # Alt+d a
       [195, 164] => 'def'
     }.each_pair do |key, func|
       config.add_oneshot_key_binding(key, func.bytes)
     end
-    stroke = Reline::KeyStroke.new(config)
+    stroke = Reline::KeyStroke.new(config, Encoding::UTF_8)
     assert_equal(:unmatched, stroke.match_status('da'.bytes))
-    assert_equal(:matched, stroke.match_status("\M-da".bytes))
+    assert_equal(:matched, stroke.match_status("\eda".bytes))
     assert_equal(:unmatched, stroke.match_status([32, 195, 164]))
     assert_equal(:matched, stroke.match_status([195, 164]))
   end

--- a/test/reline/test_macro.rb
+++ b/test/reline/test_macro.rb
@@ -14,16 +14,8 @@ class Reline::MacroTest < Reline::TestCase
     Reline.test_reset
   end
 
-  def input_key(char, combined_char = char, with_meta = false)
-    @line_editor.input_key(Reline::Key.new(char, combined_char, with_meta))
-  end
-
-  def input(str)
-    str.each_byte {|c| input_key(c)}
-  end
-
   def test_simple_input
-    input('abc')
+    input_keys('abc')
     assert_equal 'abc', @line_editor.line
   end
 
@@ -31,9 +23,9 @@ class Reline::MacroTest < Reline::TestCase
     class << @line_editor
       alias delete_char ed_delete_prev_char
     end
-    input('abc')
+    input_keys('abc')
     assert_nothing_raised(ArgumentError) {
-      input_key(:delete_char)
+      input_key_by_symbol(:delete_char)
     }
     assert_equal 'ab', @line_editor.line
   end

--- a/test/reline/test_reline.rb
+++ b/test/reline/test_reline.rb
@@ -303,12 +303,12 @@ class Reline::Test < Reline::TestCase
 
   def test_vi_editing_mode
     Reline.vi_editing_mode
-    assert_equal(Reline::KeyActor::ViInsert, Reline.core.config.editing_mode.class)
+    assert_equal(:vi_insert, Reline.core.config.editing_mode)
   end
 
   def test_emacs_editing_mode
     Reline.emacs_editing_mode
-    assert_equal(Reline::KeyActor::Emacs, Reline.core.config.editing_mode.class)
+    assert_equal(:emacs, Reline.core.config.editing_mode)
   end
 
   def test_add_dialog_proc

--- a/test/reline/test_reline_key.rb
+++ b/test/reline/test_reline_key.rb
@@ -2,53 +2,18 @@ require_relative 'helper'
 require "reline"
 
 class Reline::TestKey < Reline::TestCase
-  def setup
-    Reline.test_mode
-  end
-
-  def teardown
-    Reline.test_reset
-  end
-
-  def test_match_key
-    assert(Reline::Key.new(1, 2, false).match?(Reline::Key.new(1, 2, false)))
-    assert(Reline::Key.new(1, 2, false).match?(Reline::Key.new(nil, 2, false)))
-    assert(Reline::Key.new(1, 2, false).match?(Reline::Key.new(1, 2, nil)))
-
-    assert(Reline::Key.new(nil, 2, false).match?(Reline::Key.new(nil, 2, false)))
-    assert(Reline::Key.new(1, nil, false).match?(Reline::Key.new(1, nil, false)))
-    assert(Reline::Key.new(1, 2, nil).match?(Reline::Key.new(1, 2, nil)))
-
-    assert(Reline::Key.new(nil, 2, false).match?(Reline::Key.new(nil, 2, false)))
-    assert(Reline::Key.new(1, nil, false).match?(Reline::Key.new(1, nil, false)))
-    assert(Reline::Key.new(1, 2, nil).match?(Reline::Key.new(1, 2, nil)))
-
-    assert(!Reline::Key.new(1, 2, false).match?(Reline::Key.new(3, 1, false)))
-    assert(!Reline::Key.new(1, 2, false).match?(Reline::Key.new(1, 3, false)))
-    assert(!Reline::Key.new(1, 2, false).match?(Reline::Key.new(1, 3, true)))
-  end
-
-  def test_match_integer
-    assert(Reline::Key.new(1, 2, false).match?(2))
-    assert(Reline::Key.new(nil, 2, false).match?(2))
-    assert(Reline::Key.new(1, nil, false).match?(1))
-
-    assert(!Reline::Key.new(1, 2, false).match?(1))
-    assert(!Reline::Key.new(1, nil, false).match?(2))
-    assert(!Reline::Key.new(nil, nil, false).match?(1))
-  end
-
   def test_match_symbol
-    assert(Reline::Key.new(:key1, :key2, false).match?(:key2))
-    assert(Reline::Key.new(:key1, nil, false).match?(:key1))
+    bytes = "\e[dummy_bytes".bytes
+    assert(Reline::Key.new('a', :key2, bytes).match?(:key2))
+    assert(Reline::Key.new(12, :key1, bytes).match?(:key1))
+    assert(Reline::Key.new(12, :key3, bytes).match?(:key3))
 
-    assert(!Reline::Key.new(:key1, :key2, false).match?(:key1))
-    assert(!Reline::Key.new(:key1, nil, false).match?(:key2))
-    assert(!Reline::Key.new(nil, nil, false).match?(:key1))
+    refute(Reline::Key.new('a', :key2, bytes).match?(:key1))
+    refute(Reline::Key.new(12, :key1, bytes).match?(:key2))
+    refute(Reline::Key.new(nil, :key3, bytes).match?(:key4))
   end
 
-  def test_match_other
-    assert(!Reline::Key.new(:key1, 2, false).match?("key1"))
-    assert(!Reline::Key.new(nil, nil, false).match?(nil))
+  def test_match_symbol_wrongly_used_in_irb
+    refute(Reline::Key.new(nil, 0xE4, true).match?(:foo))
   end
 end

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -274,7 +274,7 @@ begin
       write("\e") # single ESC
       sleep 1
       write("A")
-      write("B\eAC") # ESC + A (M-A, specified ed_unassigned in Reline::KeyActor::Emacs)
+      write("B\eAC") # ignore ESC + A
       close
       assert_screen(<<~EOC)
         Multiline REPL.


### PR DESCRIPTION
## What is this?

KeyActor, key_bindings(key_stroke.rb) and multibyte_buffer(LineEditor) can be united. This will reduce complexity.
This pull request is a goal of this refactor. I'm planning to open several separate pull requests.

## What can be solved?

- LineEditor does not need to handle 3 types of input: part of multibyte character, symbol key, ascii byte assigned to a method.
- Complex read_2nd_character_of_key_sequence can be removed.
- Reline can't correctly handle conflicting key binding specified in inputrc now. It can be fixed.

## What to do

- Improve KeyStroke
  - Matching algorithm needs to be faster because the total entry will increase (default_key_bindings(size=25) → key_bindings + key_mappings(size=256))
  - Should have three state(`:matching | :matched | :matching_matched`) but the last one is missing now
  - Delete ESC-specific read_2nd_character_of_key_sequence and implement generic one
- Move multibyte_buffer from LineEditor to key recognizing layer
- Simplify Reline::Key structure, no mixing symbol and integer
