### PR TITLE
Fix FD leaks

### DIFF
--- a/test/reline/test_reline.rb
+++ b/test/reline/test_reline.rb
@@ -454,6 +454,9 @@ class Reline::Test < Reline::TestCase
         loop { break if r.readpartial(1024).include?("\e[6n") }
         w.puts "hello\e[10;#{ambiguous_width + 1}Rworld"
         assert_include(r.gets, [ambiguous_width, 'helloworld'].inspect)
+      ensure
+        r.close
+        w.close
         Process.waitpid pid
       end
     end
@@ -463,6 +466,9 @@ class Reline::Test < Reline::TestCase
       loop { break if r.readpartial(1024).include?("\e[6n") }
       w.puts "hello\e[10;2Sworld"
       assert_include(r.gets, [1, "hello\e[10;2Sworld"].inspect)
+    ensure
+      r.close
+      w.close
       Process.waitpid pid
     end
   end


### PR DESCRIPTION
`PTY.spawn` with a block detaches the spawned process and leaves it running in background even after exiting the given block.  It is the responsibility of the caller to clean up the yielded IOs and PID.

https://github.com/ruby/ruby/actions/runs/11148759246/job/30986064044#step:13:950
```
Leaked file descriptor: Reline::Test#test_tty_amibuous_width: 9 : #<File:/dev/pts/0>
Leaked file descriptor: Reline::Test#test_tty_amibuous_width: 10 : #<File:/dev/pts/0>
Leaked file descriptor: Reline::Test#test_tty_amibuous_width: 11 : #<File:/dev/pts/1>
Leaked file descriptor: Reline::Test#test_tty_amibuous_width: 12 : #<File:/dev/pts/1>
Leaked file descriptor: Reline::Test#test_tty_amibuous_width: 13 : #<File:/dev/pts/2>
Leaked file descriptor: Reline::Test#test_tty_amibuous_width: 14 : #<File:/dev/pts/2>
```