### PR TITLE
Refactor input key reading

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -375,26 +375,26 @@ module Reline
     # `ESC char` or part of CSI sequence (matching).
     private def read_io(keyseq_timeout, &block)
       buffer = []
-      status = :matching
+      status = KeyStroke::MATCHING
       loop do
-        timeout = status == :matching_matched ? keyseq_timeout.fdiv(1000) : Float::INFINITY
+        timeout = status == KeyStroke::MATCHING_MATCHED ? keyseq_timeout.fdiv(1000) : Float::INFINITY
         c = io_gate.getc(timeout)
         if c.nil? || c == -1
-          if status == :matching_matched
-            status = :matched
+          if status == KeyStroke::MATCHING_MATCHED
+            status = KeyStroke::MATCHED
           elsif buffer.empty?
             # io_gate is closed and reached EOF
             block.call([Key.new(nil, nil, false)])
             return
           else
-            status = :unmatched
+            status = KeyStroke::UNMATCHED
           end
         else
           buffer << c
           status = key_stroke.match_status(buffer)
         end
 
-        if status == :matched || status == :unmatched
+        if status == KeyStroke::MATCHED || status == KeyStroke::UNMATCHED
           expanded, rest_bytes = key_stroke.expand(buffer)
           rest_bytes.reverse_each { |c| io_gate.ungetc(c) }
           block.call(expanded)

--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -383,6 +383,7 @@ module Reline
           if status == :matching_matched
             status = :matched
           elsif buffer.empty?
+            # io_gate is closed and reached EOF
             block.call([Key.new(nil, nil, false)])
             return
           else

--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -367,89 +367,38 @@ module Reline
       end
     end
 
-    # GNU Readline waits for "keyseq-timeout" milliseconds to see if the ESC
-    # is followed by a character, and times out and treats it as a standalone
-    # ESC if the second character does not arrive. If the second character
-    # comes before timed out, it is treated as a modifier key with the
-    # meta-property of meta-key, so that it can be distinguished from
-    # multibyte characters with the 8th bit turned on.
-    #
-    # GNU Readline will wait for the 2nd character with "keyseq-timeout"
-    # milli-seconds but wait forever after 3rd characters.
+    # GNU Readline watis for "keyseq-timeout" milliseconds when the input is
+    # ambiguous whether it is matching or matched.
+    # If the next character does not arrive within the specified timeout, input
+    # is considered as matched.
+    # `ESC` is ambiguous because it can be a standalone ESC (matched) or part of
+    # `ESC char` or part of CSI sequence (matching).
     private def read_io(keyseq_timeout, &block)
       buffer = []
+      status = :matching
       loop do
-        c = io_gate.getc(Float::INFINITY)
-        if c == -1
-          result = :unmatched
+        timeout = status == :matching_matched ? keyseq_timeout.fdiv(1000) : Float::INFINITY
+        c = io_gate.getc(timeout)
+        if c.nil? || c == -1
+          if status == :matching_matched
+            status = :matched
+          elsif buffer.empty?
+            block.call([Key.new(nil, nil, false)])
+            return
+          else
+            status = :unmatched
+          end
         else
           buffer << c
-          result = key_stroke.match_status(buffer)
+          status = key_stroke.match_status(buffer)
         end
-        case result
-        when :matched
+
+        if status == :matched || status == :unmatched
           expanded, rest_bytes = key_stroke.expand(buffer)
           rest_bytes.reverse_each { |c| io_gate.ungetc(c) }
-          block.(expanded)
-          break
-        when :matching
-          if buffer.size == 1
-            case read_2nd_character_of_key_sequence(keyseq_timeout, buffer, c, block)
-            when :break then break
-            when :next  then next
-            end
-          end
-        when :unmatched
-          if buffer.size == 1 and c == "\e".ord
-            read_escaped_key(keyseq_timeout, c, block)
-          else
-            expanded, rest_bytes = key_stroke.expand(buffer)
-            rest_bytes.reverse_each { |c| io_gate.ungetc(c) }
-            block.(expanded)
-          end
-          break
+          block.call(expanded)
+          return
         end
-      end
-    end
-
-    private def read_2nd_character_of_key_sequence(keyseq_timeout, buffer, c, block)
-      succ_c = io_gate.getc(keyseq_timeout.fdiv(1000))
-      if succ_c
-        case key_stroke.match_status(buffer.dup.push(succ_c))
-        when :unmatched
-          if c == "\e".ord
-            block.([Reline::Key.new(succ_c, succ_c | 0b10000000, true)])
-          else
-            block.([Reline::Key.new(c, c, false), Reline::Key.new(succ_c, succ_c, false)])
-          end
-          return :break
-        when :matching
-          io_gate.ungetc(succ_c)
-          return :next
-        when :matched
-          buffer << succ_c
-          expanded, rest_bytes = key_stroke.expand(buffer)
-          rest_bytes.reverse_each { |c| io_gate.ungetc(c) }
-          block.(expanded)
-          return :break
-        end
-      else
-        block.([Reline::Key.new(c, c, false)])
-        return :break
-      end
-    end
-
-    private def read_escaped_key(keyseq_timeout, c, block)
-      escaped_c = io_gate.getc(keyseq_timeout.fdiv(1000))
-
-      if escaped_c.nil?
-        block.([Reline::Key.new(c, c, false)])
-      elsif escaped_c >= 128 # maybe, first byte of multi byte
-        block.([Reline::Key.new(c, c, false), Reline::Key.new(escaped_c, escaped_c, false)])
-      elsif escaped_c == "\e".ord # escape twice
-        block.([Reline::Key.new(c, c, false), Reline::Key.new(c, c, false)])
-      else
-        block.([Reline::Key.new(escaped_c, escaped_c | 0b10000000, true)])
       end
     end
 

--- a/lib/reline/key_stroke.rb
+++ b/lib/reline/key_stroke.rb
@@ -10,6 +10,11 @@ class Reline::KeyStroke
   def match_status(input)
     matching = key_mapping.matching?(input)
     matched = key_mapping.get(input)
+
+    # FIXME: Workaround for single byte. remove this after MAPPING is merged into KeyActor.
+    matched ||= input.size == 1
+    matching ||= input == [ESC_BYTE]
+
     if matching && matched
       :matching_matched
     elsif matching

--- a/lib/reline/key_stroke.rb
+++ b/lib/reline/key_stroke.rb
@@ -7,6 +7,11 @@ class Reline::KeyStroke
     @config = config
   end
 
+  # Returns the matching status (:matched | :matching | :matching_matched | :unmatched) of the input.
+  # If input matches to a key sequence, return :matched.
+  # If input matches to a part of a key sequence, return :matching.
+  # If input matches to a key sequence and the key sequence is a prefix of another key sequence, return :matching_matched.
+  # If input does not match to any key sequence, return :unmatched.
   def match_status(input)
     matching = key_mapping.matching?(input)
     matched = key_mapping.get(input)

--- a/lib/reline/key_stroke.rb
+++ b/lib/reline/key_stroke.rb
@@ -92,7 +92,15 @@ class Reline::KeyStroke
       # `ESC char` or `ESC ESC char`
       return UNMATCHED if vi_mode
     end
-    input[idx + 1] ? UNMATCHED : input[idx] ? MATCHED : MATCHING
+
+    case input.size
+    when idx
+      MATCHING
+    when idx + 1
+      MATCHED
+    else
+      UNMATCHED
+    end
   end
 
   def key_mapping

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -1081,17 +1081,7 @@ class Reline::LineEditor
     else # single byte
       return if key.char >= 128 # maybe, first byte of multi byte
       method_symbol = @config.editing_mode.get_method(key.combined_char)
-      if key.with_meta and method_symbol == :ed_unassigned
-        if @config.editing_mode_is?(:vi_command, :vi_insert)
-          # split ESC + key in vi mode
-          method_symbol = @config.editing_mode.get_method("\e".ord)
-          process_key("\e".ord, method_symbol)
-          method_symbol = @config.editing_mode.get_method(key.char)
-          process_key(key.char, method_symbol)
-        end
-      else
-        process_key(key.combined_char, method_symbol)
-      end
+      process_key(key.combined_char, method_symbol)
       @multibyte_buffer.clear
     end
     if @config.editing_mode_is?(:vi_command) and @byte_pointer > 0 and @byte_pointer == current_line.bytesize

--- a/test/reline/test_key_stroke.rb
+++ b/test/reline/test_key_stroke.rb
@@ -24,8 +24,8 @@ class Reline::KeyStroke::Test < Reline::TestCase
       config.add_default_key_binding(key.bytes, func.bytes)
     end
     stroke = Reline::KeyStroke.new(config)
-    assert_equal(:matching, stroke.match_status("a".bytes))
-    assert_equal(:matching, stroke.match_status("ab".bytes))
+    assert_equal(:matching_matched, stroke.match_status("a".bytes))
+    assert_equal(:matching_matched, stroke.match_status("ab".bytes))
     assert_equal(:matched, stroke.match_status("abc".bytes))
     assert_equal(:unmatched, stroke.match_status("abz".bytes))
     assert_equal(:unmatched, stroke.match_status("abcx".bytes))
@@ -52,7 +52,7 @@ class Reline::KeyStroke::Test < Reline::TestCase
     sequences.each do |seq|
       assert_equal(:matched, stroke.match_status(seq.bytes))
       assert_equal(:unmatched, stroke.match_status(seq.bytes + [32]))
-      (1...seq.size).each do |i|
+      (2...seq.size).each do |i|
         assert_equal(:matching, stroke.match_status(seq.bytes.take(i)))
       end
     end

--- a/test/reline/test_key_stroke.rb
+++ b/test/reline/test_key_stroke.rb
@@ -24,14 +24,14 @@ class Reline::KeyStroke::Test < Reline::TestCase
       config.add_default_key_binding(key.bytes, func.bytes)
     end
     stroke = Reline::KeyStroke.new(config)
-    assert_equal(:matching_matched, stroke.match_status("a".bytes))
-    assert_equal(:matching_matched, stroke.match_status("ab".bytes))
-    assert_equal(:matched, stroke.match_status("abc".bytes))
-    assert_equal(:unmatched, stroke.match_status("abz".bytes))
-    assert_equal(:unmatched, stroke.match_status("abcx".bytes))
-    assert_equal(:unmatched, stroke.match_status("aa".bytes))
-    assert_equal(:matched, stroke.match_status("x".bytes))
-    assert_equal(:unmatched, stroke.match_status("xa".bytes))
+    assert_equal(Reline::KeyStroke::MATCHING_MATCHED, stroke.match_status("a".bytes))
+    assert_equal(Reline::KeyStroke::MATCHING_MATCHED, stroke.match_status("ab".bytes))
+    assert_equal(Reline::KeyStroke::MATCHED, stroke.match_status("abc".bytes))
+    assert_equal(Reline::KeyStroke::UNMATCHED, stroke.match_status("abz".bytes))
+    assert_equal(Reline::KeyStroke::UNMATCHED, stroke.match_status("abcx".bytes))
+    assert_equal(Reline::KeyStroke::UNMATCHED, stroke.match_status("aa".bytes))
+    assert_equal(Reline::KeyStroke::MATCHED, stroke.match_status("x".bytes))
+    assert_equal(Reline::KeyStroke::UNMATCHED, stroke.match_status("xa".bytes))
   end
 
   def test_match_unknown
@@ -50,10 +50,10 @@ class Reline::KeyStroke::Test < Reline::TestCase
       "\e\eX"
     ]
     sequences.each do |seq|
-      assert_equal(:matched, stroke.match_status(seq.bytes))
-      assert_equal(:unmatched, stroke.match_status(seq.bytes + [32]))
+      assert_equal(Reline::KeyStroke::MATCHED, stroke.match_status(seq.bytes))
+      assert_equal(Reline::KeyStroke::UNMATCHED, stroke.match_status(seq.bytes + [32]))
       (2...seq.size).each do |i|
-        assert_equal(:matching, stroke.match_status(seq.bytes.take(i)))
+        assert_equal(Reline::KeyStroke::MATCHING, stroke.match_status(seq.bytes.take(i)))
       end
     end
   end
@@ -84,8 +84,8 @@ class Reline::KeyStroke::Test < Reline::TestCase
       config.add_default_key_binding(key.bytes, func.bytes)
     end
     stroke = Reline::KeyStroke.new(config)
-    assert_equal(:unmatched, stroke.match_status('zzz'.bytes))
-    assert_equal(:matched, stroke.match_status('abc'.bytes))
+    assert_equal(Reline::KeyStroke::UNMATCHED, stroke.match_status('zzz'.bytes))
+    assert_equal(Reline::KeyStroke::MATCHED, stroke.match_status('abc'.bytes))
   end
 
   def test_with_reline_key
@@ -97,9 +97,9 @@ class Reline::KeyStroke::Test < Reline::TestCase
       config.add_oneshot_key_binding(key, func.bytes)
     end
     stroke = Reline::KeyStroke.new(config)
-    assert_equal(:unmatched, stroke.match_status('da'.bytes))
-    assert_equal(:matched, stroke.match_status("\eda".bytes))
-    assert_equal(:unmatched, stroke.match_status([32, 195, 164]))
-    assert_equal(:matched, stroke.match_status([195, 164]))
+    assert_equal(Reline::KeyStroke::UNMATCHED, stroke.match_status('da'.bytes))
+    assert_equal(Reline::KeyStroke::MATCHED, stroke.match_status("\eda".bytes))
+    assert_equal(Reline::KeyStroke::UNMATCHED, stroke.match_status([32, 195, 164]))
+    assert_equal(Reline::KeyStroke::MATCHED, stroke.match_status([195, 164]))
   end
 end


### PR DESCRIPTION
## Simplify input key reading

Depends on #709 
Second step of #708

We don't need complex `read_2nd_character_of_key_sequence` and `read_escaped_key`.

This source code commend is partially right (only for ESC keys), but not correct.
```ruby
# GNU Readline waits for "keyseq-timeout" milliseconds to see if the ESC
# is followed by a character, and times out and treats it as a standalone
# ESC if the second character does not arrive. If the second character
# comes before timed out, it is treated as a modifier key with the
# meta-property of meta-key, so that it can be distinguished from
# multibyte characters with the 8th bit turned on.
```

## Background

With this inputrc file
```inputrc
# .inputrc
"abcd": "[ABCD]"
"ab": "[AB]"
```
Input `ab` is `:matched` and also `:matching` (part of `abcd`). In this case, Readline waits for keyseq-timeout milliseconds.
Input `abc` is `:matching` (part of `abcd`). In this case, Readline waits forever.
It's not ESC specific nor 2nd-char specific.

## Changes

1. Introduce another state `:matching_matched` for `KeyStroke#match_status`.
2. Refactor key reading. timeout will be `matching_matched ? keyseq_timeout : Infinity`.
