### PR TITLE
Add a timeout to cursor_pos

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -412,7 +412,7 @@ module Reline
     end
 
     private def may_req_ambiguous_char_width
-      @ambiguous_width = 2 if io_gate.dumb? || !STDIN.tty? || !STDOUT.tty?
+      @ambiguous_width = 1 if io_gate.dumb? || !STDIN.tty? || !STDOUT.tty?
       return if defined? @ambiguous_width
       io_gate.move_cursor_column(0)
       begin
@@ -421,7 +421,7 @@ module Reline
         # LANG=C
         @ambiguous_width = 1
       else
-        @ambiguous_width = io_gate.cursor_pos.x
+        @ambiguous_width = io_gate.cursor_pos.x == 2 ? 2 : 1
       end
       io_gate.move_cursor_column(0)
       io_gate.erase_after_cursor

--- a/lib/reline/io/dumb.rb
+++ b/lib/reline/io/dumb.rb
@@ -60,7 +60,7 @@ class Reline::Dumb < Reline::IO
   end
 
   def cursor_pos
-    Reline::CursorPos.new(1, 1)
+    Reline::CursorPos.new(0, 0)
   end
 
   def hide_cursor

--- a/test/reline/test_reline.rb
+++ b/test/reline/test_reline.rb
@@ -1,6 +1,10 @@
 require_relative 'helper'
 require 'reline'
 require 'stringio'
+begin
+  require "pty"
+rescue LoadError # some platforms don't support PTY
+end
 
 class Reline::Test < Reline::TestCase
   class DummyCallbackObject
@@ -430,6 +434,37 @@ class Reline::Test < Reline::TestCase
 
   def win?
     /mswin|mingw/.match?(RUBY_PLATFORM)
+  end
+
+  def test_tty_amibuous_width
+    omit unless defined?(PTY)
+    ruby_file = Tempfile.create('rubyfile')
+    ruby_file.write(<<~RUBY)
+      require 'reline'
+      Thread.new { sleep 2; puts 'timeout'; exit }
+      p [Reline.ambiguous_width, gets.chomp]
+    RUBY
+    ruby_file.close
+    lib = File.expand_path('../../lib', __dir__)
+    cmd = [{ 'TERM' => 'xterm' }, 'ruby', '-I', lib, ruby_file.to_path]
+
+    # Calculate ambiguous width from cursor position
+    [1, 2].each do |ambiguous_width|
+      PTY.spawn(*cmd) do |r, w, pid|
+        loop { break if r.readpartial(1024).include?("\e[6n") }
+        w.puts "hello\e[10;#{ambiguous_width + 1}Rworld"
+        assert_include(r.gets, [ambiguous_width, 'helloworld'].inspect)
+        Process.waitpid pid
+      end
+    end
+
+    # Ambiguous width = 1 when cursor pos timed out
+    PTY.spawn(*cmd) do |r, w, pid|
+      loop { break if r.readpartial(1024).include?("\e[6n") }
+      w.puts "hello\e[10;2Sworld"
+      assert_include(r.gets, [1, "hello\e[10;2Sworld"].inspect)
+      Process.waitpid pid
+    end
   end
 
   def get_reline_encoding

--- a/test/reline/test_unicode.rb
+++ b/test/reline/test_unicode.rb
@@ -15,7 +15,7 @@ class Reline::Unicode::Test < Reline::TestCase
   end
 
   def test_ambiguous_width
-    assert_equal 2, Reline::Unicode.calculate_width('√', true)
+    assert_equal 1, Reline::Unicode.calculate_width('√', true)
   end
 
   def test_csi_regexp


### PR DESCRIPTION
Add timeout to cursor_pos. Some terminal emulator or test code using pty does not respond to cursor position query `\e[6n`. Delay caused by timeout is better than unresponsive.
Fixes #674 and https://github.com/ruby/irb/issues/296

Remove `Reline::IO::ANSI#cursor_pos` fallback to `STDOUT.pread`. Not available in some environment. We don't need inaccurate value.

Change fallback value of cursor_pos to `[0, 0]`. We don't need to return `[dummy_row=1, default_ambiguous_width=1]`

Always fallback east asian ambiguous width to 1.
Note that GNU Readline and zsh also uses ambiguous_width=1. The fallback value was inconsistent, some times 1 and sometimes 2.