### PR TITLE
In ed_search_prev_history, make the cursor come to the end of the line when there is no search substr

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -1770,7 +1770,7 @@ class Reline::LineEditor
     history_range = 0...(@history_pointer || Reline::HISTORY.size)
     h_pointer, line_index = search_history(substr, history_range.reverse_each)
     return unless h_pointer
-    move_history(h_pointer, line: line_index || :start, cursor: @byte_pointer)
+    move_history(h_pointer, line: line_index || :start, cursor: substr.empty? ? :end : @byte_pointer)
     arg -= 1
     ed_search_prev_history(key, arg: arg) if arg > 0
   end

--- a/test/reline/test_key_actor_emacs.rb
+++ b/test/reline/test_key_actor_emacs.rb
@@ -1243,13 +1243,14 @@ class Reline::KeyActor::Emacs::Test < Reline::TestCase
     ])
     # The ed_search_prev_history doesn't have default binding
     @line_editor.__send__(:ed_search_prev_history, "\C-p".ord)
-    assert_line_around_cursor('', '12345')
+    assert_line_around_cursor('12345', '')
     @line_editor.__send__(:ed_search_prev_history, "\C-p".ord)
-    assert_line_around_cursor('', '12aaa')
+    assert_line_around_cursor('12345', '')
+    3.times { input_key_by_symbol(:ed_prev_char) }
     @line_editor.__send__(:ed_search_prev_history, "\C-p".ord)
-    assert_line_around_cursor('', '12356')
+    assert_line_around_cursor('12', 'aaa')
     @line_editor.__send__(:ed_search_prev_history, "\C-p".ord)
-    assert_line_around_cursor('', '12356')
+    assert_line_around_cursor('12', '356')
   end
 
   def test_ed_search_prev_history_without_match


### PR DESCRIPTION
fix #618 

## Overview
To solve the problem, I have modified the cursor behavior to move to the end of the line if the search string is empty.
Please let me know if there is anything I am missing.

Thank you for maintaining this great Ruby feature.