### PR TITLE
Suppress warning(Ruby 3.4) requiring fiddle from terminfo.rb

### DIFF
--- a/lib/reline/terminfo.rb
+++ b/lib/reline/terminfo.rb
@@ -1,4 +1,7 @@
 begin
+  # Ignore warning `Add fiddle to your Gemfile or gemspec` in Ruby 3.4.
+  # terminfo.rb and ansi.rb supports fiddle unavailable environment.
+  verbose, $VERBOSE = $VERBOSE, nil
   require 'fiddle'
   require 'fiddle/import'
 rescue LoadError
@@ -7,6 +10,8 @@ rescue LoadError
       false
     end
   end
+ensure
+  $VERBOSE = verbose
 end
 
 module Reline::Terminfo


### PR DESCRIPTION
Make CI green

Reline (ansi, terminfo) tries to load fiddle and terminfo. Reline behaves better with fiddle but does not necessarily requires fiddle.
Fiddle is planned to be a bundled gem in Ruby 3.5. In Ruby 3.4, `require 'fiddle'` through bundle exec will warn
```
terminfo.rb:2: warning: fiddle was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.5.0. Add fiddle to your Gemfile or gemspec.
```
This pull request suppress that warning causing test failure.

`lib/reline/io/windows.rb` fully depends on fiddle, and we may need to think addding fiddle to gemspec dependency before 3.5, but it is out of scope of this pull request.

