### PR TITLE
Remove unused things from reline/unicode.rb

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -391,8 +391,8 @@ class Reline::LineEditor
         if (cached = cached_wraps[[prompt, line]])
           next cached
         end
-        *wrapped_prompts, code_line_prompt = split_by_width(prompt, width).first.compact
-        wrapped_lines = split_by_width(line, width, offset: calculate_width(code_line_prompt, true)).first.compact
+        *wrapped_prompts, code_line_prompt = split_by_width(prompt, width).first
+        wrapped_lines = split_by_width(line, width, offset: calculate_width(code_line_prompt, true)).first
         wrapped_prompts.map { |p| [p, ''] } + [[code_line_prompt, wrapped_lines.first]] + wrapped_lines.drop(1).map { |c| ['', c] }
       end
     end
@@ -440,7 +440,7 @@ class Reline::LineEditor
   def wrapped_cursor_position
     prompt_width = calculate_width(prompt_list[@line_index], true)
     line_before_cursor = whole_lines[@line_index].byteslice(0, @byte_pointer)
-    wrapped_line_before_cursor = split_by_width(' ' * prompt_width + line_before_cursor, screen_width).first.compact
+    wrapped_line_before_cursor = split_by_width(' ' * prompt_width + line_before_cursor, screen_width).first
     wrapped_cursor_y = wrapped_prompt_and_input_lines[0...@line_index].sum(&:size) + wrapped_line_before_cursor.size - 1
     wrapped_cursor_x = calculate_width(wrapped_line_before_cursor.last)
     [wrapped_cursor_x, wrapped_cursor_y]

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -300,8 +300,8 @@ class Reline::LineEditor
     end
   end
 
-  private def split_by_width(str, max_width, offset: 0)
-    Reline::Unicode.split_by_width(str, max_width, encoding, offset: offset)
+  private def split_line_by_width(str, max_width, offset: 0)
+    Reline::Unicode.split_line_by_width(str, max_width, encoding, offset: offset)
   end
 
   def current_byte_pointer_cursor
@@ -391,8 +391,8 @@ class Reline::LineEditor
         if (cached = cached_wraps[[prompt, line]])
           next cached
         end
-        *wrapped_prompts, code_line_prompt = split_by_width(prompt, width)
-        wrapped_lines = split_by_width(line, width, offset: calculate_width(code_line_prompt, true))
+        *wrapped_prompts, code_line_prompt = split_line_by_width(prompt, width)
+        wrapped_lines = split_line_by_width(line, width, offset: calculate_width(code_line_prompt, true))
         wrapped_prompts.map { |p| [p, ''] } + [[code_line_prompt, wrapped_lines.first]] + wrapped_lines.drop(1).map { |c| ['', c] }
       end
     end
@@ -440,7 +440,7 @@ class Reline::LineEditor
   def wrapped_cursor_position
     prompt_width = calculate_width(prompt_list[@line_index], true)
     line_before_cursor = whole_lines[@line_index].byteslice(0, @byte_pointer)
-    wrapped_line_before_cursor = split_by_width(' ' * prompt_width + line_before_cursor, screen_width)
+    wrapped_line_before_cursor = split_line_by_width(' ' * prompt_width + line_before_cursor, screen_width)
     wrapped_cursor_y = wrapped_prompt_and_input_lines[0...@line_index].sum(&:size) + wrapped_line_before_cursor.size - 1
     wrapped_cursor_x = calculate_width(wrapped_line_before_cursor.last)
     [wrapped_cursor_x, wrapped_cursor_y]
@@ -465,7 +465,7 @@ class Reline::LineEditor
     render_differential([], 0, 0)
     lines = @buffer_of_lines.size.times.map do |i|
       line = Reline::Unicode.strip_non_printing_start_end(prompt_list[i]) + modified_lines[i]
-      wrapped_lines = split_by_width(line, screen_width)
+      wrapped_lines = split_line_by_width(line, screen_width)
       wrapped_lines.last.empty? ? "#{line} " : line
     end
     @output.puts lines.map { |l| "#{l}\r\n" }.join

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -391,8 +391,8 @@ class Reline::LineEditor
         if (cached = cached_wraps[[prompt, line]])
           next cached
         end
-        *wrapped_prompts, code_line_prompt = split_by_width(prompt, width).first
-        wrapped_lines = split_by_width(line, width, offset: calculate_width(code_line_prompt, true)).first
+        *wrapped_prompts, code_line_prompt = split_by_width(prompt, width)
+        wrapped_lines = split_by_width(line, width, offset: calculate_width(code_line_prompt, true))
         wrapped_prompts.map { |p| [p, ''] } + [[code_line_prompt, wrapped_lines.first]] + wrapped_lines.drop(1).map { |c| ['', c] }
       end
     end
@@ -440,7 +440,7 @@ class Reline::LineEditor
   def wrapped_cursor_position
     prompt_width = calculate_width(prompt_list[@line_index], true)
     line_before_cursor = whole_lines[@line_index].byteslice(0, @byte_pointer)
-    wrapped_line_before_cursor = split_by_width(' ' * prompt_width + line_before_cursor, screen_width).first
+    wrapped_line_before_cursor = split_by_width(' ' * prompt_width + line_before_cursor, screen_width)
     wrapped_cursor_y = wrapped_prompt_and_input_lines[0...@line_index].sum(&:size) + wrapped_line_before_cursor.size - 1
     wrapped_cursor_x = calculate_width(wrapped_line_before_cursor.last)
     [wrapped_cursor_x, wrapped_cursor_y]
@@ -465,7 +465,7 @@ class Reline::LineEditor
     render_differential([], 0, 0)
     lines = @buffer_of_lines.size.times.map do |i|
       line = Reline::Unicode.strip_non_printing_start_end(prompt_list[i]) + modified_lines[i]
-      wrapped_lines, = split_by_width(line, screen_width)
+      wrapped_lines = split_by_width(line, screen_width)
       wrapped_lines.last.empty? ? "#{line} " : line
     end
     @output.puts lines.map { |l| "#{l}\r\n" }.join

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -1582,7 +1582,7 @@ class Reline::LineEditor
   alias_method :backward_char, :ed_prev_char
 
   private def vi_first_print(key)
-    @byte_pointer, = Reline::Unicode.vi_first_print(current_line)
+    @byte_pointer = Reline::Unicode.vi_first_print(current_line)
   end
 
   private def ed_move_to_beg(key)
@@ -1961,7 +1961,7 @@ class Reline::LineEditor
 
   private def em_next_word(key)
     if current_line.bytesize > @byte_pointer
-      byte_size, _ = Reline::Unicode.em_forward_word(current_line, @byte_pointer)
+      byte_size = Reline::Unicode.em_forward_word(current_line, @byte_pointer)
       @byte_pointer += byte_size
     end
   end
@@ -1969,7 +1969,7 @@ class Reline::LineEditor
 
   private def ed_prev_word(key)
     if @byte_pointer > 0
-      byte_size, _ = Reline::Unicode.em_backward_word(current_line, @byte_pointer)
+      byte_size = Reline::Unicode.em_backward_word(current_line, @byte_pointer)
       @byte_pointer -= byte_size
     end
   end
@@ -1977,7 +1977,7 @@ class Reline::LineEditor
 
   private def em_delete_next_word(key)
     if current_line.bytesize > @byte_pointer
-      byte_size, _ = Reline::Unicode.em_forward_word(current_line, @byte_pointer)
+      byte_size = Reline::Unicode.em_forward_word(current_line, @byte_pointer)
       line, word = byteslice!(current_line, @byte_pointer, byte_size)
       set_current_line(line)
       @kill_ring.append(word)
@@ -1987,7 +1987,7 @@ class Reline::LineEditor
 
   private def ed_delete_prev_word(key)
     if @byte_pointer > 0
-      byte_size, _ = Reline::Unicode.em_backward_word(current_line, @byte_pointer)
+      byte_size = Reline::Unicode.em_backward_word(current_line, @byte_pointer)
       line, word = byteslice!(current_line, @byte_pointer - byte_size, byte_size)
       set_current_line(line, @byte_pointer - byte_size)
       @kill_ring.append(word, true)
@@ -2027,7 +2027,7 @@ class Reline::LineEditor
 
   private def em_capitol_case(key)
     if current_line.bytesize > @byte_pointer
-      byte_size, _, new_str = Reline::Unicode.em_forward_word_with_capitalization(current_line, @byte_pointer)
+      byte_size, new_str = Reline::Unicode.em_forward_word_with_capitalization(current_line, @byte_pointer)
       before = current_line.byteslice(0, @byte_pointer)
       after = current_line.byteslice((@byte_pointer + byte_size)..-1)
       set_current_line(before + new_str + after, @byte_pointer + new_str.bytesize)
@@ -2037,7 +2037,7 @@ class Reline::LineEditor
 
   private def em_lower_case(key)
     if current_line.bytesize > @byte_pointer
-      byte_size, = Reline::Unicode.em_forward_word(current_line, @byte_pointer)
+      byte_size = Reline::Unicode.em_forward_word(current_line, @byte_pointer)
       part = current_line.byteslice(@byte_pointer, byte_size).grapheme_clusters.map { |mbchar|
         mbchar =~ /[A-Z]/ ? mbchar.downcase : mbchar
       }.join
@@ -2050,7 +2050,7 @@ class Reline::LineEditor
 
   private def em_upper_case(key)
     if current_line.bytesize > @byte_pointer
-      byte_size, = Reline::Unicode.em_forward_word(current_line, @byte_pointer)
+      byte_size = Reline::Unicode.em_forward_word(current_line, @byte_pointer)
       part = current_line.byteslice(@byte_pointer, byte_size).grapheme_clusters.map { |mbchar|
         mbchar =~ /[a-z]/ ? mbchar.upcase : mbchar
       }.join
@@ -2063,7 +2063,7 @@ class Reline::LineEditor
 
   private def em_kill_region(key)
     if @byte_pointer > 0
-      byte_size, _ = Reline::Unicode.em_big_backward_word(current_line, @byte_pointer)
+      byte_size = Reline::Unicode.em_big_backward_word(current_line, @byte_pointer)
       line, deleted = byteslice!(current_line, @byte_pointer - byte_size, byte_size)
       set_current_line(line, @byte_pointer - byte_size)
       @kill_ring.append(deleted, true)
@@ -2094,7 +2094,7 @@ class Reline::LineEditor
 
   private def vi_next_word(key, arg: 1)
     if current_line.bytesize > @byte_pointer
-      byte_size, _ = Reline::Unicode.vi_forward_word(current_line, @byte_pointer, @drop_terminate_spaces)
+      byte_size = Reline::Unicode.vi_forward_word(current_line, @byte_pointer, @drop_terminate_spaces)
       @byte_pointer += byte_size
     end
     arg -= 1
@@ -2103,7 +2103,7 @@ class Reline::LineEditor
 
   private def vi_prev_word(key, arg: 1)
     if @byte_pointer > 0
-      byte_size, _ = Reline::Unicode.vi_backward_word(current_line, @byte_pointer)
+      byte_size = Reline::Unicode.vi_backward_word(current_line, @byte_pointer)
       @byte_pointer -= byte_size
     end
     arg -= 1
@@ -2112,7 +2112,7 @@ class Reline::LineEditor
 
   private def vi_end_word(key, arg: 1, inclusive: false)
     if current_line.bytesize > @byte_pointer
-      byte_size, _ = Reline::Unicode.vi_forward_end_word(current_line, @byte_pointer)
+      byte_size = Reline::Unicode.vi_forward_end_word(current_line, @byte_pointer)
       @byte_pointer += byte_size
     end
     arg -= 1
@@ -2127,7 +2127,7 @@ class Reline::LineEditor
 
   private def vi_next_big_word(key, arg: 1)
     if current_line.bytesize > @byte_pointer
-      byte_size, _ = Reline::Unicode.vi_big_forward_word(current_line, @byte_pointer)
+      byte_size = Reline::Unicode.vi_big_forward_word(current_line, @byte_pointer)
       @byte_pointer += byte_size
     end
     arg -= 1
@@ -2136,7 +2136,7 @@ class Reline::LineEditor
 
   private def vi_prev_big_word(key, arg: 1)
     if @byte_pointer > 0
-      byte_size, _ = Reline::Unicode.vi_big_backward_word(current_line, @byte_pointer)
+      byte_size = Reline::Unicode.vi_big_backward_word(current_line, @byte_pointer)
       @byte_pointer -= byte_size
     end
     arg -= 1
@@ -2145,7 +2145,7 @@ class Reline::LineEditor
 
   private def vi_end_big_word(key, arg: 1, inclusive: false)
     if current_line.bytesize > @byte_pointer
-      byte_size, _ = Reline::Unicode.vi_big_forward_end_word(current_line, @byte_pointer)
+      byte_size = Reline::Unicode.vi_big_forward_end_word(current_line, @byte_pointer)
       @byte_pointer += byte_size
     end
     arg -= 1

--- a/lib/reline/unicode.rb
+++ b/lib/reline/unicode.rb
@@ -121,7 +121,13 @@ class Reline::Unicode
     end
   end
 
-  def self.split_by_width(str, max_width, encoding = str.encoding, offset: 0)
+  # This method is used by IRB
+  def self.split_by_width(str, max_width)
+    lines = split_line_by_width(str, max_width)
+    [lines, lines.size]
+  end
+
+  def self.split_line_by_width(str, max_width, encoding = str.encoding, offset: 0)
     lines = [String.new(encoding: encoding)]
     width = offset
     rest = str.encode(Encoding::UTF_8)

--- a/lib/reline/unicode.rb
+++ b/lib/reline/unicode.rb
@@ -259,27 +259,23 @@ class Reline::Unicode
   end
 
   def self.em_forward_word(line, byte_pointer)
-    width = 0
     byte_size = 0
     while line.bytesize > (byte_pointer + byte_size)
       size = get_next_mbchar_size(line, byte_pointer + byte_size)
       mbchar = line.byteslice(byte_pointer + byte_size, size)
       break if mbchar.encode(Encoding::UTF_8) =~ /\p{Word}/
-      width += get_mbchar_width(mbchar)
       byte_size += size
     end
     while line.bytesize > (byte_pointer + byte_size)
       size = get_next_mbchar_size(line, byte_pointer + byte_size)
       mbchar = line.byteslice(byte_pointer + byte_size, size)
       break if mbchar.encode(Encoding::UTF_8) =~ /\P{Word}/
-      width += get_mbchar_width(mbchar)
       byte_size += size
     end
-    [byte_size, width]
+    byte_size
   end
 
   def self.em_forward_word_with_capitalization(line, byte_pointer)
-    width = 0
     byte_size = 0
     new_str = String.new
     while line.bytesize > (byte_pointer + byte_size)
@@ -287,7 +283,6 @@ class Reline::Unicode
       mbchar = line.byteslice(byte_pointer + byte_size, size)
       break if mbchar.encode(Encoding::UTF_8) =~ /\p{Word}/
       new_str += mbchar
-      width += get_mbchar_width(mbchar)
       byte_size += size
     end
     first = true
@@ -301,50 +296,43 @@ class Reline::Unicode
       else
         new_str += mbchar.downcase
       end
-      width += get_mbchar_width(mbchar)
       byte_size += size
     end
-    [byte_size, width, new_str]
+    [byte_size, new_str]
   end
 
   def self.em_backward_word(line, byte_pointer)
-    width = 0
     byte_size = 0
     while 0 < (byte_pointer - byte_size)
       size = get_prev_mbchar_size(line, byte_pointer - byte_size)
       mbchar = line.byteslice(byte_pointer - byte_size - size, size)
       break if mbchar.encode(Encoding::UTF_8) =~ /\p{Word}/
-      width += get_mbchar_width(mbchar)
       byte_size += size
     end
     while 0 < (byte_pointer - byte_size)
       size = get_prev_mbchar_size(line, byte_pointer - byte_size)
       mbchar = line.byteslice(byte_pointer - byte_size - size, size)
       break if mbchar.encode(Encoding::UTF_8) =~ /\P{Word}/
-      width += get_mbchar_width(mbchar)
       byte_size += size
     end
-    [byte_size, width]
+    byte_size
   end
 
   def self.em_big_backward_word(line, byte_pointer)
-    width = 0
     byte_size = 0
     while 0 < (byte_pointer - byte_size)
       size = get_prev_mbchar_size(line, byte_pointer - byte_size)
       mbchar = line.byteslice(byte_pointer - byte_size - size, size)
       break if mbchar =~ /\S/
-      width += get_mbchar_width(mbchar)
       byte_size += size
     end
     while 0 < (byte_pointer - byte_size)
       size = get_prev_mbchar_size(line, byte_pointer - byte_size)
       mbchar = line.byteslice(byte_pointer - byte_size - size, size)
       break if mbchar =~ /\s/
-      width += get_mbchar_width(mbchar)
       byte_size += size
     end
-    [byte_size, width]
+    byte_size
   end
 
   def self.ed_transpose_words(line, byte_pointer)
@@ -449,73 +437,61 @@ class Reline::Unicode
   end
 
   def self.vi_big_forward_word(line, byte_pointer)
-    width = 0
     byte_size = 0
     while (line.bytesize - 1) > (byte_pointer + byte_size)
       size = get_next_mbchar_size(line, byte_pointer + byte_size)
       mbchar = line.byteslice(byte_pointer + byte_size, size)
       break if mbchar =~ /\s/
-      width += get_mbchar_width(mbchar)
       byte_size += size
     end
     while (line.bytesize - 1) > (byte_pointer + byte_size)
       size = get_next_mbchar_size(line, byte_pointer + byte_size)
       mbchar = line.byteslice(byte_pointer + byte_size, size)
       break if mbchar =~ /\S/
-      width += get_mbchar_width(mbchar)
       byte_size += size
     end
-    [byte_size, width]
+    byte_size
   end
 
   def self.vi_big_forward_end_word(line, byte_pointer)
     if (line.bytesize - 1) > byte_pointer
       size = get_next_mbchar_size(line, byte_pointer)
-      mbchar = line.byteslice(byte_pointer, size)
-      width = get_mbchar_width(mbchar)
       byte_size = size
     else
-      return [0, 0]
+      return 0
     end
     while (line.bytesize - 1) > (byte_pointer + byte_size)
       size = get_next_mbchar_size(line, byte_pointer + byte_size)
       mbchar = line.byteslice(byte_pointer + byte_size, size)
       break if mbchar =~ /\S/
-      width += get_mbchar_width(mbchar)
       byte_size += size
     end
-    prev_width = width
     prev_byte_size = byte_size
     while line.bytesize > (byte_pointer + byte_size)
       size = get_next_mbchar_size(line, byte_pointer + byte_size)
       mbchar = line.byteslice(byte_pointer + byte_size, size)
       break if mbchar =~ /\s/
-      prev_width = width
       prev_byte_size = byte_size
-      width += get_mbchar_width(mbchar)
       byte_size += size
     end
-    [prev_byte_size, prev_width]
+    prev_byte_size
   end
 
   def self.vi_big_backward_word(line, byte_pointer)
-    width = 0
     byte_size = 0
     while 0 < (byte_pointer - byte_size)
       size = get_prev_mbchar_size(line, byte_pointer - byte_size)
       mbchar = line.byteslice(byte_pointer - byte_size - size, size)
       break if mbchar =~ /\S/
-      width += get_mbchar_width(mbchar)
       byte_size += size
     end
     while 0 < (byte_pointer - byte_size)
       size = get_prev_mbchar_size(line, byte_pointer - byte_size)
       mbchar = line.byteslice(byte_pointer - byte_size - size, size)
       break if mbchar =~ /\s/
-      width += get_mbchar_width(mbchar)
       byte_size += size
     end
-    [byte_size, width]
+    byte_size
   end
 
   def self.vi_forward_word(line, byte_pointer, drop_terminate_spaces = false)
@@ -529,10 +505,9 @@ class Reline::Unicode
       else
         started_by = :non_word_printable
       end
-      width = get_mbchar_width(mbchar)
       byte_size = size
     else
-      return [0, 0]
+      return 0
     end
     while line.bytesize > (byte_pointer + byte_size)
       size = get_next_mbchar_size(line, byte_pointer + byte_size)
@@ -545,18 +520,16 @@ class Reline::Unicode
       when :non_word_printable
         break if mbchar =~ /\w|\s/
       end
-      width += get_mbchar_width(mbchar)
       byte_size += size
     end
-    return [byte_size, width] if drop_terminate_spaces
+    return byte_size if drop_terminate_spaces
     while line.bytesize > (byte_pointer + byte_size)
       size = get_next_mbchar_size(line, byte_pointer + byte_size)
       mbchar = line.byteslice(byte_pointer + byte_size, size)
       break if mbchar =~ /\S/
-      width += get_mbchar_width(mbchar)
       byte_size += size
     end
-    [byte_size, width]
+    byte_size
   end
 
   def self.vi_forward_end_word(line, byte_pointer)
@@ -570,10 +543,9 @@ class Reline::Unicode
       else
         started_by = :non_word_printable
       end
-      width = get_mbchar_width(mbchar)
       byte_size = size
     else
-      return [0, 0]
+      return 0
     end
     if (line.bytesize - 1) > (byte_pointer + byte_size)
       size = get_next_mbchar_size(line, byte_pointer + byte_size)
@@ -585,13 +557,11 @@ class Reline::Unicode
       else
         second = :non_word_printable
       end
-      second_width = get_mbchar_width(mbchar)
       second_byte_size = size
     else
-      return [byte_size, width]
+      return byte_size
     end
     if second == :space
-      width += second_width
       byte_size += second_byte_size
       while (line.bytesize - 1) > (byte_pointer + byte_size)
         size = get_next_mbchar_size(line, byte_pointer + byte_size)
@@ -604,7 +574,6 @@ class Reline::Unicode
           end
           break
         end
-        width += get_mbchar_width(mbchar)
         byte_size += size
       end
     else
@@ -612,12 +581,10 @@ class Reline::Unicode
       when [:word, :non_word_printable], [:non_word_printable, :word]
         started_by = second
       else
-        width += second_width
         byte_size += second_byte_size
         started_by = second
       end
     end
-    prev_width = width
     prev_byte_size = byte_size
     while line.bytesize > (byte_pointer + byte_size)
       size = get_next_mbchar_size(line, byte_pointer + byte_size)
@@ -628,16 +595,13 @@ class Reline::Unicode
       when :non_word_printable
         break if mbchar =~ /[\w\s]/
       end
-      prev_width = width
       prev_byte_size = byte_size
-      width += get_mbchar_width(mbchar)
       byte_size += size
     end
-    [prev_byte_size, prev_width]
+    prev_byte_size
   end
 
   def self.vi_backward_word(line, byte_pointer)
-    width = 0
     byte_size = 0
     while 0 < (byte_pointer - byte_size)
       size = get_prev_mbchar_size(line, byte_pointer - byte_size)
@@ -650,7 +614,6 @@ class Reline::Unicode
         end
         break
       end
-      width += get_mbchar_width(mbchar)
       byte_size += size
     end
     while 0 < (byte_pointer - byte_size)
@@ -662,14 +625,12 @@ class Reline::Unicode
       when :non_word_printable
         break if mbchar =~ /[\w\s]/
       end
-      width += get_mbchar_width(mbchar)
       byte_size += size
     end
-    [byte_size, width]
+    byte_size
   end
 
   def self.vi_first_print(line)
-    width = 0
     byte_size = 0
     while (line.bytesize - 1) > byte_size
       size = get_next_mbchar_size(line, byte_size)
@@ -677,9 +638,8 @@ class Reline::Unicode
       if mbchar =~ /\S/
         break
       end
-      width += get_mbchar_width(mbchar)
       byte_size += size
     end
-    [byte_size, width]
+    byte_size
   end
 end

--- a/lib/reline/unicode.rb
+++ b/lib/reline/unicode.rb
@@ -151,7 +151,6 @@ class Reline::Unicode
           mbchar_width = get_mbchar_width(gc)
           if (width += mbchar_width) > max_width
             width = mbchar_width
-            lines << nil
             lines << seq.dup
             height += 1
           end
@@ -161,7 +160,6 @@ class Reline::Unicode
     end
     # The cursor moves to next line in first
     if width == max_width
-      lines << nil
       lines << String.new(encoding: encoding)
       height += 1
     end

--- a/lib/reline/unicode.rb
+++ b/lib/reline/unicode.rb
@@ -123,7 +123,6 @@ class Reline::Unicode
 
   def self.split_by_width(str, max_width, encoding = str.encoding, offset: 0)
     lines = [String.new(encoding: encoding)]
-    height = 1
     width = offset
     rest = str.encode(Encoding::UTF_8)
     in_zero_width = false
@@ -152,7 +151,6 @@ class Reline::Unicode
           if (width += mbchar_width) > max_width
             width = mbchar_width
             lines << seq.dup
-            height += 1
           end
         end
         lines.last << gc
@@ -161,9 +159,8 @@ class Reline::Unicode
     # The cursor moves to next line in first
     if width == max_width
       lines << String.new(encoding: encoding)
-      height += 1
     end
-    [lines, height]
+    lines
   end
 
   def self.strip_non_printing_start_end(prompt)

--- a/test/reline/test_unicode.rb
+++ b/test/reline/test_unicode.rb
@@ -30,17 +30,17 @@ class Reline::Unicode::Test < Reline::TestCase
   end
 
   def test_split_by_width
-    assert_equal [['abc', 'de'], 2], Reline::Unicode.split_by_width('abcde', 3)
-    assert_equal [['abc', 'def', ''], 3], Reline::Unicode.split_by_width('abcdef', 3)
-    assert_equal [['ab', 'あd', 'ef'], 3], Reline::Unicode.split_by_width('abあdef', 3)
-    assert_equal [['ab[zero]c', 'def', ''], 3], Reline::Unicode.split_by_width("ab\1[zero]\2cdef", 3)
-    assert_equal [["\e[31mabc", "\e[31md\e[42mef", "\e[31m\e[42mg"], 3], Reline::Unicode.split_by_width("\e[31mabcd\e[42mefg", 3)
-    assert_equal [["ab\e]0;1\ac", "\e]0;1\ad"], 2], Reline::Unicode.split_by_width("ab\e]0;1\acd", 3)
+    assert_equal ['abc', 'de'], Reline::Unicode.split_by_width('abcde', 3)
+    assert_equal ['abc', 'def', ''], Reline::Unicode.split_by_width('abcdef', 3)
+    assert_equal ['ab', 'あd', 'ef'], Reline::Unicode.split_by_width('abあdef', 3)
+    assert_equal ['ab[zero]c', 'def', ''], Reline::Unicode.split_by_width("ab\1[zero]\2cdef", 3)
+    assert_equal ["\e[31mabc", "\e[31md\e[42mef", "\e[31m\e[42mg"], Reline::Unicode.split_by_width("\e[31mabcd\e[42mefg", 3)
+    assert_equal ["ab\e]0;1\ac", "\e]0;1\ad"], Reline::Unicode.split_by_width("ab\e]0;1\acd", 3)
   end
 
   def test_split_by_width_csi_reset_sgr_optimization
-    assert_equal [["\e[1ma\e[mb\e[2mc", "\e[2md\e[0me\e[3mf", "\e[3mg"], 3], Reline::Unicode.split_by_width("\e[1ma\e[mb\e[2mcd\e[0me\e[3mfg", 3)
-    assert_equal [["\e[1ma\e[mzero\e[0m\e[2mb", "\e[1m\e[2mc"], 2], Reline::Unicode.split_by_width("\e[1ma\1\e[mzero\e[0m\2\e[2mbc", 2)
+    assert_equal ["\e[1ma\e[mb\e[2mc", "\e[2md\e[0me\e[3mf", "\e[3mg"], Reline::Unicode.split_by_width("\e[1ma\e[mb\e[2mcd\e[0me\e[3mfg", 3)
+    assert_equal ["\e[1ma\e[mzero\e[0m\e[2mb", "\e[1m\e[2mc"], Reline::Unicode.split_by_width("\e[1ma\1\e[mzero\e[0m\2\e[2mbc", 2)
   end
 
   def test_take_range
@@ -56,9 +56,9 @@ class Reline::Unicode::Test < Reline::TestCase
   def test_nonprinting_start_end
     # \1 and \2 should be removed
     assert_equal 'ab[zero]cd', Reline::Unicode.take_range("ab\1[zero]\2cdef", 0, 4)
-    assert_equal [['ab[zero]cd', 'ef'], 2], Reline::Unicode.split_by_width("ab\1[zero]\2cdef", 4)
+    assert_equal ['ab[zero]cd', 'ef'], Reline::Unicode.split_by_width("ab\1[zero]\2cdef", 4)
     # CSI between \1 and \2 does not need to be applied to the sebsequent line
-    assert_equal [["\e[31mab\e[32mcd", "\e[31mef"], 2], Reline::Unicode.split_by_width("\e[31mab\1\e[32m\2cdef", 4)
+    assert_equal ["\e[31mab\e[32mcd", "\e[31mef"], Reline::Unicode.split_by_width("\e[31mab\1\e[32m\2cdef", 4)
   end
 
   def test_strip_non_printing_start_end

--- a/test/reline/test_unicode.rb
+++ b/test/reline/test_unicode.rb
@@ -30,17 +30,22 @@ class Reline::Unicode::Test < Reline::TestCase
   end
 
   def test_split_by_width
-    assert_equal ['abc', 'de'], Reline::Unicode.split_by_width('abcde', 3)
-    assert_equal ['abc', 'def', ''], Reline::Unicode.split_by_width('abcdef', 3)
-    assert_equal ['ab', 'あd', 'ef'], Reline::Unicode.split_by_width('abあdef', 3)
-    assert_equal ['ab[zero]c', 'def', ''], Reline::Unicode.split_by_width("ab\1[zero]\2cdef", 3)
-    assert_equal ["\e[31mabc", "\e[31md\e[42mef", "\e[31m\e[42mg"], Reline::Unicode.split_by_width("\e[31mabcd\e[42mefg", 3)
-    assert_equal ["ab\e]0;1\ac", "\e]0;1\ad"], Reline::Unicode.split_by_width("ab\e]0;1\acd", 3)
+    # IRB uses this method.
+    assert_equal [['abc', 'de'], 2], Reline::Unicode.split_by_width('abcde', 3)
   end
 
-  def test_split_by_width_csi_reset_sgr_optimization
-    assert_equal ["\e[1ma\e[mb\e[2mc", "\e[2md\e[0me\e[3mf", "\e[3mg"], Reline::Unicode.split_by_width("\e[1ma\e[mb\e[2mcd\e[0me\e[3mfg", 3)
-    assert_equal ["\e[1ma\e[mzero\e[0m\e[2mb", "\e[1m\e[2mc"], Reline::Unicode.split_by_width("\e[1ma\1\e[mzero\e[0m\2\e[2mbc", 2)
+  def test_split_line_by_width
+    assert_equal ['abc', 'de'], Reline::Unicode.split_line_by_width('abcde', 3)
+    assert_equal ['abc', 'def', ''], Reline::Unicode.split_line_by_width('abcdef', 3)
+    assert_equal ['ab', 'あd', 'ef'], Reline::Unicode.split_line_by_width('abあdef', 3)
+    assert_equal ['ab[zero]c', 'def', ''], Reline::Unicode.split_line_by_width("ab\1[zero]\2cdef", 3)
+    assert_equal ["\e[31mabc", "\e[31md\e[42mef", "\e[31m\e[42mg"], Reline::Unicode.split_line_by_width("\e[31mabcd\e[42mefg", 3)
+    assert_equal ["ab\e]0;1\ac", "\e]0;1\ad"], Reline::Unicode.split_line_by_width("ab\e]0;1\acd", 3)
+  end
+
+  def test_split_line_by_width_csi_reset_sgr_optimization
+    assert_equal ["\e[1ma\e[mb\e[2mc", "\e[2md\e[0me\e[3mf", "\e[3mg"], Reline::Unicode.split_line_by_width("\e[1ma\e[mb\e[2mcd\e[0me\e[3mfg", 3)
+    assert_equal ["\e[1ma\e[mzero\e[0m\e[2mb", "\e[1m\e[2mc"], Reline::Unicode.split_line_by_width("\e[1ma\1\e[mzero\e[0m\2\e[2mbc", 2)
   end
 
   def test_take_range
@@ -56,9 +61,9 @@ class Reline::Unicode::Test < Reline::TestCase
   def test_nonprinting_start_end
     # \1 and \2 should be removed
     assert_equal 'ab[zero]cd', Reline::Unicode.take_range("ab\1[zero]\2cdef", 0, 4)
-    assert_equal ['ab[zero]cd', 'ef'], Reline::Unicode.split_by_width("ab\1[zero]\2cdef", 4)
+    assert_equal ['ab[zero]cd', 'ef'], Reline::Unicode.split_line_by_width("ab\1[zero]\2cdef", 4)
     # CSI between \1 and \2 does not need to be applied to the sebsequent line
-    assert_equal ["\e[31mab\e[32mcd", "\e[31mef"], Reline::Unicode.split_by_width("\e[31mab\1\e[32m\2cdef", 4)
+    assert_equal ["\e[31mab\e[32mcd", "\e[31mef"], Reline::Unicode.split_line_by_width("\e[31mab\1\e[32m\2cdef", 4)
   end
 
   def test_strip_non_printing_start_end

--- a/test/reline/test_unicode.rb
+++ b/test/reline/test_unicode.rb
@@ -30,17 +30,17 @@ class Reline::Unicode::Test < Reline::TestCase
   end
 
   def test_split_by_width
-    assert_equal [['abc', nil, 'de'], 2], Reline::Unicode.split_by_width('abcde', 3)
-    assert_equal [['abc', nil, 'def', nil, ''], 3], Reline::Unicode.split_by_width('abcdef', 3)
-    assert_equal [['ab', nil, 'あd', nil, 'ef'], 3], Reline::Unicode.split_by_width('abあdef', 3)
-    assert_equal [['ab[zero]c', nil, 'def', nil, ''], 3], Reline::Unicode.split_by_width("ab\1[zero]\2cdef", 3)
-    assert_equal [["\e[31mabc", nil, "\e[31md\e[42mef", nil, "\e[31m\e[42mg"], 3], Reline::Unicode.split_by_width("\e[31mabcd\e[42mefg", 3)
-    assert_equal [["ab\e]0;1\ac", nil, "\e]0;1\ad"], 2], Reline::Unicode.split_by_width("ab\e]0;1\acd", 3)
+    assert_equal [['abc', 'de'], 2], Reline::Unicode.split_by_width('abcde', 3)
+    assert_equal [['abc', 'def', ''], 3], Reline::Unicode.split_by_width('abcdef', 3)
+    assert_equal [['ab', 'あd', 'ef'], 3], Reline::Unicode.split_by_width('abあdef', 3)
+    assert_equal [['ab[zero]c', 'def', ''], 3], Reline::Unicode.split_by_width("ab\1[zero]\2cdef", 3)
+    assert_equal [["\e[31mabc", "\e[31md\e[42mef", "\e[31m\e[42mg"], 3], Reline::Unicode.split_by_width("\e[31mabcd\e[42mefg", 3)
+    assert_equal [["ab\e]0;1\ac", "\e]0;1\ad"], 2], Reline::Unicode.split_by_width("ab\e]0;1\acd", 3)
   end
 
   def test_split_by_width_csi_reset_sgr_optimization
-    assert_equal [["\e[1ma\e[mb\e[2mc", nil, "\e[2md\e[0me\e[3mf", nil, "\e[3mg"], 3], Reline::Unicode.split_by_width("\e[1ma\e[mb\e[2mcd\e[0me\e[3mfg", 3)
-    assert_equal [["\e[1ma\e[mzero\e[0m\e[2mb", nil, "\e[1m\e[2mc"], 2], Reline::Unicode.split_by_width("\e[1ma\1\e[mzero\e[0m\2\e[2mbc", 2)
+    assert_equal [["\e[1ma\e[mb\e[2mc", "\e[2md\e[0me\e[3mf", "\e[3mg"], 3], Reline::Unicode.split_by_width("\e[1ma\e[mb\e[2mcd\e[0me\e[3mfg", 3)
+    assert_equal [["\e[1ma\e[mzero\e[0m\e[2mb", "\e[1m\e[2mc"], 2], Reline::Unicode.split_by_width("\e[1ma\1\e[mzero\e[0m\2\e[2mbc", 2)
   end
 
   def test_take_range
@@ -56,9 +56,9 @@ class Reline::Unicode::Test < Reline::TestCase
   def test_nonprinting_start_end
     # \1 and \2 should be removed
     assert_equal 'ab[zero]cd', Reline::Unicode.take_range("ab\1[zero]\2cdef", 0, 4)
-    assert_equal [['ab[zero]cd', nil, 'ef'], 2], Reline::Unicode.split_by_width("ab\1[zero]\2cdef", 4)
+    assert_equal [['ab[zero]cd', 'ef'], 2], Reline::Unicode.split_by_width("ab\1[zero]\2cdef", 4)
     # CSI between \1 and \2 does not need to be applied to the sebsequent line
-    assert_equal [["\e[31mab\e[32mcd", nil, "\e[31mef"], 2], Reline::Unicode.split_by_width("\e[31mab\1\e[32m\2cdef", 4)
+    assert_equal [["\e[31mab\e[32mcd", "\e[31mef"], 2], Reline::Unicode.split_by_width("\e[31mab\1\e[32m\2cdef", 4)
   end
 
   def test_strip_non_printing_start_end


### PR DESCRIPTION
Remove unused value from Reline::Unicode method's return value

### split_by_width
```ruby
# Before: returns [splitted_lines_including_nil_at_odd_index, height]
Reline::Unicode.split_by_width('0123456789', 3)
#=> [["012", nil, "345", nil, "678", nil, "9"], 4]

# After: height is unused. nil is also unused, always removed with Array#compact
Reline::Unicode.split_line_by_width('0123456789', 3)
#=> ["012", "345", "678", "9"]
```

### split_line_by_width
IRB uses legacy split_by_width. We need to rename it for refactored implementation and add a legacy split_by_width back.
```ruby
# lib/irb.rb
lines, _ = Reline::Unicode.split_by_width
str = "%s..." % lines.first
```

```ruby
# IRB only uses first string in the array. Inserting nil to the array is not necessary.
Reline::Unicode.split_by_width('0123456789', 3)
#=> [["012", "345", "678", "9"], 4]
```

### em_ vi_ methods
`Reline::Unicode.em_forward_word` `Reline::Unicode.vi_big_forward_word` and more methods returned `[byte_size, visible_width]` but `visible_width` part is unused.

These method didn't had tests. Tests are added to ensure this change didn't break anything.
