### PR TITLE
Prevent a warning for `warning: literal string will be frozen in the …

### DIFF
--- a/test/reline/helper.rb
+++ b/test/reline/helper.rb
@@ -96,7 +96,7 @@ class Reline::TestCase < Test::Unit::TestCase
       end
     }.join
   rescue Encoding::UndefinedConversionError, Encoding::InvalidByteSequenceError
-    input.unicode_normalize!(:nfc)
+    input = input.unicode_normalize(:nfc)
     if normalized
       options[:undef] = :replace
       options[:replace] = '?'


### PR DESCRIPTION
…future`

ref: https://github.com/ruby/reline/actions/runs/10703449691/job/29674077514