### PR TITLE
Accept colon-style hash in test assertion

### DIFF
--- a/test/reline/test_reline.rb
+++ b/test/reline/test_reline.rb
@@ -399,7 +399,7 @@ class Reline::Test < Reline::TestCase
       io.close_write
       io.read
     end
-    assert_include(out, '{:result=>"a"}')
+    assert_include(out, { result: 'a' }.inspect)
   end
 
   def test_read_eof_returns_nil_if_empty
@@ -411,7 +411,7 @@ class Reline::Test < Reline::TestCase
       io.close_write
       io.read
     end
-    assert_include(out, '{:result=>nil}')
+    assert_include(out, { result: nil }.inspect)
   end
 
   def test_require_reline_should_not_trigger_winsize


### PR DESCRIPTION
Hash#inspect is proposed to change to `{key: value, non_symbol_key => value}` in https://bugs.ruby-lang.org/issues/20433#note-10

This pull request will make test pass in both current hash inspect style and the proposed hash inspect style.
```diff
- assert_include(actual, "{:key=>value}")
+ assert_include(actual, { key: value }.inspect)
```

Patch that change `Hash#inspect` is here https://github.com/ruby/ruby/pull/10924
`rake test` passes with colon style inspect patch, but `rake test_rendering` fails (2 failure).
This does not affect ruby core ci, so I'd like to fix it after `Hash#inspect` is changed in ruby head.