### PR TITLE
Fix memory leak in setupterm

### DIFF
--- a/lib/reline/terminfo.rb
+++ b/lib/reline/terminfo.rb
@@ -83,7 +83,7 @@ module Reline::Terminfo
   end
 
   def self.setupterm(term, fildes)
-    errret_int = Fiddle::Pointer.malloc(Fiddle::SIZEOF_INT)
+    errret_int = Fiddle::Pointer.malloc(Fiddle::SIZEOF_INT, Fiddle::RUBY_FREE)
     ret = @setupterm.(term, fildes, errret_int)
     case ret
     when 0 # OK


### PR DESCRIPTION
The allocated Fiddle::Pointer never gets freed because it doesn't have a free function defined for when it gets garbage collected. This commit changes it to use the default free function.