### PR TITLE
Make rendering test faster using updated yamatanooroti

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ is_unix = RUBY_PLATFORM =~ /(aix|darwin|linux|(net|free|open)bsd|cygwin|solaris|
 
 if is_unix && ENV['WITH_VTERM']
   gem "vterm", github: "ruby/vterm-gem"
-  gem "yamatanooroti", github: "ruby/yamatanooroti", ref: "f6e47192100d6089f70cf64c1de540dcaadf005a"
+  gem "yamatanooroti", github: "ruby/yamatanooroti"
 end
 
 gem 'bundler'

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -56,66 +56,65 @@ begin
       start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write(":a\n")
       write("\C-p")
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         prompt> :a
         => :a
         prompt> :a
       EOC
+      close
     end
 
     def test_backspace
       start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write(":abc\C-h\n")
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         prompt> :ab
         => :ab
         prompt>
       EOC
+      close
     end
 
     def test_autowrap
       start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write('01234567890123456789012')
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         prompt> 0123456789012345678901
         2
       EOC
+      close
     end
 
     def test_fullwidth
       start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write(":あ\n")
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         prompt> :あ
         => :あ
         prompt>
       EOC
+      close
     end
 
     def test_two_fullwidth
       start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write(":あい\n")
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         prompt> :あい
         => :あい
         prompt>
       EOC
+      close
     end
 
     def test_finish_autowrapped_line
       start_terminal(10, 40, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write("[{'user'=>{'email'=>'a@a', 'id'=>'ABC'}, 'version'=>4, 'status'=>'succeeded'}]\n")
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         prompt> [{'user'=>{'email'=>'a@a', 'id'=
@@ -126,13 +125,13 @@ begin
         ]
         prompt>
       EOC
+      close
     end
 
     def test_finish_autowrapped_line_in_the_middle_of_lines
       start_terminal(20, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write("[{'user'=>{'email'=>'abcdef@abcdef', 'id'=>'ABC'}, 'version'=>4, 'status'=>'succeeded'}]#{"\C-b"*7}")
       write("\n")
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         prompt> [{'user'=>{'email'=>'a
@@ -145,13 +144,13 @@ begin
         ]
         prompt>
       EOC
+      close
     end
 
     def test_finish_autowrapped_line_in_the_middle_of_multilines
       omit if RUBY_VERSION < '2.7'
       start_terminal(30, 16, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write("<<~EOM\n  ABCDEFG\nEOM\n")
-      close
       assert_screen(<<~'EOC')
         Multiline REPL.
         prompt> <<~EOM
@@ -161,6 +160,7 @@ begin
         => "ABCDEFG\n"
         prompt>
       EOC
+      close
     end
 
     def test_prompt
@@ -169,13 +169,13 @@ begin
       LINES
       start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write("abc\n")
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         prompt> 123
         => 123
         prompt>
       EOC
+      close
     end
 
     def test_mode_string_emacs
@@ -183,11 +183,11 @@ begin
         set show-mode-in-prompt on
       LINES
       start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         @prompt>
       EOC
+      close
     end
 
     def test_mode_string_vi
@@ -199,7 +199,6 @@ begin
       write(":a\n\C-[k")
       write("i\n:a")
       write("\C-[h")
-      close
       assert_screen(<<~EOC)
         (ins)prompt> :a
         => :a
@@ -207,6 +206,7 @@ begin
         => :a
         (cmd)prompt> :a
       EOC
+      close
     end
 
     def test_original_mode_string_emacs
@@ -215,11 +215,11 @@ begin
         set emacs-mode-string [emacs]
       LINES
       start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         [emacs]prompt>
       EOC
+      close
     end
 
     def test_original_mode_string_with_quote
@@ -228,11 +228,11 @@ begin
         set emacs-mode-string "[emacs]"
       LINES
       start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         [emacs]prompt>
       EOC
+      close
     end
 
     def test_original_mode_string_vi
@@ -244,13 +244,13 @@ begin
       LINES
       start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write(":a\n\C-[k")
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         {InS}prompt> :a
         => :a
         {CmD}prompt> :a
       EOC
+      close
     end
 
     def test_mode_string_vi_changing
@@ -260,11 +260,11 @@ begin
       LINES
       start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write(":a\C-[ab\C-[ac\C-h\C-h\C-h\C-h:a")
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         (ins)prompt> :a
       EOC
+      close
     end
 
     def test_esc_input
@@ -275,31 +275,30 @@ begin
       sleep 1
       write("A")
       write("B\eAC") # ESC + A (M-A, specified ed_unassigned in Reline::KeyActor::Emacs)
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         prompt> abcABCdef
       EOC
+      close
     end
 
     def test_prompt_with_escape_sequence
       ENV['RELINE_TEST_PROMPT'] = "\1\e[30m\2prompt> \1\e[m\2"
       start_terminal(5, 20, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write("123\n")
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         prompt> 123
         => 123
         prompt>
       EOC
+      close
     end
 
     def test_prompt_with_escape_sequence_and_autowrap
       ENV['RELINE_TEST_PROMPT'] = "\1\e[30m\2prompt> \1\e[m\2"
       start_terminal(5, 20, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write("1234567890123\n")
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         prompt> 123456789012
@@ -307,6 +306,7 @@ begin
         => 1234567890123
         prompt>
       EOC
+      close
     end
 
     def test_readline_with_multiline_input
@@ -314,7 +314,6 @@ begin
       write("def foo\n  bar\nend\n")
       write("Reline.readline('prompt> ')\n")
       write("\C-p\C-p")
-      close
       assert_screen(<<~EOC)
         => :foo
         [0000]> Reline.readline('prompt> ')
@@ -322,12 +321,12 @@ begin
           bar
         end
       EOC
+      close
     end
 
     def test_multiline_and_autowrap
       start_terminal(10, 20, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write("def aaaaaaaaaa\n  33333333\n           end\C-a\C-pputs\C-e\e\C-m888888888888888")
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         prompt> def aaaaaaaa
@@ -339,6 +338,7 @@ begin
         prompt>            e
         nd
       EOC
+      close
     end
 
     def test_multiline_add_new_line_and_autowrap
@@ -347,7 +347,6 @@ begin
       write("\n")
       write("  bbbbbbbbbbbb")
       write("\n")
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         prompt> def aaaaaaaa
@@ -356,56 +355,56 @@ begin
         bb
         prompt>
       EOC
+      close
     end
 
     def test_clear
       start_terminal(10, 15, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write("3\C-l")
-      close
       assert_screen(<<~EOC)
         prompt> 3
       EOC
+      close
     end
 
     def test_clear_multiline_and_autowrap
       start_terminal(10, 15, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write("def aaaaaa\n  3\n\C-lend")
-      close
       assert_screen(<<~EOC)
         prompt> def aaa
         aaa
         prompt>   3
         prompt> end
       EOC
+      close
     end
 
     def test_nearest_cursor
       start_terminal(10, 20, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write("def ああ\n  :いい\nend\C-pbb\C-pcc")
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         prompt> def ccああ
         prompt>   :bbいい
         prompt> end
       EOC
+      close
     end
 
     def test_delete_line
       start_terminal(10, 20, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write("def a\n\nend\C-p\C-h")
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         prompt> def a
         prompt> end
       EOC
+      close
     end
 
     def test_last_line_of_screen
       start_terminal(5, 20, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write("\n\n\n\n\ndef a\nend")
-      close
       assert_screen(<<~EOC)
         prompt>
         prompt>
@@ -413,13 +412,13 @@ begin
         prompt> def a
         prompt> end
       EOC
+      close
     end
 
     # c17a09b7454352e2aff5a7d8722e80afb73e454b
     def test_autowrap_at_last_line_of_screen
       start_terminal(5, 15, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write("def a\nend\n\C-p")
-      close
       assert_screen(<<~EOC)
         prompt> def a
         prompt> end
@@ -427,60 +426,60 @@ begin
         prompt> def a
         prompt> end
       EOC
+      close
     end
 
     # f002483b27cdb325c5edf9e0fe4fa4e1c71c4b0e
     def test_insert_line_in_the_middle_of_line
       start_terminal(5, 20, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write("333\C-b\C-b\e\C-m8")
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         prompt> 3
         prompt> 833
       EOC
+      close
     end
 
     # 9d8978961c5de5064f949d56d7e0286df9e18f43
     def test_insert_line_in_the_middle_of_line_at_last_line_of_screen
       start_terminal(3, 20, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write("333333333333333\C-a\C-f\e\C-m")
-      close
       assert_screen(<<~EOC)
         prompt> 3
         prompt> 333333333333
         33
       EOC
+      close
     end
 
     def test_insert_after_clear
       start_terminal(10, 20, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write("def a\n  01234\nend\C-l\C-p5678")
-      close
       assert_screen(<<~EOC)
         prompt> def a
         prompt>   056781234
         prompt> end
       EOC
+      close
     end
 
     def test_foced_newline_insertion
       start_terminal(10, 20, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       #write("def a\nend\C-p\C-e\e\C-m  3")
       write("def a\nend\C-p\C-e\e\x0D")
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         prompt> def a
         prompt>
         prompt> end
       EOC
+      close
     end
 
     def test_multiline_incremental_search
       start_terminal(6, 25, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write("def a\n  8\nend\ndef b\n  3\nend\C-s8")
-      close
       assert_screen(<<~EOC)
         prompt>   8
         prompt> end
@@ -489,12 +488,12 @@ begin
         (i-search)`8'  8
         (i-search)`8'end
       EOC
+      close
     end
 
     def test_multiline_incremental_search_finish
       start_terminal(6, 25, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write("def a\n  8\nend\ndef b\n  3\nend\C-r8\C-j")
-      close
       assert_screen(<<~EOC)
         prompt>   8
         prompt> end
@@ -503,6 +502,7 @@ begin
         prompt>   8
         prompt> end
       EOC
+      close
     end
 
     def test_binding_for_vi_movement_mode
@@ -512,48 +512,48 @@ begin
       LINES
       start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write(":1234\C-ahhhi0")
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         prompt> :01234
       EOC
+      close
     end
 
     def test_broken_prompt_list
       start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --broken-dynamic-prompt}, startup_message: 'Multiline REPL.')
       write("def hoge\n  3\nend")
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         [0000]> def hoge
         [0001]>   3
         [0001]> end
       EOC
+      close
     end
 
     def test_no_escape_sequence_passed_to_dynamic_prompt
       start_terminal(10, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl  --autocomplete --color-bold --broken-dynamic-prompt-assert-no-escape-sequence}, startup_message: 'Multiline REPL.')
       write("%[ S")
       write("\n")
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         [0000]> %[ S
         [0001]>
       EOC
+      close
     end
 
     def test_bracketed_paste
       omit if Reline.core.io_gate.win?
       start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write("\e[200~def hoge\r\t3\rend\e[201~")
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         prompt> def hoge
         prompt>   3
         prompt> end
       EOC
+      close
     end
 
     def test_bracketed_paste_with_undo
@@ -562,11 +562,11 @@ begin
       write("abc")
       write("\e[200~def hoge\r\t3\rend\e[201~")
       write("\C-_")
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         prompt> abc
       EOC
+      close
     end
 
     def test_bracketed_paste_with_redo
@@ -576,24 +576,24 @@ begin
       write("\e[200~def hoge\r\t3\rend\e[201~")
       write("\C-_")
       write("\M-\C-_")
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         prompt> abcdef hoge
         prompt>   3
         prompt> end
       EOC
+      close
     end
 
     def test_backspace_until_returns_to_initial
       start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write("ABC")
       write("\C-h\C-h\C-h")
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         prompt>
       EOC
+      close
     end
 
     def test_longer_than_screen_height
@@ -632,8 +632,6 @@ begin
           end
         end
       EOC
-      sleep 1
-      close
       assert_screen(<<~EOC)
         prompt>         prompt
         prompt>       end
@@ -641,6 +639,7 @@ begin
         prompt>   end
         prompt> end
       EOC
+      close
     end
 
     def test_longer_than_screen_height_with_scroll_back
@@ -681,7 +680,6 @@ begin
       EOC
       sleep 1
       write("\C-p" * 6)
-      close
       assert_screen(<<~EOC)
         prompt>       rescue Terminate
         LineInput
@@ -689,6 +687,7 @@ begin
         ut
         prompt>         prompt
       EOC
+      close
     end
 
     def test_longer_than_screen_height_with_complex_scroll_back
@@ -730,13 +729,13 @@ begin
       sleep 1
       write("\C-p" * 5)
       write("\C-n" * 3)
-      close
       assert_screen(<<~EOC)
         ut
         prompt>         prompt
         prompt>       end
         prompt>     end
       EOC
+      close
     end
 
     def test_longer_than_screen_height_nearest_cursor_with_scroll_back
@@ -754,7 +753,6 @@ begin
       EOC
       write("\C-p" * 4 + "\C-e" + "\C-p" * 4)
       write("2")
-      close
       assert_screen(<<~EOC)
         prompt> if 12
         prompt>   if 2
@@ -762,6 +760,7 @@ begin
         prompt>       if 4
         prompt>         puts
       EOC
+      close
     end
 
     def test_update_cursor_correctly_when_just_cursor_moving
@@ -773,12 +772,12 @@ begin
       write('5')
       write("\C-e")
       write('9')
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         prompt> def hoge
         prompt>   0123456789
       EOC
+      close
     end
 
     def test_auto_indent
@@ -786,7 +785,6 @@ begin
       "def hoge\nputs(\n1,\n2\n)\nend".lines do |line|
         write line
       end
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         prompt> def hoge
@@ -796,18 +794,19 @@ begin
         prompt>   )
         prompt> end
       EOC
+      close
     end
 
     def test_auto_indent_when_inserting_line
       start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --auto-indent}, startup_message: 'Multiline REPL.')
       write 'aa(bb(cc(dd(ee('
       write "\C-b" * 5 + "\n"
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         prompt> aa(bb(cc(d
         prompt>       d(ee(
       EOC
+      close
     end
 
     def test_auto_indent_multibyte_insert_line
@@ -815,7 +814,6 @@ begin
       write "if true\n"
       write "あいうえお\n"
       4.times { write "\C-b\C-b\C-b\C-b\e\r" }
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         prompt> if true
@@ -826,26 +824,26 @@ begin
         prompt>   お
         prompt>
       EOC
+      close
     end
 
     def test_newline_after_wrong_indent
       start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --auto-indent}, startup_message: 'Multiline REPL.')
       write "if 1\n    aa"
       write "\n"
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         prompt> if 1
         prompt>   aa
         prompt>
       EOC
+      close
     end
 
     def test_suppress_auto_indent_just_after_pasted
       start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --auto-indent}, startup_message: 'Multiline REPL.')
       write("def hoge\n  [[\n      3]]\ned")
       write("\C-bn")
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         prompt> def hoge
@@ -853,6 +851,7 @@ begin
         prompt>       3]]
         prompt> end
       EOC
+      close
     end
 
     def test_suppress_auto_indent_for_adding_newlines_in_pasting
@@ -860,7 +859,6 @@ begin
       write("<<~Q\n")
       write("{\n  #\n}")
       write("#")
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         prompt> <<~Q
@@ -868,6 +866,7 @@ begin
         prompt>   #
         prompt> }#
       EOC
+      close
     end
 
     def test_auto_indent_with_various_spaces
@@ -875,13 +874,13 @@ begin
       write "(\n\C-v"
       write "\C-k\n\C-v"
       write "\C-k)"
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         prompt> (
         prompt> ^K
         prompt> )
       EOC
+      close
     end
 
     def test_autowrap_in_the_middle_of_a_line
@@ -890,19 +889,18 @@ begin
       %w{h i}.each do |c|
         write(c)
       end
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         prompt> def abcdefgh
         i; end
       EOC
+      close
     end
 
     def test_terminate_in_the_middle_of_lines
       start_terminal(5, 20, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write("def hoge\n  1\n  2\n  3\n  4\nend\n")
       write("\C-p\C-p\C-p\C-e\n")
-      close
       assert_screen(<<~EOC)
         prompt>   3
         prompt>   4
@@ -910,12 +908,12 @@ begin
         => :hoge
         prompt>
       EOC
+      close
     end
 
     def test_dynamic_prompt_returns_empty
       start_terminal(5, 20, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --dynamic-prompt-returns-empty}, startup_message: 'Multiline REPL.')
       write("def hoge\nend\n")
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         prompt> def hoge
@@ -923,108 +921,106 @@ begin
         => :hoge
         prompt>
       EOC
+      close
     end
 
     def test_reset_rest_height_when_clear_screen
       start_terminal(5, 20, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write("\n\n\n\C-l3\n")
-      close
       assert_screen(<<~EOC)
         prompt> 3
         => 3
         prompt>
       EOC
+      close
     end
 
     def test_meta_key
       start_terminal(30, 20, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write("def ge\M-bho")
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         prompt> def hoge
       EOC
+      close
     end
 
     def test_not_meta_key
       start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write("おだんご") # "だ" in UTF-8 contains "\xA0"
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         prompt> おだんご
       EOC
+      close
     end
 
     def test_force_enter
       start_terminal(30, 120, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write("def hoge\nend\C-p\C-e")
       write("\M-\x0D")
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         prompt> def hoge
         prompt>
         prompt> end
       EOC
+      close
     end
 
     def test_nontty
       omit if Reline.core.io_gate.win?
       cmd = %Q{ruby -e 'puts(%Q{ello\C-ah\C-e})' | ruby -I#{@pwd}/lib -rreline -e 'p Reline.readline(%{> })' | ruby -e 'print STDIN.read'}
       start_terminal(40, 50, ['bash', '-c', cmd])
-      sleep 1
-      close rescue nil
       assert_screen(<<~'EOC')
         > hello
         "hello"
       EOC
+      close
     end
 
     def test_eof_with_newline
       omit if Reline.core.io_gate.win?
       cmd = %Q{ruby -e 'print(%Q{abc def \\e\\r})' | ruby -I#{@pwd}/lib -rreline -e 'p Reline.readline(%{> })'}
       start_terminal(40, 50, ['bash', '-c', cmd])
-      sleep 1
-      close rescue nil
       assert_screen(<<~'EOC')
         > abc def
         "abc def "
       EOC
+      close
     end
 
     def test_eof_without_newline
       omit if Reline.core.io_gate.win?
       cmd = %Q{ruby -e 'print(%{hello})' | ruby -I#{@pwd}/lib -rreline -e 'p Reline.readline(%{> })'}
       start_terminal(40, 50, ['bash', '-c', cmd])
-      sleep 1
-      close rescue nil
       assert_screen(<<~'EOC')
         > hello
         "hello"
       EOC
+      close
     end
 
     def test_em_set_mark_and_em_exchange_mark
       start_terminal(10, 50, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write("aaa bbb ccc ddd\M-b\M-b\M-\x20\M-b\C-x\C-xX\C-x\C-xY")
-      close
       assert_screen(<<~'EOC')
         Multiline REPL.
         prompt> aaa Ybbb Xccc ddd
       EOC
+      close
     end
 
     def test_multiline_completion
       start_terminal(10, 50, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --complete}, startup_message: 'Multiline REPL.')
       write("def hoge\n  St\n  St\C-p\t")
-      close
       assert_screen(<<~'EOC')
         Multiline REPL.
         prompt> def hoge
         prompt>   String
         prompt>   St
       EOC
+      close
     end
 
     def test_completion_journey_2nd_line
@@ -1033,12 +1029,12 @@ begin
       LINES
       start_terminal(10, 50, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --complete}, startup_message: 'Multiline REPL.')
       write("def hoge\n  S\C-n")
-      close
       assert_screen(<<~'EOC')
         Multiline REPL.
         prompt> def hoge
         prompt>   String
       EOC
+      close
     end
 
     def test_completion_journey_with_empty_line
@@ -1047,23 +1043,23 @@ begin
       LINES
       start_terminal(10, 50, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --complete}, startup_message: 'Multiline REPL.')
       write("\C-n\C-p")
-      close
       assert_screen(<<~'EOC')
         Multiline REPL.
         prompt>
       EOC
+      close
     end
 
     def test_completion_menu_is_displayed_horizontally
       start_terminal(20, 50, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --complete}, startup_message: 'Multiline REPL.')
       write("S\t\t")
-      close
       assert_screen(<<~'EOC')
         Multiline REPL.
         prompt> S
         ScriptError  String
         Signal       SyntaxError
       EOC
+      close
     end
 
     def test_show_all_if_ambiguous_on
@@ -1072,13 +1068,13 @@ begin
       LINES
       start_terminal(20, 50, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --complete}, startup_message: 'Multiline REPL.')
       write("S\t")
-      close
       assert_screen(<<~'EOC')
         Multiline REPL.
         prompt> S
         ScriptError  String
         Signal       SyntaxError
       EOC
+      close
     end
 
     def test_show_all_if_ambiguous_on_and_menu_with_perfect_match
@@ -1087,12 +1083,12 @@ begin
       LINES
       start_terminal(20, 50, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --complete-menu-with-perfect-match}, startup_message: 'Multiline REPL.')
       write("a\t")
-      close
       assert_screen(<<~'EOC')
         Multiline REPL.
         prompt> abs
         abs   abs2
       EOC
+      close
     end
 
     def test_simple_dialog
@@ -1143,7 +1139,6 @@ begin
         write("\n" * 10)
         write("if 1\n  sSts\nend")
         write("\C-p\C-h\C-e\C-h")
-        close
         assert_screen(<<~'EOC')
           prompt>
           prompt>
@@ -1156,6 +1151,7 @@ begin
           prompt> enString
                     Struct
         EOC
+        close
       end
     end
 
@@ -1179,7 +1175,6 @@ begin
       start_terminal(15, 50, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --autocomplete}, startup_message: 'Multiline REPL.')
       write('def hoge' + "\C-m" * 10 + "end\C-p  ")
       write('S')
-      close
       assert_screen(<<~'EOC')
         Multiline REPL.
         prompt> def hoge
@@ -1194,6 +1189,7 @@ begin
         prompt>   S
         prompt> end
       EOC
+      close
     end
 
     def test_autocomplete_return_to_original
@@ -1202,13 +1198,13 @@ begin
       write('t')
       write('r')
       3.times{ write("\C-i") }
-      close
       assert_screen(<<~'EOC')
         Multiline REPL.
         prompt> Str
                 String
                 Struct
       EOC
+      close
     end
 
     def test_autocomplete_target_is_wrapped
@@ -1217,7 +1213,6 @@ begin
       write('S')
       write('t')
       write('r')
-      close
       assert_screen(<<~'EOC')
         Multiline REPL.
         prompt>           St
@@ -1225,6 +1220,7 @@ begin
         String
         Struct
       EOC
+      close
     end
 
     def test_autocomplete_target_at_end_of_line
@@ -1232,13 +1228,13 @@ begin
       write('         ')
       write('Str')
       write("\C-i")
-      close
       assert_screen(<<~'EOC')
         Multiline REPL.
         prompt>          Str
         ing           String
                       Struct
       EOC
+      close
     end
 
     def test_autocomplete_completed_input_is_wrapped
@@ -1246,33 +1242,32 @@ begin
       write('        ')
       write('Str')
       write("\C-i")
-      close
       assert_screen(<<~'EOC')
         Multiline REPL.
         prompt>         Stri
         ng            String
                       Struct
       EOC
+      close
     end
 
     def test_force_insert_before_autocomplete
       start_terminal(20, 20, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --autocomplete}, startup_message: 'Multiline REPL.')
       write('Sy')
       write(";St\t\t")
-      close
       assert_screen(<<~'EOC')
         Multiline REPL.
         prompt> Sy;Struct
                    String
                    Struct
       EOC
+      close
     end
 
     def test_simple_dialog_with_scroll_key
       start_terminal(20, 50, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --dialog long,scrollkey}, startup_message: 'Multiline REPL.')
       write('a')
       5.times{ write('j') }
-      close
       assert_screen(<<~'EOC')
         Multiline REPL.
         prompt> a
@@ -1281,13 +1276,13 @@ begin
                  language with a
                  focus on simplicity
       EOC
+      close
     end
 
     def test_simple_dialog_scrollbar_with_moving_to_right
       start_terminal(20, 50, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --dialog long,scrollkey,scrollbar}, startup_message: 'Multiline REPL.')
       6.times{ write('j') }
       write('a')
-      close
       assert_screen(<<~'EOC')
         Multiline REPL.
         prompt> a
@@ -1296,6 +1291,7 @@ begin
                  focus on simplicity
                  and productivity.
       EOC
+      close
     end
 
     def test_simple_dialog_scrollbar_with_moving_to_left
@@ -1303,7 +1299,6 @@ begin
       write('a')
       6.times{ write('j') }
       write("\C-h")
-      close
       assert_screen(<<~'EOC')
         Multiline REPL.
         prompt>
@@ -1312,13 +1307,13 @@ begin
                 focus on simplicity
                 and productivity.
       EOC
+      close
     end
 
     def test_dialog_with_fullwidth_chars
       ENV['RELINE_TEST_PROMPT'] = '> '
       start_terminal(20, 5, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --dialog fullwidth,scrollkey,scrollbar}, startup_message: 'Multiline REPL.')
       6.times{ write('j') }
-      close
       assert_screen(<<~'EOC')
         Multi
         line
@@ -1329,13 +1324,13 @@ begin
         備え█
         ち、█
       EOC
+      close
     end
 
     def test_dialog_with_fullwidth_chars_split
       ENV['RELINE_TEST_PROMPT'] = '> '
       start_terminal(20, 6, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --dialog fullwidth,scrollkey,scrollbar}, startup_message: 'Multiline REPL.')
       6.times{ write('j') }
-      close
       assert_screen(<<~'EOC')
         Multil
         ine RE
@@ -1346,34 +1341,34 @@ begin
         備え █
         ち、 █
       EOC
+      close
     end
 
     def test_autocomplete_empty
       start_terminal(20, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --autocomplete}, startup_message: 'Multiline REPL.')
       write('Street')
-      close
       assert_screen(<<~'EOC')
         Multiline REPL.
         prompt> Street
       EOC
+      close
     end
 
     def test_autocomplete
       start_terminal(20, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --autocomplete}, startup_message: 'Multiline REPL.')
       write('Str')
-      close
       assert_screen(<<~'EOC')
         Multiline REPL.
         prompt> Str
                 String
                 Struct
       EOC
+      close
     end
 
     def test_autocomplete_empty_string
       start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --autocomplete}, startup_message: 'Multiline REPL.')
       write("\C-i")
-      close
       assert_screen(<<~'EOC')
         Multiline REPL.
         prompt> String
@@ -1381,12 +1376,12 @@ begin
                 Struct     ▀
                 Symbol
       EOC
+      close
     end
 
     def test_paste_code_with_tab_indent_does_not_fail
       start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --autocomplete-empty}, startup_message: 'Multiline REPL.')
       write("2.times do\n\tputs\n\tputs\nend")
-      close
       assert_screen(<<~'EOC')
         Multiline REPL.
         prompt> 2.times do
@@ -1394,12 +1389,12 @@ begin
         prompt> puts
         prompt> end
       EOC
+      close
     end
 
     def test_autocomplete_after_2nd_line
       start_terminal(20, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --autocomplete}, startup_message: 'Multiline REPL.')
       write("def hoge\n  Str")
-      close
       assert_screen(<<~'EOC')
         Multiline REPL.
         prompt> def hoge
@@ -1407,13 +1402,13 @@ begin
                   String
                   Struct
       EOC
+      close
     end
 
     def test_autocomplete_rerender_under_dialog
       start_terminal(20, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --autocomplete}, startup_message: 'Multiline REPL.')
       write("def hoge\n\n  123456\n  456789\nend\C-p\C-p\C-p  a = Str")
       write('i')
-      close
       assert_screen(<<~'EOC')
         Multiline REPL.
         prompt> def hoge
@@ -1422,13 +1417,13 @@ begin
         prompt>   456789
         prompt> end
       EOC
+      close
     end
 
     def test_rerender_multiple_dialog
       start_terminal(20, 60, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --autocomplete --dialog simple}, startup_message: 'Multiline REPL.')
       write("if\n  abcdef\n  123456\n  456789\nend\C-p\C-p\C-p\C-p Str")
       write("\t")
-      close
       assert_screen(<<~'EOC')
         Multiline REPL.
         prompt> if String
@@ -1439,12 +1434,12 @@ begin
                          syntax that is natural to read and
                          easy to write.
       EOC
+      close
     end
 
     def test_autocomplete_long_with_scrollbar
       start_terminal(20, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --autocomplete-long}, startup_message: 'Multiline REPL.')
       write('S')
-      close
       assert_screen(<<~'EOC')
         Multiline REPL.
         prompt> S
@@ -1464,12 +1459,12 @@ begin
                 Socket
                 StringIO
       EOC
+      close
     end
 
     def test_autocomplete_long_with_scrollbar_scroll
       start_terminal(20, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --autocomplete-long}, startup_message: 'Multiline REPL.')
       write('S' + "\C-i" * 16)
-      close
       assert_screen(<<~'EOC')
         Multiline REPL.
         prompt> StringScanner
@@ -1489,13 +1484,13 @@ begin
                 StringIO
                 StringScanner
       EOC
+      close
     end
 
     def test_autocomplete_super_long_scroll_to_bottom
       start_terminal(20, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --autocomplete-super-long}, startup_message: 'Multiline REPL.')
       shift_tab = [27, 91, 90]
       write('S' + shift_tab.map(&:chr).join)
-      close
       assert_screen(<<~'EOC')
         Multiline REPL.
         prompt> Str_BXX
@@ -1515,6 +1510,7 @@ begin
                 Str_BXW
                 Str_BXX▄
       EOC
+      close
     end
 
     def test_autocomplete_super_long_and_backspace
@@ -1522,7 +1518,6 @@ begin
       shift_tab = [27, 91, 90]
       write('S' + shift_tab.map(&:chr).join)
       write("\C-h")
-      close
       assert_screen(<<~'EOC')
         Multiline REPL.
         prompt> Str_BX
@@ -1542,21 +1537,21 @@ begin
                 Str_BXM
                 Str_BXN
       EOC
+      close
     end
 
     def test_dialog_callback_returns_nil
       start_terminal(20, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --dialog nil}, startup_message: 'Multiline REPL.')
       write('a')
-      close
       assert_screen(<<~'EOC')
         Multiline REPL.
         prompt> a
       EOC
+      close
     end
 
     def test_dialog_narrower_than_screen
       start_terminal(20, 11, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --dialog simple}, startup_message: 'Multiline REPL.')
-      close
       assert_screen(<<~'EOC')
         Multiline R
         EPL.
@@ -1568,12 +1563,12 @@ begin
         syntax that
         easy to wri
       EOC
+      close
     end
 
     def test_dialog_narrower_than_screen_with_scrollbar
       start_terminal(20, 11, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --autocomplete-long}, startup_message: 'Multiline REPL.')
       write('S' + "\C-i" * 3)
-      close
       assert_screen(<<~'EOC')
         Multiline R
         EPL.
@@ -1594,11 +1589,11 @@ begin
         Socket
         StringIO
       EOC
+      close
     end
 
     def test_dialog_with_fullwidth_scrollbar
       start_terminal(20, 40, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --dialog simple,scrollkey,alt-scrollbar}, startup_message: 'Multiline REPL.')
-      close
       assert_screen(<<~'EOC')
         Multiline REPL.
         prompt>
@@ -1607,17 +1602,18 @@ begin
            language with a focus on simplicity''
            and productivity. It has an elegant
       EOC
+      close
     end
 
     def test_rerender_argument_prompt_after_pasting
       start_terminal(20, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write('abcdef')
       write("\M-3\C-h")
-      close
       assert_screen(<<~'EOC')
         Multiline REPL.
         prompt> abc
       EOC
+      close
     end
 
     def test_autocomplete_old_dialog_width_greater_than_dialog_width
@@ -1626,13 +1622,13 @@ begin
       write("\C-p")
       write("r")
       write("a")
-      close
       assert_screen(<<~'EOC')
         Multiline REPL.
         prompt> 0+ ra
         prompt> 123rand 901234
                    raise
       EOC
+      close
     end
 
     def test_scroll_at_bottom_for_dialog
@@ -1640,7 +1636,6 @@ begin
       write("\n\n\n\n\n\n\n\n\n\n\n")
       write("def hoge\n\nend\C-p\C-e")
       write("  S")
-      close
       assert_screen(<<~'EOC')
         prompt>
         prompt>
@@ -1653,63 +1648,64 @@ begin
                   Struct     ▀
                   Symbol
       EOC
+      close
     end
 
     def test_clear_dialog_in_pasting
       start_terminal(10, 40, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --autocomplete}, startup_message: 'Multiline REPL.')
       write("S")
       write("tring ")
-      close
       assert_screen(<<~'EOC')
         Multiline REPL.
         prompt> String
       EOC
+      close
     end
 
     def test_prompt_with_newline
       ENV['RELINE_TEST_PROMPT'] = "::\n> "
       start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write("def hoge\n  3\nend")
-      close
       assert_screen(<<~'EOC')
         Multiline REPL.
         ::\n> def hoge
         ::\n>   3
         ::\n> end
       EOC
+      close
     end
 
     def test_dynamic_prompt_with_newline
       start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --dynamic-prompt-with-newline}, startup_message: 'Multiline REPL.')
       write("def hoge\n  3\nend")
-      close
       assert_screen(<<~'EOC')
         Multiline REPL.
         [0000\n]> def hoge
         [0001\n]>   3
         [0001\n]> end
       EOC
+      close
     end
 
     def test_lines_passed_to_dynamic_prompt
       start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --dynamic-prompt-show-line}, startup_message: 'Multiline REPL.')
       write("if true")
       write("\n")
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         [if t]> if true
         [    ]>
       EOC
+      close
     end
 
     def test_clear_dialog_when_just_move_cursor_at_last_line
       start_terminal(10, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --autocomplete}, startup_message: 'Multiline REPL.')
       write("class A\n  3\nend\n\n\n")
       write("\C-p\C-p\C-e; S")
+      assert_screen(/String/)
       write("\C-n")
       write(";")
-      close
       assert_screen(<<~'EOC')
         prompt>   3
         prompt> end
@@ -1720,6 +1716,7 @@ begin
         prompt>   3; S
         prompt> end;
       EOC
+      close
     end
 
     def test_clear_dialog_when_adding_new_line_to_end_of_buffer
@@ -1729,7 +1726,6 @@ begin
       write("class S")
       write("\n")
       write("  3")
-      close
       assert_screen(<<~'EOC')
         prompt>   def a
         prompt>     3
@@ -1740,6 +1736,7 @@ begin
         prompt> class S
         prompt>   3
       EOC
+      close
     end
 
     def test_insert_newline_in_the_middle_of_buffer_just_after_dialog
@@ -1749,7 +1746,6 @@ begin
       write("\C-p\C-p\C-p\C-p\C-p\C-e\C-hS")
       write("\M-\x0D")
       write("  3")
-      close
       assert_screen(<<~'EOC')
         prompt>     3
         prompt>   end
@@ -1762,6 +1758,7 @@ begin
         prompt>   end
         prompt> end
       EOC
+      close
     end
 
     def test_incremental_search_on_not_last_line
@@ -1772,7 +1769,6 @@ begin
       write("\C-r")
       write("a")
       write("\n\n")
-      close
       assert_screen(<<~'EOC')
         prompt> def abc
         prompt> end
@@ -1785,28 +1781,29 @@ begin
         => :abc
         prompt>
       EOC
+      close
     end
 
     def test_bracket_newline_indent
       start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --auto-indent}, startup_message: 'Multiline REPL.')
       write("[\n")
       write("1")
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         prompt> [
         prompt>   1
       EOC
+      close
     end
 
     def test_repeated_input_delete
       start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write("a\C-h" * 4000)
-      close
       assert_screen(<<~'EOC')
         Multiline REPL.
         prompt>
       EOC
+      close
     end
 
     def test_exit_with_ctrl_d
@@ -1821,6 +1818,7 @@ begin
         Multiline REPL.
         prompt>
       EOC
+      close
     end
 
     def test_print_before_readline
@@ -1833,12 +1831,12 @@ begin
       RUBY
       start_terminal(6, 30, ['ruby', "-I#{@pwd}/lib", '-rreline', '-e', code], startup_message: 'Multiline REPL.')
       write "x\n"
-      close
       assert_screen(<<~EOC)
         Multiline REPL.
         >x
         >
       EOC
+      close
     end
 
     def test_pre_input_hook_with_redisplay
@@ -1855,6 +1853,7 @@ begin
         Multiline REPL.
         prompt> abc
       EOC
+      close
     end
 
     def test_pre_input_hook_with_multiline_text_insert
@@ -1873,6 +1872,7 @@ begin
         >abc
         def
       EOC
+      close
     end
 
     def test_thread_safe
@@ -1881,7 +1881,6 @@ begin
       write("exit\n")
       write("exit\n")
       write("42\n")
-      close
       assert_screen(<<~EOC)
         >exit
         >exit
@@ -1890,6 +1889,7 @@ begin
         => 42
         prompt>
       EOC
+      close
     end
 
     def test_stop_continue
@@ -1902,13 +1902,15 @@ begin
       rubyfile.close
       start_terminal(40, 50, ['bash'])
       write "ruby -I#{@pwd}/lib -rreline #{rubyfile.path}\n"
+      assert_screen(/^>/)
       write "abc\ndef\nhi"
       pid = pidfile.tap(&:rewind).read.to_i
       Process.kill(:STOP, pid) unless pid.zero?
       write "fg\n"
+      assert_screen(/fg\n.*>/m)
       write "\ebg"
+      assert_screen(/>abc\n>def\n>ghi\n/)
       close
-      assert_include result.join("\n"), ">abc\n>def\n>ghi\n"
     end
 
     def write_inputrc(content)


### PR DESCRIPTION
Makes test_rendering faster. Yamatanooroti's wait time is reduced from 0.1 sec to 0.01 sec
rake test_yamatanooroti(vterm-yamatanooroti ubuntu-latest head) 209 seconds → 57 seconds
