### PR TITLE
Use IO's encoding instead of Encoding.default_external

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -487,7 +487,7 @@ module Reline
     @core ||= Core.new { |core|
       core.config = Reline::Config.new
       core.key_stroke = Reline::KeyStroke.new(core.config)
-      core.line_editor = Reline::LineEditor.new(core.config, core.encoding)
+      core.line_editor = Reline::LineEditor.new(core.config)
 
       core.basic_word_break_characters = " \t\n`><=;|&{("
       core.completer_word_break_characters = " \t\n`><=;|&{("

--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -308,7 +308,7 @@ module Reline
       otio = io_gate.prep
 
       may_req_ambiguous_char_width
-      line_editor.reset(prompt, encoding: encoding)
+      line_editor.reset(prompt)
       if multiline
         line_editor.multiline_on
         if block_given?

--- a/lib/reline/io/ansi.rb
+++ b/lib/reline/io/ansi.rb
@@ -41,7 +41,7 @@ class Reline::ANSI < Reline::IO
   end
 
   def encoding
-    Encoding.default_external
+    @input.external_encoding || Encoding.default_external
   end
 
   def set_default_key_bindings(config, allow_terminfo: true)

--- a/lib/reline/io/dumb.rb
+++ b/lib/reline/io/dumb.rb
@@ -7,7 +7,7 @@ class Reline::Dumb < Reline::IO
     @input = STDIN
     @buf = []
     @pasting = false
-    @encoding = encoding || @input.external_encoding
+    @encoding = encoding
     @screen_size = [24, 80]
   end
 
@@ -21,7 +21,7 @@ class Reline::Dumb < Reline::IO
     elsif RUBY_PLATFORM =~ /mswin|mingw/
       Encoding::UTF_8
     else
-      Encoding::default_external
+      @input.external_encoding || Encoding::default_external
     end
   end
 

--- a/lib/reline/io/dumb.rb
+++ b/lib/reline/io/dumb.rb
@@ -7,7 +7,7 @@ class Reline::Dumb < Reline::IO
     @input = STDIN
     @buf = []
     @pasting = false
-    @encoding = encoding
+    @encoding = encoding || @input.external_encoding
     @screen_size = [24, 80]
   end
 

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -72,15 +72,19 @@ class Reline::LineEditor
 
   MINIMUM_SCROLLBAR_HEIGHT = 1
 
-  def initialize(config, encoding)
+  def initialize(config)
     @config = config
     @completion_append_character = ''
     @screen_size = [0, 0] # Should be initialized with actual winsize in LineEditor#reset
-    reset_variables(encoding: encoding)
+    reset_variables
   end
 
   def io_gate
     Reline::IOGate
+  end
+
+  def encoding
+    io_gate.encoding
   end
 
   def set_pasting_state(in_pasting)
@@ -138,7 +142,7 @@ class Reline::LineEditor
 
   def reset(prompt = '', encoding:)
     @screen_size = Reline::IOGate.get_screen_size
-    reset_variables(prompt, encoding: encoding)
+    reset_variables(prompt)
     @rendered_screen.base_y = Reline::IOGate.cursor_pos.y
     if ENV.key?('RELINE_ALT_SCROLLBAR')
       @full_block = '::'
@@ -150,7 +154,7 @@ class Reline::LineEditor
       @upper_half_block = '▀'
       @lower_half_block = '▄'
       @block_elem_width = 1
-    elsif @encoding == Encoding::UTF_8
+    elsif encoding == Encoding::UTF_8
       @full_block = '█'
       @upper_half_block = '▀'
       @lower_half_block = '▄'
@@ -219,10 +223,9 @@ class Reline::LineEditor
     @eof
   end
 
-  def reset_variables(prompt = '', encoding:)
+  def reset_variables(prompt = '')
     @prompt = prompt.gsub("\n", "\\n")
     @mark_pointer = nil
-    @encoding = encoding
     @is_multiline = false
     @finished = false
     @history_pointer = nil
@@ -239,7 +242,7 @@ class Reline::LineEditor
     @searching_prompt = nil
     @just_cursor_moving = false
     @eof = false
-    @continuous_insertion_buffer = String.new(encoding: @encoding)
+    @continuous_insertion_buffer = String.new(encoding: encoding)
     @scroll_partial_screen = 0
     @drop_terminate_spaces = false
     @in_pasting = false
@@ -259,7 +262,7 @@ class Reline::LineEditor
 
   def reset_line
     @byte_pointer = 0
-    @buffer_of_lines = [String.new(encoding: @encoding)]
+    @buffer_of_lines = [String.new(encoding: encoding)]
     @line_index = 0
     @cache.clear
     @line_backup_in_history = nil
@@ -275,7 +278,7 @@ class Reline::LineEditor
   end
 
   private def insert_new_line(cursor_line, next_line)
-    @buffer_of_lines.insert(@line_index + 1, String.new(next_line, encoding: @encoding))
+    @buffer_of_lines.insert(@line_index + 1, String.new(next_line, encoding: encoding))
     @buffer_of_lines[@line_index] = cursor_line
     @line_index += 1
     @byte_pointer = 0
@@ -298,7 +301,7 @@ class Reline::LineEditor
   end
 
   private def split_by_width(str, max_width, offset: 0)
-    Reline::Unicode.split_by_width(str, max_width, @encoding, offset: offset)
+    Reline::Unicode.split_by_width(str, max_width, encoding, offset: offset)
   end
 
   def current_byte_pointer_cursor
@@ -882,8 +885,8 @@ class Reline::LineEditor
         perform_completion(list, true) if @config.show_all_if_ambiguous
       end
       if not just_show_list and target < completed
-        @buffer_of_lines[@line_index] = (preposing + completed + completion_append_character.to_s + postposing).split("\n")[@line_index] || String.new(encoding: @encoding)
-        line_to_pointer = (preposing + completed + completion_append_character.to_s).split("\n")[@line_index] || String.new(encoding: @encoding)
+        @buffer_of_lines[@line_index] = (preposing + completed + completion_append_character.to_s + postposing).split("\n")[@line_index] || String.new(encoding: encoding)
+        line_to_pointer = (preposing + completed + completion_append_character.to_s).split("\n")[@line_index] || String.new(encoding: encoding)
         @byte_pointer = line_to_pointer.bytesize
       end
     end
@@ -1058,8 +1061,8 @@ class Reline::LineEditor
   private def normal_char(key)
     @multibyte_buffer << key.combined_char
     if @multibyte_buffer.size > 1
-      if @multibyte_buffer.dup.force_encoding(@encoding).valid_encoding?
-        process_key(@multibyte_buffer.dup.force_encoding(@encoding), nil)
+      if @multibyte_buffer.dup.force_encoding(encoding).valid_encoding?
+        process_key(@multibyte_buffer.dup.force_encoding(encoding), nil)
         @multibyte_buffer.clear
       else
         # invalid
@@ -1317,7 +1320,7 @@ class Reline::LineEditor
     if (lines.size - 1) > @line_index
       postposing = postposing + "\n" + lines[(@line_index + 1)..-1].join("\n")
     end
-    [preposing.encode(@encoding), target.encode(@encoding), postposing.encode(@encoding)]
+    [preposing.encode(encoding), target.encode(encoding), postposing.encode(encoding)]
   end
 
   def confirm_multiline_termination
@@ -1329,7 +1332,7 @@ class Reline::LineEditor
     save_old_buffer
     pre = @buffer_of_lines[@line_index].byteslice(0, @byte_pointer)
     post = @buffer_of_lines[@line_index].byteslice(@byte_pointer..)
-    lines = (pre + Reline::Unicode.safe_encode(text, @encoding).gsub(/\r\n?/, "\n") + post).split("\n", -1)
+    lines = (pre + Reline::Unicode.safe_encode(text, encoding).gsub(/\r\n?/, "\n") + post).split("\n", -1)
     lines << '' if lines.empty?
     @buffer_of_lines[@line_index, 1] = lines
     @line_index += lines.size - 1
@@ -1374,7 +1377,7 @@ class Reline::LineEditor
       last += current_line.bytesize if last < 0
       first += current_line.bytesize if first < 0
       range = range.exclude_end? ? first...last : first..last
-      line = current_line.bytes.reject.with_index{ |c, i| range.include?(i) }.map{ |c| c.chr(Encoding::ASCII_8BIT) }.join.force_encoding(@encoding)
+      line = current_line.bytes.reject.with_index{ |c, i| range.include?(i) }.map{ |c| c.chr(Encoding::ASCII_8BIT) }.join.force_encoding(encoding)
       set_current_line(line)
     else
       set_current_line(current_line.byteslice(0, start))
@@ -1585,7 +1588,7 @@ class Reline::LineEditor
   alias_method :end_of_line, :ed_move_to_end
 
   private def generate_searcher(search_key)
-    search_word = String.new(encoding: @encoding)
+    search_word = String.new(encoding: encoding)
     multibyte_buf = String.new(encoding: 'ASCII-8BIT')
     hit_pointer = nil
     lambda do |key|
@@ -1602,8 +1605,8 @@ class Reline::LineEditor
         search_key = key
       else
         multibyte_buf << key
-        if multibyte_buf.dup.force_encoding(@encoding).valid_encoding?
-          search_word << multibyte_buf.dup.force_encoding(@encoding)
+        if multibyte_buf.dup.force_encoding(encoding).valid_encoding?
+          search_word << multibyte_buf.dup.force_encoding(encoding)
           multibyte_buf.clear
         end
       end
@@ -1763,7 +1766,7 @@ class Reline::LineEditor
       @history_pointer = history_pointer
     end
     @buffer_of_lines = buf.split("\n")
-    @buffer_of_lines = [String.new(encoding: @encoding)] if @buffer_of_lines.empty?
+    @buffer_of_lines = [String.new(encoding: encoding)] if @buffer_of_lines.empty?
     @line_index = line == :start ? 0 : line == :end ? @buffer_of_lines.size - 1 : line
     @byte_pointer = cursor == :start ? 0 : cursor == :end ? current_line.bytesize : cursor
   end
@@ -2288,7 +2291,7 @@ class Reline::LineEditor
     }
     system("#{ENV['EDITOR']} #{path}")
     @buffer_of_lines = File.read(path).split("\n")
-    @buffer_of_lines = [String.new(encoding: @encoding)] if @buffer_of_lines.empty?
+    @buffer_of_lines = [String.new(encoding: encoding)] if @buffer_of_lines.empty?
     @line_index = 0
     finish
   end

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -140,7 +140,7 @@ class Reline::LineEditor
     end
   end
 
-  def reset(prompt = '', encoding:)
+  def reset(prompt = '')
     @screen_size = Reline::IOGate.get_screen_size
     reset_variables(prompt)
     @rendered_screen.base_y = Reline::IOGate.cursor_pos.y

--- a/test/reline/helper.rb
+++ b/test/reline/helper.rb
@@ -92,7 +92,7 @@ class Reline::TestCase < Test::Unit::TestCase
       if Reline::Unicode::EscapedChars.include?(c.ord)
         c
       else
-        c.encode(@line_editor.instance_variable_get(:@encoding), Encoding::UTF_8, **options)
+        c.encode(@line_editor.encoding, Encoding::UTF_8, **options)
       end
     }.join
   rescue Encoding::UndefinedConversionError, Encoding::InvalidByteSequenceError

--- a/test/reline/test_key_actor_emacs.rb
+++ b/test/reline/test_key_actor_emacs.rb
@@ -9,7 +9,7 @@ class Reline::KeyActor::EmacsTest < Reline::TestCase
     Reline::HISTORY.instance_variable_set(:@config, @config)
     Reline::HISTORY.clear
     @encoding = Reline.core.encoding
-    @line_editor = Reline::LineEditor.new(@config, @encoding)
+    @line_editor = Reline::LineEditor.new(@config)
     @line_editor.reset(@prompt, encoding: @encoding)
   end
 

--- a/test/reline/test_key_actor_emacs.rb
+++ b/test/reline/test_key_actor_emacs.rb
@@ -10,7 +10,7 @@ class Reline::KeyActor::EmacsTest < Reline::TestCase
     Reline::HISTORY.clear
     @encoding = Reline.core.encoding
     @line_editor = Reline::LineEditor.new(@config)
-    @line_editor.reset(@prompt, encoding: @encoding)
+    @line_editor.reset(@prompt)
   end
 
   def teardown

--- a/test/reline/test_key_actor_vi.rb
+++ b/test/reline/test_key_actor_vi.rb
@@ -10,7 +10,7 @@ class Reline::ViInsertTest < Reline::TestCase
     LINES
     @encoding = Reline.core.encoding
     @line_editor = Reline::LineEditor.new(@config)
-    @line_editor.reset(@prompt, encoding: @encoding)
+    @line_editor.reset(@prompt)
   end
 
   def editing_mode_label

--- a/test/reline/test_key_actor_vi.rb
+++ b/test/reline/test_key_actor_vi.rb
@@ -9,7 +9,7 @@ class Reline::ViInsertTest < Reline::TestCase
       set editing-mode vi
     LINES
     @encoding = Reline.core.encoding
-    @line_editor = Reline::LineEditor.new(@config, @encoding)
+    @line_editor = Reline::LineEditor.new(@config)
     @line_editor.reset(@prompt, encoding: @encoding)
   end
 

--- a/test/reline/test_line_editor.rb
+++ b/test/reline/test_line_editor.rb
@@ -16,7 +16,7 @@ class Reline::LineEditor
 
     def setup
       verbose, $VERBOSE = $VERBOSE, nil
-      @line_editor = Reline::LineEditor.new(nil, Encoding::UTF_8)
+      @line_editor = Reline::LineEditor.new(nil)
       @original_iogate = Reline::IOGate
       @output = StringIO.new
       @line_editor.instance_variable_set(:@screen_size, [24, 80])

--- a/test/reline/test_macro.rb
+++ b/test/reline/test_macro.rb
@@ -5,7 +5,7 @@ class Reline::MacroTest < Reline::TestCase
     Reline.send(:test_mode)
     @config = Reline::Config.new
     @encoding = Reline.core.encoding
-    @line_editor = Reline::LineEditor.new(@config, @encoding)
+    @line_editor = Reline::LineEditor.new(@config)
     @output = @line_editor.output = File.open(IO::NULL, "w")
   end
 

--- a/test/reline/test_string_processing.rb
+++ b/test/reline/test_string_processing.rb
@@ -7,7 +7,7 @@ class Reline::LineEditor::StringProcessingTest < Reline::TestCase
     @config = Reline::Config.new
     Reline::HISTORY.instance_variable_set(:@config, @config)
     @encoding = Reline.core.encoding
-    @line_editor = Reline::LineEditor.new(@config, @encoding)
+    @line_editor = Reline::LineEditor.new(@config)
     @line_editor.reset(@prompt, encoding: @encoding)
   end
 

--- a/test/reline/test_string_processing.rb
+++ b/test/reline/test_string_processing.rb
@@ -6,9 +6,8 @@ class Reline::LineEditor::StringProcessingTest < Reline::TestCase
     @prompt = '> '
     @config = Reline::Config.new
     Reline::HISTORY.instance_variable_set(:@config, @config)
-    @encoding = Reline.core.encoding
     @line_editor = Reline::LineEditor.new(@config)
-    @line_editor.reset(@prompt, encoding: @encoding)
+    @line_editor.reset(@prompt)
   end
 
   def teardown


### PR DESCRIPTION
Fix #755. Use IO object's encoding to separate  from global `Encoding.default_external`.

For example:

```ruby
require 'reline'
::Encoding.default_external = ::Encoding::ASCII_8BIT
::Encoding.default_internal = ::Encoding::ASCII_8BIT

input = STDIN.dup
input.set_encoding(Encoding::UTF_8)
Reline.input = input

ascii_text = Reline.readline('prompt > ', false)

$stderr.puts ascii_text.encoding.to_s
```

and get `UTF-8`:
```
prompt > こんにちは
UTF-8
```

