### PR TITLE
Implement re-read-init-file

### DIFF
--- a/lib/reline/config.rb
+++ b/lib/reline/config.rb
@@ -29,6 +29,17 @@ class Reline::Config
   attr_accessor :autocompletion
 
   def initialize
+    reset_variables
+  end
+
+  def reset
+    if editing_mode_is?(:vi_command)
+      @editing_mode_label = :vi_insert
+    end
+    @oneshot_key_bindings.clear
+  end
+
+  def reset_variables
     @additional_key_bindings = { # from inputrc
       emacs: Reline::KeyActor::Base.new,
       vi_insert: Reline::KeyActor::Base.new,
@@ -54,13 +65,7 @@ class Reline::Config
     @convert_meta = true if seven_bit_encoding?(Reline::IOGate.encoding)
     @loaded = false
     @enable_bracketed_paste = true
-  end
-
-  def reset
-    if editing_mode_is?(:vi_command)
-      @editing_mode_label = :vi_insert
-    end
-    @oneshot_key_bindings.clear
+    @show_mode_in_prompt = false
   end
 
   def editing_mode
@@ -358,6 +363,11 @@ class Reline::Config
       ret << key_notation_to_code($&)
     end
     ret
+  end
+
+  def reload
+    reset_variables
+    read
   end
 
   private def seven_bit_encoding?(encoding)

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -2554,4 +2554,8 @@ class Reline::LineEditor
   private def set_next_action_state(type, value)
     @next_action_state = [type, value]
   end
+
+  private def re_read_init_file(_key)
+    @config.reload
+  end
 end

--- a/test/reline/test_config.rb
+++ b/test/reline/test_config.rb
@@ -13,6 +13,7 @@ class Reline::Config::Test < Reline::TestCase
     Dir.chdir(@tmpdir)
     Reline.test_mode
     @config = Reline::Config.new
+    @inputrc_backup = ENV['INPUTRC']
   end
 
   def teardown
@@ -20,6 +21,7 @@ class Reline::Config::Test < Reline::TestCase
     FileUtils.rm_rf(@tmpdir)
     Reline.test_reset
     @config.reset
+    ENV['INPUTRC'] = @inputrc_backup
   end
 
   def additional_key_bindings(keymap_label)
@@ -561,5 +563,18 @@ class Reline::Config::Test < Reline::TestCase
     FileUtils.rm(expected)
     ENV['XDG_CONFIG_HOME'] = xdg_config_home_backup
     ENV['HOME'] = home_backup
+  end
+
+  def test_reload
+    inputrc = "#{@tmpdir}/inputrc"
+    ENV['INPUTRC'] = inputrc
+
+    File.write(inputrc, "set emacs-mode-string !")
+    @config.read
+    assert_equal '!', @config.emacs_mode_string
+
+    File.write(inputrc, "set emacs-mode-string ?")
+    @config.reload
+    assert_equal '?', @config.emacs_mode_string
   end
 end


### PR DESCRIPTION
I implemented re-read-init-file to reload .inputrc.

The default key bindings are not set because they can’t be configured in the current Reline. Given the low usage of inputrc, I believe it’s unnecessary to include them. This was mainly implemented for debugging.

I haven’t written tests for this since I’m unsure how to test inputrc changes. Any suggestions are welcome.

