### PR TITLE
Fix redisplay/insert_text called from pre_input_hook

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -346,7 +346,7 @@ module Reline
             inputs.each do |key|
               if key.char == :bracketed_paste_start
                 text = io_gate.read_bracketed_paste
-                line_editor.insert_pasted_text(text)
+                line_editor.insert_multiline_text(text)
                 line_editor.scroll_into_view
               else
                 line_editor.update(key)
@@ -461,7 +461,7 @@ module Reline
   def_single_delegator :line_editor, :byte_pointer=, :point=
 
   def self.insert_text(text)
-    line_editor.insert_pasted_text(text)
+    line_editor.insert_multiline_text(text)
     self
   end
 

--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -324,14 +324,17 @@ module Reline
       line_editor.prompt_proc = prompt_proc
       line_editor.auto_indent_proc = auto_indent_proc
       line_editor.dig_perfect_match_proc = dig_perfect_match_proc
+
+      # Readline calls pre_input_hook just after printing the first prompt.
+      line_editor.print_nomultiline_prompt
       pre_input_hook&.call
+
       unless Reline::IOGate.dumb?
         @dialog_proc_list.each_pair do |name_sym, d|
           line_editor.add_dialog_proc(name_sym, d.dialog_proc, d.context)
         end
       end
 
-      line_editor.print_nomultiline_prompt
       line_editor.update_dialogs
       line_editor.rerender
 
@@ -457,8 +460,8 @@ module Reline
   def_single_delegator :line_editor, :byte_pointer, :point
   def_single_delegator :line_editor, :byte_pointer=, :point=
 
-  def self.insert_text(*args, &block)
-    line_editor.insert_text(*args, &block)
+  def self.insert_text(text)
+    line_editor.insert_pasted_text(text)
     self
   end
 

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -1333,7 +1333,7 @@ class Reline::LineEditor
     @confirm_multiline_termination_proc.(temp_buffer.join("\n") + "\n")
   end
 
-  def insert_pasted_text(text)
+  def insert_multiline_text(text)
     save_old_buffer
     pre = @buffer_of_lines[@line_index].byteslice(0, @byte_pointer)
     post = @buffer_of_lines[@line_index].byteslice(@byte_pointer..)


### PR DESCRIPTION
Fix https://bugs.ruby-lang.org/issues/20711
Add test for frequently used pre_input_hook pattern.