### PR TITLE
Ensure no escape sequence before printing prompt

### DIFF
--- a/lib/reline/io/ansi.rb
+++ b/lib/reline/io/ansi.rb
@@ -242,7 +242,7 @@ class Reline::ANSI < Reline::IO
   end
 
   def cursor_pos
-    if @input.tty? && @output.tty?
+    if both_tty?
       res = +''
       m = nil
       @input.raw do |stdin|
@@ -274,6 +274,10 @@ class Reline::ANSI < Reline::IO
       end
     end
     Reline::CursorPos.new(column, row)
+  end
+
+  def both_tty?
+    @input.tty? && @output.tty?
   end
 
   def move_cursor_column(x)
@@ -343,14 +347,14 @@ class Reline::ANSI < Reline::IO
 
   def prep
     # Enable bracketed paste
-    @output.write "\e[?2004h" if Reline.core.config.enable_bracketed_paste
+    @output.write "\e[?2004h" if Reline.core.config.enable_bracketed_paste && both_tty?
     retrieve_keybuffer
     nil
   end
 
   def deprep(otio)
     # Disable bracketed paste
-    @output.write "\e[?2004l" if Reline.core.config.enable_bracketed_paste
+    @output.write "\e[?2004l" if Reline.core.config.enable_bracketed_paste && both_tty?
     Signal.trap('WINCH', @old_winch_handler) if @old_winch_handler
   end
 end

--- a/test/reline/test_reline.rb
+++ b/test/reline/test_reline.rb
@@ -378,6 +378,18 @@ class Reline::Test < Reline::TestCase
     assert_match(/#<Reline::Dumb/, out.chomp)
   end
 
+  def test_print_prompt_before_everything_else
+    pend if win?
+    lib = File.expand_path("../../lib", __dir__)
+    code = "p Reline::IOGate.class; p Reline.readline 'prompt> '"
+    out = IO.popen([Reline.test_rubybin, "-I#{lib}", "-rreline", "-e", code], "r+") do |io|
+      io.write "abc\n"
+      io.close_write
+      io.read
+    end
+    assert_match(/\AReline::ANSI\nprompt> /, out)
+  end
+
   def test_require_reline_should_not_trigger_winsize
     pend if win?
     lib = File.expand_path("../../lib", __dir__)


### PR DESCRIPTION
Some test (readline-ext, bundler) expects output of `Readline.readline("prompt>")` to match `/\Aprompt>/`.

Readline prints `"\e[?2004h"` (enable bracketed-paste) before prompt if STDIN and STDOUT is both tty.
```
$ ruby -rreadline -e "Readline.readline 'prompt>'" | ruby -e "p STDIN.read"
"\e[?2004hprompt>a\b\e[Kb\b\e[Kc\n\e[?2004l\r"
```
Readline does not print escape sequence before prompt if STDIN or STDOUT is not a tty. But Reline prints it.
```
$ printf "a\bb\bc\n" | ruby -rreadline -e "Readline.readline 'prompt>'" | ruby -e "p STDIN.read"
"prompt>a\b\e[Kb\b\e[Kc\n"
```

This pull request fixes Reline to align with Readline.

## Background

Ruby ci was failing. https://github.com/ruby/ruby/actions/runs/9352049059/job/25739247917
This pull request fixes the problem of Reline side. Unfortunately, test still fails. I'll also open a pull request to Rubygems to relax the test assertion.
