### PR TITLE
Add fiddle to gemspec dependencies

### DIFF
--- a/reline.gemspec
+++ b/reline.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = Gem::Requirement.new('>= 2.6')
 
   spec.add_dependency 'io-console', '~> 0.5'
+  spec.add_dependency 'fiddle'
 end


### PR DESCRIPTION
Fiddle will be bundled gem in Ruby 3.5 https://github.com/ruby/ruby/commit/10ecdeb4665cbc061f80cc26c5456ff124703d89


Fixes this test failure (irb head ubuntu latest)
```
Failure: test_backtrace_filtering_with_backtrace_filter(TestIRB::BacktraceFilteringTest):
  </from .*\/irbtest-.*.rb:6:in (`|'Object#)bar'/> was expected to be =~
  <"/home/runner/.rubies/ruby-head/lib/ruby/gems/3.4.0+0/gems/reline-0.5.8/lib/reline/terminfo.rb:2: warning: fiddle was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.5.0. Add fiddle to your Gemfile or gemspec.">.
```