### PR TITLE
Fix RELINE_TEST_ENCODING

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -807,11 +807,13 @@ class Reline::LineEditor
     target = target.downcase if @config.completion_ignore_case
     list.select do |item|
       next unless item
-
       unless Encoding.compatible?(target.encoding, item.encoding)
-        # Crash with Encoding::CompatibilityError is required by readline-ext/test/readline/test_readline.rb
-        # TODO: fix the test
-        raise Encoding::CompatibilityError, "#{target.encoding.name} is not compatible with #{item.encoding.name}"
+        # Workaround for Readline test
+        if defined?(::Readline) && ::Readline == ::Reline
+          raise Encoding::CompatibilityError, "incompatible character encodings: #{target.encoding} and #{item.encoding}"
+        end
+
+        next true
       end
 
       if @config.completion_ignore_case

--- a/test/reline/helper.rb
+++ b/test/reline/helper.rb
@@ -23,7 +23,7 @@ module Reline
     def test_mode(ansi: false)
       @original_iogate = IOGate
 
-      if Reline.const_defined?(:RELINE_TEST_ENCODING) && RELINE_TEST_ENCODING.is_a?(Encoding)
+      if defined?(RELINE_TEST_ENCODING)
         encoding = RELINE_TEST_ENCODING
       else
         encoding = Encoding::UTF_8

--- a/test/reline/helper.rb
+++ b/test/reline/helper.rb
@@ -19,12 +19,12 @@ rescue LoadError
 end
 
 module Reline
-  class <<self
+  class << self
     def test_mode(ansi: false)
       @original_iogate = IOGate
 
-      if ENV['RELINE_TEST_ENCODING']
-        encoding = Encoding.find(ENV['RELINE_TEST_ENCODING'])
+      if Reline.const_defined?(:RELINE_TEST_ENCODING) && RELINE_TEST_ENCODING.is_a?(Encoding)
+        encoding = RELINE_TEST_ENCODING
       else
         encoding = Encoding::UTF_8
       end
@@ -88,7 +88,7 @@ end
 class Reline::TestCase < Test::Unit::TestCase
   private def convert_str(input, options = {}, normalized = nil)
     return nil if input.nil?
-    input.chars.map { |c|
+    input = input.chars.map { |c|
       if Reline::Unicode::EscapedChars.include?(c.ord)
         c
       else
@@ -96,13 +96,16 @@ class Reline::TestCase < Test::Unit::TestCase
       end
     }.join
   rescue Encoding::UndefinedConversionError, Encoding::InvalidByteSequenceError
-    input = input.unicode_normalize(:nfc)
-    if normalized
-      options[:undef] = :replace
-      options[:replace] = '?'
+    if unicode?(input.encoding)
+      input = input.unicode_normalize(:nfc)
+      if normalized
+        options[:undef] = :replace
+        options[:replace] = '?'
+      end
+      normalized = true
+      retry
     end
-    normalized = true
-    retry
+    input
   end
 
   def input_key_by_symbol(input)
@@ -175,5 +178,9 @@ class Reline::TestCase < Test::Unit::TestCase
       @config.editing_mode = editing_mode
       assert_equal(method_symbol, @config.editing_mode.get(input.bytes))
     end
+  end
+
+  private def unicode?(encoding)
+    [Encoding::UTF_8, Encoding::UTF_16BE, Encoding::UTF_16LE, Encoding::UTF_32BE, Encoding::UTF_32LE].include?(encoding)
   end
 end

--- a/test/reline/test_key_actor_emacs.rb
+++ b/test/reline/test_key_actor_emacs.rb
@@ -1487,6 +1487,7 @@ class Reline::KeyActor::EmacsTest < Reline::TestCase
   end
 
   def test_halfwidth_kana_width_dakuten
+    omit "This test is for UTF-8 but the locale is #{Reline.core.encoding}" if Reline.core.encoding != Encoding::UTF_8
     input_raw_keys('ｶﾞｷﾞｹﾞｺﾞ')
     assert_line_around_cursor('ｶﾞｷﾞｹﾞｺﾞ', '')
     input_keys("\C-b\C-b", false)
@@ -1519,7 +1520,7 @@ class Reline::KeyActor::EmacsTest < Reline::TestCase
   def test_undo
     input_keys("\C-_", false)
     assert_line_around_cursor('', '')
-    input_keys("aあb\C-h\C-h\C-h", false)
+    input_keys("aあb\C-h\C-h\C-h".encode(@encoding), false)
     assert_line_around_cursor('', '')
     input_keys("\C-_", false)
     assert_line_around_cursor('a', '')
@@ -1540,7 +1541,7 @@ class Reline::KeyActor::EmacsTest < Reline::TestCase
     assert_line_around_cursor('a', 'c')
     input_keys("\C-_", false)
     assert_line_around_cursor('ab', 'c')
-    input_keys("あいう\C-b\C-h", false)
+    input_keys("あいう\C-b\C-h".encode(@encoding), false)
     assert_line_around_cursor('abあ', 'うc')
     input_keys("\C-_", false)
     assert_line_around_cursor('abあい', 'うc')
@@ -1585,7 +1586,7 @@ class Reline::KeyActor::EmacsTest < Reline::TestCase
   end
 
   def test_redo
-    input_keys("aあb", false)
+    input_keys("aあb".encode(@encoding), false)
     assert_line_around_cursor('aあb', '')
     input_keys("\M-\C-_", false)
     assert_line_around_cursor('aあb', '')


### PR DESCRIPTION
It was not working because `RELINE_TEST_ENCODING` was not environment variable.