### PR TITLE
Handle multibyte character input by KeyStroke

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -307,6 +307,7 @@ module Reline
       otio = io_gate.prep
 
       may_req_ambiguous_char_width
+      key_stroke.encoding = encoding
       line_editor.reset(prompt)
       if multiline
         line_editor.multiline_on
@@ -485,7 +486,7 @@ module Reline
   def self.core
     @core ||= Core.new { |core|
       core.config = Reline::Config.new
-      core.key_stroke = Reline::KeyStroke.new(core.config)
+      core.key_stroke = Reline::KeyStroke.new(core.config, core.encoding)
       core.line_editor = Reline::LineEditor.new(core.config)
 
       core.basic_word_break_characters = " \t\n`><=;|&{("

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -265,7 +265,6 @@ class Reline::LineEditor
     @line_index = 0
     @cache.clear
     @line_backup_in_history = nil
-    @multibyte_buffer = String.new(encoding: 'ASCII-8BIT')
   end
 
   def multiline_on
@@ -1036,20 +1035,11 @@ class Reline::LineEditor
   end
 
   private def normal_char(key)
-    @multibyte_buffer << key.combined_char
-    if @multibyte_buffer.size > 1
-      if @multibyte_buffer.dup.force_encoding(encoding).valid_encoding?
-        process_key(@multibyte_buffer.dup.force_encoding(encoding), nil)
-        @multibyte_buffer.clear
-      else
-        # invalid
-        return
-      end
-    else # single byte
-      return if key.char >= 128 # maybe, first byte of multi byte
+    if key.char < 0x80
       method_symbol = @config.editing_mode.get_method(key.combined_char)
       process_key(key.combined_char, method_symbol)
-      @multibyte_buffer.clear
+    else
+      process_key(key.char.chr(encoding), nil)
     end
     if @config.editing_mode_is?(:vi_command) and @byte_pointer > 0 and @byte_pointer == current_line.bytesize
       byte_size = Reline::Unicode.get_prev_mbchar_size(@buffer_of_lines[@line_index], @byte_pointer)
@@ -1531,7 +1521,6 @@ class Reline::LineEditor
 
   private def generate_searcher(search_key)
     search_word = String.new(encoding: encoding)
-    multibyte_buf = String.new(encoding: 'ASCII-8BIT')
     hit_pointer = nil
     lambda do |key|
       search_again = false
@@ -1546,11 +1535,7 @@ class Reline::LineEditor
         search_again = true if search_key == key
         search_key = key
       else
-        multibyte_buf << key
-        if multibyte_buf.dup.force_encoding(encoding).valid_encoding?
-          search_word << multibyte_buf.dup.force_encoding(encoding)
-          multibyte_buf.clear
-        end
+        search_word << key
       end
       hit = nil
       if not search_word.empty? and @line_backup_in_history&.include?(search_word)

--- a/test/reline/helper.rb
+++ b/test/reline/helper.rb
@@ -121,17 +121,15 @@ class Reline::TestCase < Test::Unit::TestCase
           @line_editor.input_key(Reline::Key.new(byte, byte, false))
         end
       else
-        c.bytes.each do |b|
-          @line_editor.input_key(Reline::Key.new(b, b, false))
-        end
+        @line_editor.input_key(Reline::Key.new(c.ord, c.ord, false))
       end
     end
   end
 
   def input_raw_keys(input, convert = true)
     input = convert_str(input) if convert
-    input.bytes.each do |b|
-      @line_editor.input_key(Reline::Key.new(b, b, false))
+    input.chars.each do |c|
+      @line_editor.input_key(Reline::Key.new(c.ord, c.ord, false))
     end
   end
 

--- a/test/reline/test_line_editor.rb
+++ b/test/reline/test_line_editor.rb
@@ -8,7 +8,7 @@ class Reline::LineEditor
     def setup
       @original_quote_characters = Reline.completer_quote_characters
       @original_word_break_characters = Reline.completer_word_break_characters
-      @line_editor = Reline::LineEditor.new(nil, Encoding::UTF_8)
+      @line_editor = Reline::LineEditor.new(nil)
     end
 
     def retrieve_completion_block(lines, line_index, byte_pointer)


### PR DESCRIPTION
Depends on #712
Third step of #708

LineEditor was handling multibyte input with `@multibyte_buffer`. I think it should be done in keystroke recognizing layer.
We can handle multibyte character by `:matching | :matched | :matching_matched` mechanism just like other keystroke inputs.

## Bug fix

When invalid byte is input to Reline, Reline does not respond to any key except arrow keys.
```
$ irb -Eus-ascii
irb(main):001> type something and then input multibyte character without using paste
```
You can not input anything because `@multibyte_buffer` never become a valid string.

This pull request considers invalid string as `:matching_matched`. It can be a broken string (:matched) and it can also be part of a valid multibyte character (:matching).
This way, if Reline doesn't receive next bytes within keyseq timeout, Reline can ignore the broken input bytes.
