### PR TITLE
Support continuous tab completion

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -846,7 +846,11 @@ class Reline::LineEditor
     when CompletionState::NORMAL
       @completion_state = CompletionState::COMPLETION
     when CompletionState::PERFECT_MATCH
-      @dig_perfect_match_proc&.(@perfect_matched)
+      if @dig_perfect_match_proc
+        @dig_perfect_match_proc.(@perfect_matched)
+      else
+        @completion_state = CompletionState::COMPLETION
+      end
     end
     if just_show_list
       is_menu = true

--- a/test/reline/test_key_actor_emacs.rb
+++ b/test/reline/test_key_actor_emacs.rb
@@ -920,6 +920,29 @@ class Reline::KeyActor::EmacsTest < Reline::TestCase
     assert_equal('foo_bar', matched)
   end
 
+  def test_continuous_completion_with_perfect_match
+    @line_editor.completion_proc = proc { |word|
+      word == 'f' ? ['foo'] : %w[foobar foobaz]
+    }
+    input_keys('f')
+    input_keys("\C-i", false)
+    assert_line_around_cursor('foo', '')
+    input_keys("\C-i", false)
+    assert_line_around_cursor('fooba', '')
+  end
+
+  def test_continuous_completion_disabled_with_perfect_match
+    @line_editor.completion_proc = proc { |word|
+      word == 'f' ? ['foo'] : %w[foobar foobaz]
+    }
+    @line_editor.dig_perfect_match_proc = proc {}
+    input_keys('f')
+    input_keys("\C-i", false)
+    assert_line_around_cursor('foo', '')
+    input_keys("\C-i", false)
+    assert_line_around_cursor('foo', '')
+  end
+
   def test_completion_with_completion_ignore_case
     @line_editor.completion_proc = proc { |word|
       %w{


### PR DESCRIPTION
Fixes #760
Continuous tab completion is possible in GNU Readline.
If dig_perfect_match_proc is set, continuous tab completion will be disabled.

`dig_perfect_match_proc` is used in IRB to show document when pressing TAB after perfect match completion.
In such case, setting dig_perfect_match_proc is a hook intended to disable continuous completion and do something else.