### PR TITLE
Fix Reline crash with invalid encoding history

### DIFF
--- a/lib/reline/history.rb
+++ b/lib/reline/history.rb
@@ -19,7 +19,7 @@ class Reline::History < Array
 
   def []=(index, val)
     index = check_index(index)
-    super(index, String.new(val, encoding: Reline.encoding_system_needs))
+    super(index, Reline::Unicode.safe_encode(val, Reline.encoding_system_needs))
   end
 
   def concat(*val)
@@ -45,7 +45,7 @@ class Reline::History < Array
       end
     end
     super(*(val.map{ |v|
-      String.new(v, encoding: Reline.encoding_system_needs)
+      Reline::Unicode.safe_encode(v, Reline.encoding_system_needs)
     }))
   end
 
@@ -56,7 +56,7 @@ class Reline::History < Array
     if @config.history_size.positive?
       shift if size + 1 > @config.history_size
     end
-    super(String.new(val, encoding: Reline.encoding_system_needs))
+    super(Reline::Unicode.safe_encode(val, Reline.encoding_system_needs))
   end
 
   private def check_index(index)

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -1325,7 +1325,7 @@ class Reline::LineEditor
     save_old_buffer
     pre = @buffer_of_lines[@line_index].byteslice(0, @byte_pointer)
     post = @buffer_of_lines[@line_index].byteslice(@byte_pointer..)
-    lines = (pre + text.gsub(/\r\n?/, "\n") + post).split("\n", -1)
+    lines = (pre + Reline::Unicode.safe_encode(text, @encoding).gsub(/\r\n?/, "\n") + post).split("\n", -1)
     lines << '' if lines.empty?
     @buffer_of_lines[@line_index, 1] = lines
     @line_index += lines.size - 1

--- a/lib/reline/unicode.rb
+++ b/lib/reline/unicode.rb
@@ -54,6 +54,22 @@ class Reline::Unicode
     }.join
   end
 
+  def self.safe_encode(str, encoding)
+    # Reline only supports utf-8 convertible string.
+    converted = str.encode(encoding, invalid: :replace, undef: :replace)
+    return converted if str.encoding == Encoding::UTF_8 || converted.encoding == Encoding::UTF_8 || converted.ascii_only?
+
+    # This code is essentially doing the same thing as
+    # `str.encode(utf8, **replace_options).encode(encoding, **replace_options)`
+    # but also avoids unneccesary irreversible encoding conversion.
+    converted.gsub(/\X/) do |c|
+      c.encode(Encoding::UTF_8)
+      c
+    rescue Encoding::UndefinedConversionError
+      '?'
+    end
+  end
+
   require 'reline/unicode/east_asian_width'
 
   def self.get_mbchar_width(mbchar)

--- a/test/reline/test_history.rb
+++ b/test/reline/test_history.rb
@@ -266,6 +266,15 @@ class Reline::History::Test < Reline::TestCase
     assert_equal 5, history.size
   end
 
+  def test_history_encoding_conversion
+    history = history_new
+    text1 = String.new("a\u{65535}b\xFFc", encoding: Encoding::UTF_8)
+    text2 = String.new("d\xFFe", encoding: Encoding::Shift_JIS)
+    history.push(text1.dup, text2.dup)
+    expected = [text1, text2].map { |s| s.encode(Reline.encoding_system_needs, invalid: :replace, undef: :replace) }
+    assert_equal(expected, history.to_a)
+  end
+
   private
 
   def history_new(history_size: 10)

--- a/test/reline/test_unicode.rb
+++ b/test/reline/test_unicode.rb
@@ -89,4 +89,32 @@ class Reline::Unicode::Test < Reline::TestCase
     assert_equal ["\e[31mc\1ABC\2d\e[0mef", 2, 4], Reline::Unicode.take_mbchar_range("\e[31mabc\1ABC\2d\e[0mefghi", 2, 4)
     assert_equal ["\e[41m \e[42mい\e[43m ", 1, 4], Reline::Unicode.take_mbchar_range("\e[41mあ\e[42mい\e[43mう", 1, 4, padding: true)
   end
+
+  def test_encoding_conversion
+    texts = [
+      String.new("invalid\xFFutf8", encoding: 'utf-8'),
+      String.new("invalid\xFFsjis", encoding: 'sjis'),
+      "utf8#{33111.chr('sjis')}convertible",
+      "utf8#{33222.chr('sjis')}inconvertible",
+      "sjis->utf8->sjis#{60777.chr('sjis')}irreversible"
+    ]
+    utf8_texts = [
+      'invalid�utf8',
+      'invalid�sjis',
+      'utf8仝convertible',
+      'utf8�inconvertible',
+      'sjis->utf8->sjis劦irreversible'
+    ]
+    sjis_texts = [
+      'invalid?utf8',
+      'invalid?sjis',
+      "utf8#{33111.chr('sjis')}convertible",
+      'utf8?inconvertible',
+      "sjis->utf8->sjis#{60777.chr('sjis')}irreversible"
+    ]
+    assert_equal(utf8_texts, texts.map { |s| Reline::Unicode.safe_encode(s, 'utf-8') })
+    assert_equal(utf8_texts, texts.map { |s| Reline::Unicode.safe_encode(s, Encoding::UTF_8) })
+    assert_equal(sjis_texts, texts.map { |s| Reline::Unicode.safe_encode(s, 'sjis') })
+    assert_equal(sjis_texts, texts.map { |s| Reline::Unicode.safe_encode(s, Encoding::Windows_31J) })
+  end
 end


### PR DESCRIPTION
Fixes #615 and https://github.com/ruby/irb/issues/86

Points:
- Reline::LineEditor only supports utf8 convertible valid byte sequences.
- Not all characters are convertible to utf8.
- Some sjis to utf8 conversion are not reversible.
