### PR TITLE
Add `fiddle` runtime dependency

### DIFF
--- a/reline.gemspec
+++ b/reline.gemspec
@@ -26,5 +26,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = Gem::Requirement.new('>= 2.6')
 
+  spec.add_dependency 'fiddle', '~> 1.1'
   spec.add_dependency 'io-console', '~> 0.5'
 end


### PR DESCRIPTION
Resolve Ruby warning:
```
/home/alex/.rbenv/versions/3.3.5/lib/ruby/3.3.0/reline.rb:9: warning: fiddle was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
```

(I've tried to add `t.warning = true` for `Rake::TestTask`, but it didn't help)