### PR TITLE
Add more fallbacks when terminfo or fiddle is not available

### DIFF
--- a/lib/reline/io/ansi.rb
+++ b/lib/reline/io/ansi.rb
@@ -114,10 +114,14 @@ class Reline::ANSI < Reline::IO
 
   def set_default_key_bindings_comprehensive_list(config)
     {
+      # xterm
+      [27, 91, 51, 126] => :key_delete, # kdch1
+      [27, 91, 53, 126] => :ed_search_prev_history, # kpp
+      [27, 91, 54, 126] => :ed_search_next_history, # knp
+
       # Console (80x25)
       [27, 91, 49, 126] => :ed_move_to_beg, # Home
       [27, 91, 52, 126] => :ed_move_to_end, # End
-      [27, 91, 51, 126] => :key_delete,     # Del
 
       # KDE
       # Del is 0x08
@@ -301,27 +305,27 @@ class Reline::ANSI < Reline::IO
   end
 
   def hide_cursor
+    seq = "\e[?25l"
     if Reline::Terminfo.enabled? && Reline::Terminfo.term_supported?
       begin
-        @output.write Reline::Terminfo.tigetstr('civis')
+        seq = Reline::Terminfo.tigetstr('civis')
       rescue Reline::Terminfo::TerminfoError
         # civis is undefined
       end
-    else
-      # ignored
     end
+    @output.write seq
   end
 
   def show_cursor
+    seq = "\e[?25h"
     if Reline::Terminfo.enabled? && Reline::Terminfo.term_supported?
       begin
-        @output.write Reline::Terminfo.tigetstr('cnorm')
+        seq = Reline::Terminfo.tigetstr('cnorm')
       rescue Reline::Terminfo::TerminfoError
         # cnorm is undefined
       end
-    else
-      # ignored
     end
+    @output.write seq
   end
 
   def erase_after_cursor


### PR DESCRIPTION
Add xterm key bindings to comprehensive list. Add fallback escape sequence of cursor hide/show.
Reline works perfectly in xterm without fiddle and terminfo.

Add xterm kpp knp kdch1(kdch1 was already added) to comprehensive list because I think it is the most major `ENV['TERM']` value.

Add cursor show/hide escape sequence fallback `"\e[?25h"` and `"\e[?25l"`.
`"\e[?#{number}#{enable ? 'h' : 'l'}"` (Terminal private modes set and rest, DECSET DECRST) is a commonly used escape sequence. Even if terminal emulator does not recognize it, it will be just ignored. Note that GNU Readline always outputs DECSET of bracketed paste `"\e[?2004h"` even if TERM=dumb.

The value is slightly different from `infocmp xterm`. But I think simple one (just reset extension number 25 = cursor visibility) is safer on non-xterm environment.
```
$ infocmp xterm
#	Reconstructed via infocmp from file: /Applications/iTerm.app/Contents/Resources/terminfo/78/xterm
xterm|X11 terminal emulator,
	...
	civis=\E[?25l
	cnorm=\E[?12l\E[?25h
	cvvis=\E[?12;25h
	...
```
