### PR TITLE
Fix vi_yank or vi_delete_meta copies nil bug

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -2259,9 +2259,11 @@ class Reline::LineEditor
       line, cut = byteslice!(current_line, @byte_pointer, byte_pointer_diff)
     elsif byte_pointer_diff < 0
       line, cut = byteslice!(current_line, @byte_pointer + byte_pointer_diff, -byte_pointer_diff)
+    else
+      return
     end
     copy_for_vi(cut)
-    set_current_line(line || '', @byte_pointer + (byte_pointer_diff < 0 ? byte_pointer_diff : 0))
+    set_current_line(line, @byte_pointer + (byte_pointer_diff < 0 ? byte_pointer_diff : 0))
   end
 
   private def vi_yank(key, arg: nil)
@@ -2280,6 +2282,8 @@ class Reline::LineEditor
       cut = current_line.byteslice(@byte_pointer, byte_pointer_diff)
     elsif byte_pointer_diff < 0
       cut = current_line.byteslice(@byte_pointer + byte_pointer_diff, -byte_pointer_diff)
+    else
+      return
     end
     copy_for_vi(cut)
   end

--- a/test/reline/test_key_actor_vi.rb
+++ b/test/reline/test_key_actor_vi.rb
@@ -738,6 +738,13 @@ class Reline::ViInsertTest < Reline::TestCase
     assert_line_around_cursor('aaa ', 'ddd eee')
   end
 
+  def test_vi_delete_meta_nothing
+    input_keys("foo\C-[0")
+    assert_line_around_cursor('', 'foo')
+    input_keys('dhp')
+    assert_line_around_cursor('', 'foo')
+  end
+
   def test_vi_delete_meta_with_vi_next_word_at_eol
     input_keys("foo bar\C-[0w")
     assert_line_around_cursor('foo ', 'bar')
@@ -846,6 +853,13 @@ class Reline::ViInsertTest < Reline::TestCase
     assert_line_around_cursor('foofo', 'o barbar')
     input_keys('yyP')
     assert_line_around_cursor('foofofoofoo barba', 'ro barbar')
+  end
+
+  def test_vi_yank_nothing
+    input_keys("foo\C-[0")
+    assert_line_around_cursor('', 'foo')
+    input_keys('yhp')
+    assert_line_around_cursor('', 'foo')
   end
 
   def test_vi_end_word_with_operator


### PR DESCRIPTION
In vi command mode, and when cursor is at the beginning of the line, `dhp` or `yhp` will copy a nil to `@vi_clipboard` and tries to paste nil as a text, and raises:
```
lib/reline/line_editor.rb:2348:in `vi_paste_next': undefined method `size' for nil (NoMethodError)
    if @vi_clipboard.size > 0
```