### PR TITLE
Add cursor keys for application keypad mode to default key bindings

### DIFF
--- a/lib/reline/io/ansi.rb
+++ b/lib/reline/io/ansi.rb
@@ -75,7 +75,10 @@ class Reline::ANSI < Reline::IO
 
   def set_default_key_bindings_ansi_cursor(config)
     ANSI_CURSOR_KEY_BINDINGS.each do |char, (default_func, modifiers)|
-      bindings = [["\e[#{char}", default_func]] # CSI + char
+      bindings = [
+        ["\e[#{char}", default_func], # CSI + char
+        ["\eO#{char}", default_func] # SS3 + char, application cursor key mode
+      ]
       if modifiers[:ctrl]
         # CSI + ctrl_key_modifier + char
         bindings << ["\e[1;5#{char}", modifiers[:ctrl]]
@@ -129,17 +132,6 @@ class Reline::ANSI < Reline::IO
       # urxvt / exoterm
       [27, 91, 55, 126] => :ed_move_to_beg, # Home
       [27, 91, 56, 126] => :ed_move_to_end, # End
-
-      # GNOME
-      [27, 79, 72] => :ed_move_to_beg,      # Home
-      [27, 79, 70] => :ed_move_to_end,      # End
-      # Del is 0x08
-      # Arrow keys are the same of KDE
-
-      [27, 79, 65] => :ed_prev_history,     # ↑
-      [27, 79, 66] => :ed_next_history,     # ↓
-      [27, 79, 67] => :ed_next_char,        # →
-      [27, 79, 68] => :ed_prev_char,        # ←
     }.each_pair do |key, func|
       config.add_default_key_binding_by_keymap(:emacs, key, func)
       config.add_default_key_binding_by_keymap(:vi_insert, key, func)

--- a/lib/reline/io/ansi.rb
+++ b/lib/reline/io/ansi.rb
@@ -122,13 +122,6 @@ class Reline::ANSI < Reline::IO
       [27, 91, 52, 126] => :ed_move_to_end, # End
       [27, 91, 51, 126] => :key_delete,     # Del
 
-      # KDE
-      # Del is 0x08
-      [27, 71, 65] => :ed_prev_history,     # ↑
-      [27, 71, 66] => :ed_next_history,     # ↓
-      [27, 71, 67] => :ed_next_char,        # →
-      [27, 71, 68] => :ed_prev_char,        # ←
-
       # urxvt / exoterm
       [27, 91, 55, 126] => :ed_move_to_beg, # Home
       [27, 91, 56, 126] => :ed_move_to_end, # End

--- a/test/reline/test_ansi_without_terminfo.rb
+++ b/test/reline/test_ansi_without_terminfo.rb
@@ -32,25 +32,21 @@ class Reline::ANSI::WithoutTerminfoTest < Reline::TestCase
 
   def test_up_arrow
     assert_key_binding("\e[A", :ed_prev_history) # Console (80x25)
-    assert_key_binding("\eGA", :ed_prev_history) # KDE
     assert_key_binding("\eOA", :ed_prev_history)
   end
 
   def test_down_arrow
     assert_key_binding("\e[B", :ed_next_history) # Console (80x25)
-    assert_key_binding("\eGB", :ed_next_history) # KDE
     assert_key_binding("\eOB", :ed_next_history)
   end
 
   def test_right_arrow
     assert_key_binding("\e[C", :ed_next_char) # Console (80x25)
-    assert_key_binding("\eGC", :ed_next_char) # KDE
     assert_key_binding("\eOC", :ed_next_char)
   end
 
   def test_left_arrow
     assert_key_binding("\e[D", :ed_prev_char) # Console (80x25)
-    assert_key_binding("\eGD", :ed_prev_char) # KDE
     assert_key_binding("\eOD", :ed_prev_char)
   end
 


### PR DESCRIPTION
## Add SS3 cursor keys to `set_default_key_bindings_ansi_cursor`
Added `\eOA \eOB \eOC \eOD \eOF \eOH` (arrow keys, home key, end key for application mode) to default key bindings.
Adding this, we can reduce `set_default_key_bindings_comprehensive_list`.

We added ANSI CSI cursor keys in https://github.com/ruby/reline/pull/569.
This pull request adds SS3 keys that we forgot to add. https://vt100.net/docs/vt100-ug/chapter3.html#T3-6

## Removing \eGA \eGB \eGC \eGD

Removed them because these are not specified in terminfo for any terminal emulator.
I think the bytes `[27, 71, 65..68]` is a mistake of `[27, 79, 65..68]`

In KDE source code, arrow keys are `CSI + (A|B|C|D)` or `SS3 + (A|B|C|D)`
https://invent.kde.org/utilities/konsole/-/blob/master/data/keyboard-layouts/default.keytab?ref_type=heads#L62-72
