### PR TITLE
Merge key mapping with key bindings

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -17,10 +17,12 @@ module Reline
 
   class ConfigEncodingConversionError < StandardError; end
 
-  Key = Struct.new(:char, :combined_char, :with_meta) do
+  # EOF key: { char: nil, method_symbol: nil }
+  # Other key: { char: String, method_symbol: Symbol }
+  Key = Struct.new(:char, :method_symbol, :unused_boolean) do
     # For dialog_proc `key.match?(dialog.name)`
     def match?(sym)
-      combined_char.is_a?(Symbol) && combined_char == sym
+      method_symbol && method_symbol == sym
     end
   end
   CursorPos = Struct.new(:x, :y)
@@ -341,7 +343,7 @@ module Reline
           read_io(config.keyseq_timeout) { |inputs|
             line_editor.set_pasting_state(io_gate.in_pasting?)
             inputs.each do |key|
-              if key.char == :bracketed_paste_start
+              if key.method_symbol == :bracketed_paste_start
                 text = io_gate.read_bracketed_paste
                 line_editor.insert_multiline_text(text)
                 line_editor.scroll_into_view

--- a/lib/reline/io/windows.rb
+++ b/lib/reline/io/windows.rb
@@ -55,7 +55,6 @@ class Reline::Windows < Reline::IO
       [224, 83] => :key_delete,      # Del
       [224, 71] => :ed_move_to_beg,  # Home
       [224, 79] => :ed_move_to_end,  # End
-      [  0, 41] => :ed_unassigned,   # input method on/off
       [  0, 72] => :ed_prev_history, # ↑
       [  0, 80] => :ed_next_history, # ↓
       [  0, 77] => :ed_next_char,    # →

--- a/lib/reline/key_actor/base.rb
+++ b/lib/reline/key_actor/base.rb
@@ -1,12 +1,18 @@
 class Reline::KeyActor::Base
-  def initialize(mapping = [])
-    @mapping = mapping
+  def initialize(mappings = nil)
     @matching_bytes = {}
     @key_bindings = {}
+    add_mappings(mappings) if mappings
   end
 
-  def get_method(key)
-    @mapping[key]
+  def add_mappings(mappings)
+    add([27], :ed_ignore)
+    128.times do |key|
+      func = mappings[key]
+      meta_func = mappings[key | 0b10000000]
+      add([key], func) if func
+      add([27, key], meta_func) if meta_func
+    end
   end
 
   def add(key, func)

--- a/lib/reline/key_actor/emacs.rb
+++ b/lib/reline/key_actor/emacs.rb
@@ -15,7 +15,7 @@ module Reline::KeyActor
     #   6 ^F
     :ed_next_char,
     #   7 ^G
-    :ed_unassigned,
+    nil,
     #   8 ^H
     :em_delete_prev_char,
     #   9 ^I
@@ -49,19 +49,19 @@ module Reline::KeyActor
     #  23 ^W
     :em_kill_region,
     #  24 ^X
-    :ed_unassigned,
+    nil,
     #  25 ^Y
     :em_yank,
     #  26 ^Z
     :ed_ignore,
     #  27 ^[
-    :ed_unassigned,
+    nil,
     #  28 ^\
     :ed_ignore,
     #  29 ^]
     :ed_ignore,
     #  30 ^^
-    :ed_unassigned,
+    nil,
     #  31 ^_
     :undo,
     #  32 SPACE
@@ -257,101 +257,101 @@ module Reline::KeyActor
     # 127 ^?
     :em_delete_prev_char,
     # 128 M-^@
-    :ed_unassigned,
+    nil,
     # 129 M-^A
-    :ed_unassigned,
+    nil,
     # 130 M-^B
-    :ed_unassigned,
+    nil,
     # 131 M-^C
-    :ed_unassigned,
+    nil,
     # 132 M-^D
-    :ed_unassigned,
+    nil,
     # 133 M-^E
-    :ed_unassigned,
+    nil,
     # 134 M-^F
-    :ed_unassigned,
+    nil,
     # 135 M-^G
-    :ed_unassigned,
+    nil,
     # 136 M-^H
     :ed_delete_prev_word,
     # 137 M-^I
-    :ed_unassigned,
+    nil,
     # 138 M-^J
     :key_newline,
     # 139 M-^K
-    :ed_unassigned,
+    nil,
     # 140 M-^L
     :ed_clear_screen,
     # 141 M-^M
     :key_newline,
     # 142 M-^N
-    :ed_unassigned,
+    nil,
     # 143 M-^O
-    :ed_unassigned,
+    nil,
     # 144 M-^P
-    :ed_unassigned,
+    nil,
     # 145 M-^Q
-    :ed_unassigned,
+    nil,
     # 146 M-^R
-    :ed_unassigned,
+    nil,
     # 147 M-^S
-    :ed_unassigned,
+    nil,
     # 148 M-^T
-    :ed_unassigned,
+    nil,
     # 149 M-^U
-    :ed_unassigned,
+    nil,
     # 150 M-^V
-    :ed_unassigned,
+    nil,
     # 151 M-^W
-    :ed_unassigned,
+    nil,
     # 152 M-^X
-    :ed_unassigned,
+    nil,
     # 153 M-^Y
     :em_yank_pop,
     # 154 M-^Z
-    :ed_unassigned,
+    nil,
     # 155 M-^[
-    :ed_unassigned,
+    nil,
     # 156 M-^\
-    :ed_unassigned,
+    nil,
     # 157 M-^]
-    :ed_unassigned,
+    nil,
     # 158 M-^^
-    :ed_unassigned,
+    nil,
     # 159 M-^_
     :redo,
     # 160 M-SPACE
     :em_set_mark,
     # 161 M-!
-    :ed_unassigned,
+    nil,
     # 162 M-"
-    :ed_unassigned,
+    nil,
     # 163 M-#
-    :ed_unassigned,
+    nil,
     # 164 M-$
-    :ed_unassigned,
+    nil,
     # 165 M-%
-    :ed_unassigned,
+    nil,
     # 166 M-&
-    :ed_unassigned,
+    nil,
     # 167 M-'
-    :ed_unassigned,
+    nil,
     # 168 M-(
-    :ed_unassigned,
+    nil,
     # 169 M-)
-    :ed_unassigned,
+    nil,
     # 170 M-*
-    :ed_unassigned,
+    nil,
     # 171 M-+
-    :ed_unassigned,
+    nil,
     # 172 M-,
-    :ed_unassigned,
+    nil,
     # 173 M--
-    :ed_unassigned,
+    nil,
     # 174 M-.
-    :ed_unassigned,
+    nil,
     # 175 M-/
-    :ed_unassigned,
+    nil,
     # 176 M-0
     :ed_argument_digit,
     # 177 M-1
@@ -373,21 +373,21 @@ module Reline::KeyActor
     # 185 M-9
     :ed_argument_digit,
     # 186 M-:
-    :ed_unassigned,
+    nil,
     # 187 M-;
-    :ed_unassigned,
+    nil,
     # 188 M-<
-    :ed_unassigned,
+    nil,
     # 189 M-=
-    :ed_unassigned,
+    nil,
     # 190 M->
-    :ed_unassigned,
+    nil,
     # 191 M-?
-    :ed_unassigned,
+    nil,
     # 192 M-@
-    :ed_unassigned,
+    nil,
     # 193 M-A
-    :ed_unassigned,
+    nil,
     # 194 M-B
     :ed_prev_word,
     # 195 M-C
@@ -395,63 +395,63 @@ module Reline::KeyActor
     # 196 M-D
     :em_delete_next_word,
     # 197 M-E
-    :ed_unassigned,
+    nil,
     # 198 M-F
     :em_next_word,
     # 199 M-G
-    :ed_unassigned,
+    nil,
     # 200 M-H
-    :ed_unassigned,
+    nil,
     # 201 M-I
-    :ed_unassigned,
+    nil,
     # 202 M-J
-    :ed_unassigned,
+    nil,
     # 203 M-K
-    :ed_unassigned,
+    nil,
     # 204 M-L
     :em_lower_case,
     # 205 M-M
-    :ed_unassigned,
+    nil,
     # 206 M-N
     :vi_search_next,
     # 207 M-O
-    :ed_unassigned,
+    nil,
     # 208 M-P
     :vi_search_prev,
     # 209 M-Q
-    :ed_unassigned,
+    nil,
     # 210 M-R
-    :ed_unassigned,
+    nil,
     # 211 M-S
-    :ed_unassigned,
+    nil,
     # 212 M-T
-    :ed_unassigned,
+    nil,
     # 213 M-U
     :em_upper_case,
     # 214 M-V
-    :ed_unassigned,
+    nil,
     # 215 M-W
-    :ed_unassigned,
+    nil,
     # 216 M-X
-    :ed_unassigned,
+    nil,
     # 217 M-Y
     :em_yank_pop,
     # 218 M-Z
-    :ed_unassigned,
+    nil,
     # 219 M-[
-    :ed_unassigned,
+    nil,
     # 220 M-\
-    :ed_unassigned,
+    nil,
     # 221 M-]
-    :ed_unassigned,
+    nil,
     # 222 M-^
-    :ed_unassigned,
+    nil,
     # 223 M-_
-    :ed_unassigned,
+    nil,
     # 224 M-`
-    :ed_unassigned,
+    nil,
     # 225 M-a
-    :ed_unassigned,
+    nil,
     # 226 M-b
     :ed_prev_word,
     # 227 M-c
@@ -459,57 +459,57 @@ module Reline::KeyActor
     # 228 M-d
     :em_delete_next_word,
     # 229 M-e
-    :ed_unassigned,
+    nil,
     # 230 M-f
     :em_next_word,
     # 231 M-g
-    :ed_unassigned,
+    nil,
     # 232 M-h
-    :ed_unassigned,
+    nil,
     # 233 M-i
-    :ed_unassigned,
+    nil,
     # 234 M-j
-    :ed_unassigned,
+    nil,
     # 235 M-k
-    :ed_unassigned,
+    nil,
     # 236 M-l
     :em_lower_case,
     # 237 M-m
-    :ed_unassigned,
+    nil,
     # 238 M-n
     :vi_search_next,
     # 239 M-o
-    :ed_unassigned,
+    nil,
     # 240 M-p
     :vi_search_prev,
     # 241 M-q
-    :ed_unassigned,
+    nil,
     # 242 M-r
-    :ed_unassigned,
+    nil,
     # 243 M-s
-    :ed_unassigned,
+    nil,
     # 244 M-t
     :ed_transpose_words,
     # 245 M-u
     :em_upper_case,
     # 246 M-v
-    :ed_unassigned,
+    nil,
     # 247 M-w
-    :ed_unassigned,
+    nil,
     # 248 M-x
-    :ed_unassigned,
+    nil,
     # 249 M-y
-    :ed_unassigned,
+    nil,
     # 250 M-z
-    :ed_unassigned,
+    nil,
     # 251 M-{
-    :ed_unassigned,
+    nil,
     # 252 M-|
-    :ed_unassigned,
+    nil,
     # 253 M-}
-    :ed_unassigned,
+    nil,
     # 254 M-~
-    :ed_unassigned,
+    nil,
     # 255 M-^?
     :ed_delete_prev_word
     # EOF

--- a/lib/reline/key_actor/vi_command.rb
+++ b/lib/reline/key_actor/vi_command.rb
@@ -1,11 +1,11 @@
 module Reline::KeyActor
   VI_COMMAND_MAPPING = [
     #   0 ^@
-    :ed_unassigned,
+    nil,
     #   1 ^A
     :ed_move_to_beg,
     #   2 ^B
-    :ed_unassigned,
+    nil,
     #   3 ^C
     :ed_ignore,
     #   4 ^D
@@ -13,13 +13,13 @@ module Reline::KeyActor
     #   5 ^E
     :ed_move_to_end,
     #   6 ^F
-    :ed_unassigned,
+    nil,
     #   7 ^G
-    :ed_unassigned,
+    nil,
     #   8 ^H
     :ed_prev_char,
     #   9 ^I
-    :ed_unassigned,
+    nil,
     #  10 ^J
     :ed_newline,
     #  11 ^K
@@ -49,51 +49,51 @@ module Reline::KeyActor
     #  23 ^W
     :ed_delete_prev_word,
     #  24 ^X
-    :ed_unassigned,
+    nil,
     #  25 ^Y
     :em_yank,
     #  26 ^Z
-    :ed_unassigned,
+    nil,
     #  27 ^[
-    :ed_unassigned,
+    nil,
     #  28 ^\
     :ed_ignore,
     #  29 ^]
-    :ed_unassigned,
+    nil,
     #  30 ^^
-    :ed_unassigned,
+    nil,
     #  31 ^_
-    :ed_unassigned,
+    nil,
     #  32 SPACE
     :ed_next_char,
     #  33 !
-    :ed_unassigned,
+    nil,
     #  34 "
-    :ed_unassigned,
+    nil,
     #  35 #
     :vi_comment_out,
     #  36 $
     :ed_move_to_end,
     #  37 %
-    :ed_unassigned,
+    nil,
     #  38 &
-    :ed_unassigned,
+    nil,
     #  39 '
-    :ed_unassigned,
+    nil,
     #  40 (
-    :ed_unassigned,
+    nil,
     #  41 )
-    :ed_unassigned,
+    nil,
     #  42 *
-    :ed_unassigned,
+    nil,
     #  43 +
     :ed_next_history,
     #  44 ,
-    :ed_unassigned,
+    nil,
     #  45 -
     :ed_prev_history,
     #  46 .
-    :ed_unassigned,
+    nil,
     #  47 /
     :vi_search_prev,
     #  48 0
@@ -117,15 +117,15 @@ module Reline::KeyActor
     #  57 9
     :ed_argument_digit,
     #  58 :
-    :ed_unassigned,
+    nil,
     #  59 ;
-    :ed_unassigned,
+    nil,
     #  60 <
-    :ed_unassigned,
+    nil,
     #  61 =
-    :ed_unassigned,
+    nil,
     #  62 >
-    :ed_unassigned,
+    nil,
     #  63 ?
     :vi_search_next,
     #  64 @
@@ -145,7 +145,7 @@ module Reline::KeyActor
     #  71 G
     :vi_to_history_line,
     #  72 H
-    :ed_unassigned,
+    nil,
     #  73 I
     :vi_insert_at_bol,
     #  74 J
@@ -153,47 +153,47 @@ module Reline::KeyActor
     #  75 K
     :vi_search_prev,
     #  76 L
-    :ed_unassigned,
+    nil,
     #  77 M
-    :ed_unassigned,
+    nil,
     #  78 N
-    :ed_unassigned,
+    nil,
     #  79 O
-    :ed_unassigned,
+    nil,
     #  80 P
     :vi_paste_prev,
     #  81 Q
-    :ed_unassigned,
+    nil,
     #  82 R
-    :ed_unassigned,
+    nil,
     #  83 S
-    :ed_unassigned,
+    nil,
     #  84 T
     :vi_to_prev_char,
     #  85 U
-    :ed_unassigned,
+    nil,
     #  86 V
-    :ed_unassigned,
+    nil,
     #  87 W
     :vi_next_big_word,
     #  88 X
     :ed_delete_prev_char,
     #  89 Y
-    :ed_unassigned,
+    nil,
     #  90 Z
-    :ed_unassigned,
+    nil,
     #  91 [
-    :ed_unassigned,
+    nil,
     #  92 \
-    :ed_unassigned,
+    nil,
     #  93 ]
-    :ed_unassigned,
+    nil,
     #  94 ^
     :vi_first_print,
     #  95 _
-    :ed_unassigned,
+    nil,
     #  96 `
-    :ed_unassigned,
+    nil,
     #  97 a
     :vi_add,
     #  98 b
@@ -207,7 +207,7 @@ module Reline::KeyActor
     # 102 f
     :vi_next_char,
     # 103 g
-    :ed_unassigned,
+    nil,
     # 104 h
     :ed_prev_char,
     # 105 i
@@ -219,23 +219,23 @@ module Reline::KeyActor
     # 108 l
     :ed_next_char,
     # 109 m
-    :ed_unassigned,
+    nil,
     # 110 n
-    :ed_unassigned,
+    nil,
     # 111 o
-    :ed_unassigned,
+    nil,
     # 112 p
     :vi_paste_next,
     # 113 q
-    :ed_unassigned,
+    nil,
     # 114 r
     :vi_replace_char,
     # 115 s
-    :ed_unassigned,
+    nil,
     # 116 t
     :vi_to_next_char,
     # 117 u
-    :ed_unassigned,
+    nil,
     # 118 v
     :vi_histedit,
     # 119 w
@@ -245,273 +245,273 @@ module Reline::KeyActor
     # 121 y
     :vi_yank,
     # 122 z
-    :ed_unassigned,
+    nil,
     # 123 {
-    :ed_unassigned,
+    nil,
     # 124 |
     :vi_to_column,
     # 125 }
-    :ed_unassigned,
+    nil,
     # 126 ~
-    :ed_unassigned,
+    nil,
     # 127 ^?
     :em_delete_prev_char,
     # 128 M-^@
-    :ed_unassigned,
+    nil,
     # 129 M-^A
-    :ed_unassigned,
+    nil,
     # 130 M-^B
-    :ed_unassigned,
+    nil,
     # 131 M-^C
-    :ed_unassigned,
+    nil,
     # 132 M-^D
-    :ed_unassigned,
+    nil,
     # 133 M-^E
-    :ed_unassigned,
+    nil,
     # 134 M-^F
-    :ed_unassigned,
+    nil,
     # 135 M-^G
-    :ed_unassigned,
+    nil,
     # 136 M-^H
-    :ed_unassigned,
+    nil,
     # 137 M-^I
-    :ed_unassigned,
+    nil,
     # 138 M-^J
-    :ed_unassigned,
+    nil,
     # 139 M-^K
-    :ed_unassigned,
+    nil,
     # 140 M-^L
-    :ed_unassigned,
+    nil,
     # 141 M-^M
-    :ed_unassigned,
+    nil,
     # 142 M-^N
-    :ed_unassigned,
+    nil,
     # 143 M-^O
-    :ed_unassigned,
+    nil,
     # 144 M-^P
-    :ed_unassigned,
+    nil,
     # 145 M-^Q
-    :ed_unassigned,
+    nil,
     # 146 M-^R
-    :ed_unassigned,
+    nil,
     # 147 M-^S
-    :ed_unassigned,
+    nil,
     # 148 M-^T
-    :ed_unassigned,
+    nil,
     # 149 M-^U
-    :ed_unassigned,
+    nil,
     # 150 M-^V
-    :ed_unassigned,
+    nil,
     # 151 M-^W
-    :ed_unassigned,
+    nil,
     # 152 M-^X
-    :ed_unassigned,
+    nil,
     # 153 M-^Y
-    :ed_unassigned,
+    nil,
     # 154 M-^Z
-    :ed_unassigned,
+    nil,
     # 155 M-^[
-    :ed_unassigned,
+    nil,
     # 156 M-^\
-    :ed_unassigned,
+    nil,
     # 157 M-^]
-    :ed_unassigned,
+    nil,
     # 158 M-^^
-    :ed_unassigned,
+    nil,
     # 159 M-^_
-    :ed_unassigned,
+    nil,
     # 160 M-SPACE
-    :ed_unassigned,
+    nil,
     # 161 M-!
-    :ed_unassigned,
+    nil,
     # 162 M-"
-    :ed_unassigned,
+    nil,
     # 163 M-#
-    :ed_unassigned,
+    nil,
     # 164 M-$
-    :ed_unassigned,
+    nil,
     # 165 M-%
-    :ed_unassigned,
+    nil,
     # 166 M-&
-    :ed_unassigned,
+    nil,
     # 167 M-'
-    :ed_unassigned,
+    nil,
     # 168 M-(
-    :ed_unassigned,
+    nil,
     # 169 M-)
-    :ed_unassigned,
+    nil,
     # 170 M-*
-    :ed_unassigned,
+    nil,
     # 171 M-+
-    :ed_unassigned,
+    nil,
     # 172 M-,
-    :ed_unassigned,
+    nil,
     # 173 M--
-    :ed_unassigned,
+    nil,
     # 174 M-.
-    :ed_unassigned,
+    nil,
     # 175 M-/
-    :ed_unassigned,
+    nil,
     # 176 M-0
-    :ed_unassigned,
+    nil,
     # 177 M-1
-    :ed_unassigned,
+    nil,
     # 178 M-2
-    :ed_unassigned,
+    nil,
     # 179 M-3
-    :ed_unassigned,
+    nil,
     # 180 M-4
-    :ed_unassigned,
+    nil,
     # 181 M-5
-    :ed_unassigned,
+    nil,
     # 182 M-6
-    :ed_unassigned,
+    nil,
     # 183 M-7
-    :ed_unassigned,
+    nil,
     # 184 M-8
-    :ed_unassigned,
+    nil,
     # 185 M-9
-    :ed_unassigned,
+    nil,
     # 186 M-:
-    :ed_unassigned,
+    nil,
     # 187 M-;
-    :ed_unassigned,
+    nil,
     # 188 M-<
-    :ed_unassigned,
+    nil,
     # 189 M-=
-    :ed_unassigned,
+    nil,
     # 190 M->
-    :ed_unassigned,
+    nil,
     # 191 M-?
-    :ed_unassigned,
+    nil,
     # 192 M-@
-    :ed_unassigned,
+    nil,
     # 193 M-A
-    :ed_unassigned,
+    nil,
     # 194 M-B
-    :ed_unassigned,
+    nil,
     # 195 M-C
-    :ed_unassigned,
+    nil,
     # 196 M-D
-    :ed_unassigned,
+    nil,
     # 197 M-E
-    :ed_unassigned,
+    nil,
     # 198 M-F
-    :ed_unassigned,
+    nil,
     # 199 M-G
-    :ed_unassigned,
+    nil,
     # 200 M-H
-    :ed_unassigned,
+    nil,
     # 201 M-I
-    :ed_unassigned,
+    nil,
     # 202 M-J
-    :ed_unassigned,
+    nil,
     # 203 M-K
-    :ed_unassigned,
+    nil,
     # 204 M-L
-    :ed_unassigned,
+    nil,
     # 205 M-M
-    :ed_unassigned,
+    nil,
     # 206 M-N
-    :ed_unassigned,
+    nil,
     # 207 M-O
-    :ed_unassigned,
+    nil,
     # 208 M-P
-    :ed_unassigned,
+    nil,
     # 209 M-Q
-    :ed_unassigned,
+    nil,
     # 210 M-R
-    :ed_unassigned,
+    nil,
     # 211 M-S
-    :ed_unassigned,
+    nil,
     # 212 M-T
-    :ed_unassigned,
+    nil,
     # 213 M-U
-    :ed_unassigned,
+    nil,
     # 214 M-V
-    :ed_unassigned,
+    nil,
     # 215 M-W
-    :ed_unassigned,
+    nil,
     # 216 M-X
-    :ed_unassigned,
+    nil,
     # 217 M-Y
-    :ed_unassigned,
+    nil,
     # 218 M-Z
-    :ed_unassigned,
+    nil,
     # 219 M-[
-    :ed_unassigned,
+    nil,
     # 220 M-\
-    :ed_unassigned,
+    nil,
     # 221 M-]
-    :ed_unassigned,
+    nil,
     # 222 M-^
-    :ed_unassigned,
+    nil,
     # 223 M-_
-    :ed_unassigned,
+    nil,
     # 224 M-`
-    :ed_unassigned,
+    nil,
     # 225 M-a
-    :ed_unassigned,
+    nil,
     # 226 M-b
-    :ed_unassigned,
+    nil,
     # 227 M-c
-    :ed_unassigned,
+    nil,
     # 228 M-d
-    :ed_unassigned,
+    nil,
     # 229 M-e
-    :ed_unassigned,
+    nil,
     # 230 M-f
-    :ed_unassigned,
+    nil,
     # 231 M-g
-    :ed_unassigned,
+    nil,
     # 232 M-h
-    :ed_unassigned,
+    nil,
     # 233 M-i
-    :ed_unassigned,
+    nil,
     # 234 M-j
-    :ed_unassigned,
+    nil,
     # 235 M-k
-    :ed_unassigned,
+    nil,
     # 236 M-l
-    :ed_unassigned,
+    nil,
     # 237 M-m
-    :ed_unassigned,
+    nil,
     # 238 M-n
-    :ed_unassigned,
+    nil,
     # 239 M-o
-    :ed_unassigned,
+    nil,
     # 240 M-p
-    :ed_unassigned,
+    nil,
     # 241 M-q
-    :ed_unassigned,
+    nil,
     # 242 M-r
-    :ed_unassigned,
+    nil,
     # 243 M-s
-    :ed_unassigned,
+    nil,
     # 244 M-t
-    :ed_unassigned,
+    nil,
     # 245 M-u
-    :ed_unassigned,
+    nil,
     # 246 M-v
-    :ed_unassigned,
+    nil,
     # 247 M-w
-    :ed_unassigned,
+    nil,
     # 248 M-x
-    :ed_unassigned,
+    nil,
     # 249 M-y
-    :ed_unassigned,
+    nil,
     # 250 M-z
-    :ed_unassigned,
+    nil,
     # 251 M-{
-    :ed_unassigned,
+    nil,
     # 252 M-|
-    :ed_unassigned,
+    nil,
     # 253 M-}
-    :ed_unassigned,
+    nil,
     # 254 M-~
-    :ed_unassigned,
+    nil,
     # 255 M-^?
-    :ed_unassigned
+    nil
     # EOF
   ]
 end

--- a/lib/reline/key_actor/vi_insert.rb
+++ b/lib/reline/key_actor/vi_insert.rb
@@ -1,7 +1,7 @@
 module Reline::KeyActor
   VI_INSERT_MAPPING = [
     #   0 ^@
-    :ed_unassigned,
+    nil,
     #   1 ^A
     :ed_insert,
     #   2 ^B
@@ -257,261 +257,261 @@ module Reline::KeyActor
     # 127 ^?
     :vi_delete_prev_char,
     # 128 M-^@
-    :ed_unassigned,
+    nil,
     # 129 M-^A
-    :ed_unassigned,
+    nil,
     # 130 M-^B
-    :ed_unassigned,
+    nil,
     # 131 M-^C
-    :ed_unassigned,
+    nil,
     # 132 M-^D
-    :ed_unassigned,
+    nil,
     # 133 M-^E
-    :ed_unassigned,
+    nil,
     # 134 M-^F
-    :ed_unassigned,
+    nil,
     # 135 M-^G
-    :ed_unassigned,
+    nil,
     # 136 M-^H
-    :ed_unassigned,
+    nil,
     # 137 M-^I
-    :ed_unassigned,
+    nil,
     # 138 M-^J
     :key_newline,
     # 139 M-^K
-    :ed_unassigned,
+    nil,
     # 140 M-^L
-    :ed_unassigned,
+    nil,
     # 141 M-^M
     :key_newline,
     # 142 M-^N
-    :ed_unassigned,
+    nil,
     # 143 M-^O
-    :ed_unassigned,
+    nil,
     # 144 M-^P
-    :ed_unassigned,
+    nil,
     # 145 M-^Q
-    :ed_unassigned,
+    nil,
     # 146 M-^R
-    :ed_unassigned,
+    nil,
     # 147 M-^S
-    :ed_unassigned,
+    nil,
     # 148 M-^T
-    :ed_unassigned,
+    nil,
     # 149 M-^U
-    :ed_unassigned,
+    nil,
     # 150 M-^V
-    :ed_unassigned,
+    nil,
     # 151 M-^W
-    :ed_unassigned,
+    nil,
     # 152 M-^X
-    :ed_unassigned,
+    nil,
     # 153 M-^Y
-    :ed_unassigned,
+    nil,
     # 154 M-^Z
-    :ed_unassigned,
+    nil,
     # 155 M-^[
-    :ed_unassigned,
+    nil,
     # 156 M-^\
-    :ed_unassigned,
+    nil,
     # 157 M-^]
-    :ed_unassigned,
+    nil,
     # 158 M-^^
-    :ed_unassigned,
+    nil,
     # 159 M-^_
-    :ed_unassigned,
+    nil,
     # 160 M-SPACE
-    :ed_unassigned,
+    nil,
     # 161 M-!
-    :ed_unassigned,
+    nil,
     # 162 M-"
-    :ed_unassigned,
+    nil,
     # 163 M-#
-    :ed_unassigned,
+    nil,
     # 164 M-$
-    :ed_unassigned,
+    nil,
     # 165 M-%
-    :ed_unassigned,
+    nil,
     # 166 M-&
-    :ed_unassigned,
+    nil,
     # 167 M-'
-    :ed_unassigned,
+    nil,
     # 168 M-(
-    :ed_unassigned,
+    nil,
     # 169 M-)
-    :ed_unassigned,
+    nil,
     # 170 M-*
-    :ed_unassigned,
+    nil,
     # 171 M-+
-    :ed_unassigned,
+    nil,
     # 172 M-,
-    :ed_unassigned,
+    nil,
     # 173 M--
-    :ed_unassigned,
+    nil,
     # 174 M-.
-    :ed_unassigned,
+    nil,
     # 175 M-/
-    :ed_unassigned,
+    nil,
     # 176 M-0
-    :ed_unassigned,
+    nil,
     # 177 M-1
-    :ed_unassigned,
+    nil,
     # 178 M-2
-    :ed_unassigned,
+    nil,
     # 179 M-3
-    :ed_unassigned,
+    nil,
     # 180 M-4
-    :ed_unassigned,
+    nil,
     # 181 M-5
-    :ed_unassigned,
+    nil,
     # 182 M-6
-    :ed_unassigned,
+    nil,
     # 183 M-7
-    :ed_unassigned,
+    nil,
     # 184 M-8
-    :ed_unassigned,
+    nil,
     # 185 M-9
-    :ed_unassigned,
+    nil,
     # 186 M-:
-    :ed_unassigned,
+    nil,
     # 187 M-;
-    :ed_unassigned,
+    nil,
     # 188 M-<
-    :ed_unassigned,
+    nil,
     # 189 M-=
-    :ed_unassigned,
+    nil,
     # 190 M->
-    :ed_unassigned,
+    nil,
     # 191 M-?
-    :ed_unassigned,
+    nil,
     # 192 M-@
-    :ed_unassigned,
+    nil,
     # 193 M-A
-    :ed_unassigned,
+    nil,
     # 194 M-B
-    :ed_unassigned,
+    nil,
     # 195 M-C
-    :ed_unassigned,
+    nil,
     # 196 M-D
-    :ed_unassigned,
+    nil,
     # 197 M-E
-    :ed_unassigned,
+    nil,
     # 198 M-F
-    :ed_unassigned,
+    nil,
     # 199 M-G
-    :ed_unassigned,
+    nil,
     # 200 M-H
-    :ed_unassigned,
+    nil,
     # 201 M-I
-    :ed_unassigned,
+    nil,
     # 202 M-J
-    :ed_unassigned,
+    nil,
     # 203 M-K
-    :ed_unassigned,
+    nil,
     # 204 M-L
-    :ed_unassigned,
+    nil,
     # 205 M-M
-    :ed_unassigned,
+    nil,
     # 206 M-N
-    :ed_unassigned,
+    nil,
     # 207 M-O
-    :ed_unassigned,
+    nil,
     # 208 M-P
-    :ed_unassigned,
+    nil,
     # 209 M-Q
-    :ed_unassigned,
+    nil,
     # 210 M-R
-    :ed_unassigned,
+    nil,
     # 211 M-S
-    :ed_unassigned,
+    nil,
     # 212 M-T
-    :ed_unassigned,
+    nil,
     # 213 M-U
-    :ed_unassigned,
+    nil,
     # 214 M-V
-    :ed_unassigned,
+    nil,
     # 215 M-W
-    :ed_unassigned,
+    nil,
     # 216 M-X
-    :ed_unassigned,
+    nil,
     # 217 M-Y
-    :ed_unassigned,
+    nil,
     # 218 M-Z
-    :ed_unassigned,
+    nil,
     # 219 M-[
-    :ed_unassigned,
+    nil,
     # 220 M-\
-    :ed_unassigned,
+    nil,
     # 221 M-]
-    :ed_unassigned,
+    nil,
     # 222 M-^
-    :ed_unassigned,
+    nil,
     # 223 M-_
-    :ed_unassigned,
+    nil,
     # 224 M-`
-    :ed_unassigned,
+    nil,
     # 225 M-a
-    :ed_unassigned,
+    nil,
     # 226 M-b
-    :ed_unassigned,
+    nil,
     # 227 M-c
-    :ed_unassigned,
+    nil,
     # 228 M-d
-    :ed_unassigned,
+    nil,
     # 229 M-e
-    :ed_unassigned,
+    nil,
     # 230 M-f
-    :ed_unassigned,
+    nil,
     # 231 M-g
-    :ed_unassigned,
+    nil,
     # 232 M-h
-    :ed_unassigned,
+    nil,
     # 233 M-i
-    :ed_unassigned,
+    nil,
     # 234 M-j
-    :ed_unassigned,
+    nil,
     # 235 M-k
-    :ed_unassigned,
+    nil,
     # 236 M-l
-    :ed_unassigned,
+    nil,
     # 237 M-m
-    :ed_unassigned,
+    nil,
     # 238 M-n
-    :ed_unassigned,
+    nil,
     # 239 M-o
-    :ed_unassigned,
+    nil,
     # 240 M-p
-    :ed_unassigned,
+    nil,
     # 241 M-q
-    :ed_unassigned,
+    nil,
     # 242 M-r
-    :ed_unassigned,
+    nil,
     # 243 M-s
-    :ed_unassigned,
+    nil,
     # 244 M-t
-    :ed_unassigned,
+    nil,
     # 245 M-u
-    :ed_unassigned,
+    nil,
     # 246 M-v
-    :ed_unassigned,
+    nil,
     # 247 M-w
-    :ed_unassigned,
+    nil,
     # 248 M-x
-    :ed_unassigned,
+    nil,
     # 249 M-y
-    :ed_unassigned,
+    nil,
     # 250 M-z
-    :ed_unassigned,
+    nil,
     # 251 M-{
-    :ed_unassigned,
+    nil,
     # 252 M-|
-    :ed_unassigned,
+    nil,
     # 253 M-}
-    :ed_unassigned,
+    nil,
     # 254 M-~
-    :ed_unassigned,
+    nil,
     # 255 M-^?
-    :ed_unassigned
+    nil
     # EOF
   ]
 end

--- a/test/reline/test_key_actor_emacs.rb
+++ b/test/reline/test_key_actor_emacs.rb
@@ -157,18 +157,18 @@ class Reline::KeyActor::EmacsTest < Reline::TestCase
   end
 
   def test_em_kill_line
-    @line_editor.input_key(Reline::Key.new(:em_kill_line, :em_kill_line, false))
+    input_key_by_symbol(:em_kill_line)
     assert_line_around_cursor('', '')
     input_keys('abc')
-    @line_editor.input_key(Reline::Key.new(:em_kill_line, :em_kill_line, false))
+    input_key_by_symbol(:em_kill_line)
     assert_line_around_cursor('', '')
     input_keys('abc')
     input_keys("\C-b", false)
-    @line_editor.input_key(Reline::Key.new(:em_kill_line, :em_kill_line, false))
+    input_key_by_symbol(:em_kill_line)
     assert_line_around_cursor('', '')
     input_keys('abc')
     input_keys("\C-a", false)
-    @line_editor.input_key(Reline::Key.new(:em_kill_line, :em_kill_line, false))
+    input_key_by_symbol(:em_kill_line)
     assert_line_around_cursor('', '')
   end
 
@@ -273,12 +273,12 @@ class Reline::KeyActor::EmacsTest < Reline::TestCase
   def test_key_delete
     input_keys('abc')
     assert_line_around_cursor('abc', '')
-    @line_editor.input_key(Reline::Key.new(:key_delete, :key_delete, false))
+    input_key_by_symbol(:key_delete)
     assert_line_around_cursor('abc', '')
   end
 
   def test_key_delete_does_not_end_editing
-    @line_editor.input_key(Reline::Key.new(:key_delete, :key_delete, false))
+    input_key_by_symbol(:key_delete)
     assert_line_around_cursor('', '')
     refute(@line_editor.finished?)
   end
@@ -287,7 +287,7 @@ class Reline::KeyActor::EmacsTest < Reline::TestCase
     input_keys('abc')
     input_keys("\C-b", false)
     assert_line_around_cursor('ab', 'c')
-    @line_editor.input_key(Reline::Key.new(:key_delete, :key_delete, false))
+    input_key_by_symbol(:key_delete)
     assert_line_around_cursor('ab', '')
   end
 
@@ -731,10 +731,10 @@ class Reline::KeyActor::EmacsTest < Reline::TestCase
     input_keys("\C-b", false)
     assert_line_around_cursor('foo', 'o')
     assert_equal(nil, @line_editor.instance_variable_get(:@menu_info))
-    @line_editor.input_key(Reline::Key.new(:em_delete_or_list, :em_delete_or_list, false))
+    input_key_by_symbol(:em_delete_or_list)
     assert_line_around_cursor('foo', '')
     assert_equal(nil, @line_editor.instance_variable_get(:@menu_info))
-    @line_editor.input_key(Reline::Key.new(:em_delete_or_list, :em_delete_or_list, false))
+    input_key_by_symbol(:em_delete_or_list)
     assert_line_around_cursor('foo', '')
     assert_equal(%w{foo_foo foo_bar foo_baz}, @line_editor.instance_variable_get(:@menu_info).list)
   end
@@ -1363,7 +1363,7 @@ class Reline::KeyActor::EmacsTest < Reline::TestCase
   def test_incremental_search_history_cancel_by_symbol_key
     # ed_prev_char should move cursor left and cancel incremental search
     input_keys("abc\C-r")
-    input_key_by_symbol(:ed_prev_char)
+    input_key_by_symbol(:ed_prev_char, csi: true)
     input_keys('d')
     assert_line_around_cursor('abd', 'c')
   end

--- a/test/reline/test_key_actor_vi.rb
+++ b/test/reline/test_key_actor_vi.rb
@@ -112,6 +112,17 @@ class Reline::ViInsertTest < Reline::TestCase
     assert_line_around_cursor("か\u3099き\u3099", '')
   end
 
+  def test_ed_insert_ignore_in_vi_command
+    input_keys("\C-[")
+    chars_to_be_ignored = "\C-Oあ=".chars
+    input_keys(chars_to_be_ignored.join)
+    assert_line_around_cursor('', '')
+    input_keys(chars_to_be_ignored.map {|c| "5#{c}" }.join)
+    assert_line_around_cursor('', '')
+    input_keys('iい')
+    assert_line_around_cursor("い", '')
+  end
+
   def test_ed_next_char
     input_keys("abcdef\C-[0")
     assert_line_around_cursor('', 'abcdef')
@@ -648,7 +659,7 @@ class Reline::ViInsertTest < Reline::TestCase
     assert_line_around_cursor('Readline', '')
     input_keys("\C-i", false)
     assert_line_around_cursor('Regexp', '')
-    @line_editor.input_key(Reline::Key.new(:completion_journey_up, :completion_journey_up, false))
+    input_key_by_symbol(:completion_journey_up)
     assert_line_around_cursor('Readline', '')
   ensure
     @config.autocompletion = false
@@ -671,7 +682,7 @@ class Reline::ViInsertTest < Reline::TestCase
     assert_line_around_cursor('Readline', '')
     input_keys("\C-i", false)
     assert_line_around_cursor('Regexp', '')
-    @line_editor.input_key(Reline::Key.new(:menu_complete_backward, :menu_complete_backward, false))
+    input_key_by_symbol(:menu_complete_backward)
     assert_line_around_cursor('Readline', '')
   ensure
     @config.autocompletion = false
@@ -804,6 +815,14 @@ class Reline::ViInsertTest < Reline::TestCase
     assert_line_around_cursor(' f', 'oo foo')
   end
 
+  def test_waiting_operator_arg_including_zero
+    input_keys("a111111111111222222222222\C-[0")
+    input_keys('10df1')
+    assert_line_around_cursor('', '11222222222222')
+    input_keys('d10f2')
+    assert_line_around_cursor('', '22')
+  end
+
   def test_vi_waiting_operator_cancel
     input_keys("aaa bbb ccc\C-[02w")
     assert_line_around_cursor('aaa bbb ', 'ccc')
@@ -825,14 +844,14 @@ class Reline::ViInsertTest < Reline::TestCase
     assert_line_around_cursor('', 'aaa bbb lll')
     # ed_next_char should move cursor right and cancel vi_next_char
     input_keys('f')
-    input_key_by_symbol(:ed_next_char)
+    input_key_by_symbol(:ed_next_char, csi: true)
     input_keys('l')
     assert_line_around_cursor('aa', 'a bbb lll')
-    # ed_next_char should move cursor right and cancel delete_meta
+    # vi_delete_meta + ed_next_char should delete character
     input_keys('d')
-    input_key_by_symbol(:ed_next_char)
+    input_key_by_symbol(:ed_next_char, csi: true)
     input_keys('l')
-    assert_line_around_cursor('aaa ', 'bbb lll')
+    assert_line_around_cursor('aa ', 'bbb lll')
   end
 
   def test_unimplemented_vi_command_should_be_no_op

--- a/test/reline/test_macro.rb
+++ b/test/reline/test_macro.rb
@@ -14,12 +14,12 @@ class Reline::MacroTest < Reline::TestCase
     Reline.test_reset
   end
 
-  def input_key(char, combined_char = char, with_meta = false)
-    @line_editor.input_key(Reline::Key.new(char, combined_char, with_meta))
+  def input_key(char, method_symbol = :ed_insert)
+    @line_editor.input_key(Reline::Key.new(char, method_symbol, false))
   end
 
   def input(str)
-    str.each_byte {|c| input_key(c)}
+    str.each_char {|c| input_key(c)}
   end
 
   def test_simple_input
@@ -33,7 +33,7 @@ class Reline::MacroTest < Reline::TestCase
     end
     input('abc')
     assert_nothing_raised(ArgumentError) {
-      input_key(:delete_char)
+      input_key('x', :delete_char)
     }
     assert_equal 'ab', @line_editor.line
   end

--- a/test/reline/test_reline_key.rb
+++ b/test/reline/test_reline_key.rb
@@ -3,9 +3,8 @@ require "reline"
 
 class Reline::TestKey < Reline::TestCase
   def test_match_symbol
-    assert(Reline::Key.new(:key1, :key1, false).match?(:key1))
-    refute(Reline::Key.new(:key1, :key1, false).match?(:key2))
-    refute(Reline::Key.new(:key1, :key1, false).match?(nil))
-    refute(Reline::Key.new(1, 1, false).match?(:key1))
+    assert(Reline::Key.new('a', :key1, false).match?(:key1))
+    refute(Reline::Key.new('a', :key1, false).match?(:key2))
+    refute(Reline::Key.new('a', :key1, false).match?(nil))
   end
 end

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -271,7 +271,7 @@ begin
       write("\e") # single ESC
       sleep 1
       write("A")
-      write("B\eAC") # ESC + A (M-A, specified ed_unassigned in Reline::KeyActor::Emacs)
+      write("B\eAC") # ESC + A (M-A, no key specified in Reline::KeyActor::Emacs)
       assert_screen(<<~EOC)
         Multiline REPL.
         prompt> abcABCdef


### PR DESCRIPTION
Depends on #713
Fourth step of #708

Combines KeyActor::XXX_MAPPING(single byte to method symbol) with key_bindings(escape sequence to method symbol)

This will simplify the implementation of keys in LineEditor.
We can remove `key.instance_of?(String)` `key.is_a?(Symbol)` check.
Reline::Key structure will be simple.
```ruby
# before
EOF:          Key{ char: nil, combined_char: nil, with_meta: false}
Normal key:   Key{ char: number, combined_char: number, with_meta: false}
ESC+key:      Key{ char: number, combined_char: number|0x80, with_meta: true}
Binding key:  Key{ char: symbol, combined_char: symbol, with_meta: false}

# after
EOF:   Key{ char: nil, combined_char: nil}
Other: Key{ char: string, method_symbol: symbol}
```

## Future refactor

Key can contain string.
This means we can assign bracketed-pasted string to a key. `bracketed_paste` and `quoted_insert` will be simple.
Simplifies bracketed-paste and completion handling, undo-redo handling. Simplifies quoted_insert waiting_proc mechanism and fixes bug.
```ruby
key.char = read_bracketed_paste if key.method_symbol == :bracketed_paste_start
key.char = read_next_valid_char if key.method_symbol == :quoted_insert
line_editor.update(key)
```

Implementing compress-meta will be significantly easy.
```ruby
class Reline::KeyActor::Base
  def add_mappings(mappings)
    ...
    128.times do |key|
      ...
      add([27, key], meta_func)
      add([key | 0x80], meta_func) if compress_meta_enabled # Just add this line
    end
  end
end
```
