### PR TITLE
Fix rendering bug of nomultiline prompt

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -331,7 +331,7 @@ module Reline
         end
       end
 
-      line_editor.print_nomultiline_prompt(prompt)
+      line_editor.print_nomultiline_prompt
       line_editor.update_dialogs
       line_editor.rerender
 

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -490,13 +490,9 @@ class Reline::LineEditor
     @output.puts lines.map { |l| "#{l}\r\n" }.join
   end
 
-  def print_nomultiline_prompt(prompt)
-    return unless prompt && !@is_multiline
-
+  def print_nomultiline_prompt
     # Readline's test `TestRelineAsReadline#test_readline` requires first output to be prompt, not cursor reset escape sequence.
-    @rendered_screen.lines = [[[0, Reline::Unicode.calculate_width(prompt, true), prompt]]]
-    @rendered_screen.cursor_y = 0
-    @output.write prompt
+    @output.write @prompt if @prompt && !@is_multiline
   end
 
   def render_differential

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -1823,6 +1823,24 @@ begin
       EOC
     end
 
+    def test_print_before_readline
+      code = <<~RUBY
+        puts 'Multiline REPL.'
+        2.times do
+          print 'a' * 10
+          Reline.readline '>'
+        end
+      RUBY
+      start_terminal(6, 30, ['ruby', "-I#{@pwd}/lib", '-rreline', '-e', code], startup_message: 'Multiline REPL.')
+      write "x\n"
+      close
+      assert_screen(<<~EOC)
+        Multiline REPL.
+        >x
+        >
+      EOC
+    end
+
     def test_thread_safe
       start_terminal(6, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --auto-indent}, startup_message: 'Multiline REPL.')
       write("[Thread.new{Reline.readline'>'},Thread.new{Reline.readmultiline('>'){true}}].map(&:join).size\n")


### PR DESCRIPTION
Fix bug of `print('a'*10); Reline.readline('>')` wrong rendering


Readline prints prompt before any other escape sequence, which is ensured in readline-ext test. Reline follows this in singleline mode.

Just after printing prompt, Reline sets `@rendered_screen.lines = [[[0, prompt_width, prompt]]]` representing that prompt is rendered in column 0.

But in this case
```ruby
Reline.readline 'prompt1>'
print 'foo'
Reline.readline 'bar>'
# screen is `foob█ar>`
```
`foobar>` is rendered in terminal screen. `bar>` is not rendered in column 0.


```ruby
# After this fix
print 'foo'
Reline.readline 'bar>'
# prints `"bar>"` for compatibility with readline. This step is not needed for usability at all.
# clears current line and renders "bar>" on column 0
# screen is `bar>█`
```
