### PR TITLE
nonprinting_start and nonprinting_end should be removed before print

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -464,7 +464,7 @@ class Reline::LineEditor
   def render_finished
     render_differential([], 0, 0)
     lines = @buffer_of_lines.size.times.map do |i|
-      line = prompt_list[i] + modified_lines[i]
+      line = Reline::Unicode.strip_non_printing_start_end(prompt_list[i]) + modified_lines[i]
       wrapped_lines, = split_by_width(line, screen_width)
       wrapped_lines.last.empty? ? "#{line} " : line
     end
@@ -473,7 +473,7 @@ class Reline::LineEditor
 
   def print_nomultiline_prompt
     # Readline's test `TestRelineAsReadline#test_readline` requires first output to be prompt, not cursor reset escape sequence.
-    @output.write @prompt if @prompt && !@is_multiline
+    @output.write Reline::Unicode.strip_non_printing_start_end(@prompt) if @prompt && !@is_multiline
   end
 
   def render

--- a/lib/reline/unicode.rb
+++ b/lib/reline/unicode.rb
@@ -132,10 +132,8 @@ class Reline::Unicode
       case
       when non_printing_start
         in_zero_width = true
-        lines.last << NON_PRINTING_START
       when non_printing_end
         in_zero_width = false
-        lines.last << NON_PRINTING_END
       when csi
         lines.last << csi
         unless in_zero_width
@@ -147,7 +145,7 @@ class Reline::Unicode
         end
       when osc
         lines.last << osc
-        seq << osc
+        seq << osc unless in_zero_width
       when gc
         unless in_zero_width
           mbchar_width = get_mbchar_width(gc)
@@ -170,6 +168,10 @@ class Reline::Unicode
     [lines, height]
   end
 
+  def self.strip_non_printing_start_end(prompt)
+    prompt.gsub(/\x01([^\x02]*)(?:\x02|\z)/) { $1 }
+  end
+
   # Take a chunk of a String cut by width with escape sequences.
   def self.take_range(str, start_col, max_width)
     take_mbchar_range(str, start_col, max_width).first
@@ -189,10 +191,8 @@ class Reline::Unicode
       case
       when non_printing_start
         in_zero_width = true
-        chunk << NON_PRINTING_START
       when non_printing_end
         in_zero_width = false
-        chunk << NON_PRINTING_END
       when csi
         has_csi = true
         chunk << csi

--- a/test/reline/test_unicode.rb
+++ b/test/reline/test_unicode.rb
@@ -33,24 +33,36 @@ class Reline::Unicode::Test < Reline::TestCase
     assert_equal [['abc', nil, 'de'], 2], Reline::Unicode.split_by_width('abcde', 3)
     assert_equal [['abc', nil, 'def', nil, ''], 3], Reline::Unicode.split_by_width('abcdef', 3)
     assert_equal [['ab', nil, 'あd', nil, 'ef'], 3], Reline::Unicode.split_by_width('abあdef', 3)
-    assert_equal [["ab\1zero\2c", nil, 'def', nil, ''], 3], Reline::Unicode.split_by_width("ab\1zero\2cdef", 3)
+    assert_equal [['ab[zero]c', nil, 'def', nil, ''], 3], Reline::Unicode.split_by_width("ab\1[zero]\2cdef", 3)
     assert_equal [["\e[31mabc", nil, "\e[31md\e[42mef", nil, "\e[31m\e[42mg"], 3], Reline::Unicode.split_by_width("\e[31mabcd\e[42mefg", 3)
     assert_equal [["ab\e]0;1\ac", nil, "\e]0;1\ad"], 2], Reline::Unicode.split_by_width("ab\e]0;1\acd", 3)
   end
 
   def test_split_by_width_csi_reset_sgr_optimization
     assert_equal [["\e[1ma\e[mb\e[2mc", nil, "\e[2md\e[0me\e[3mf", nil, "\e[3mg"], 3], Reline::Unicode.split_by_width("\e[1ma\e[mb\e[2mcd\e[0me\e[3mfg", 3)
-    assert_equal [["\e[1ma\1\e[mzero\e[0m\2\e[2mb", nil, "\e[1m\e[2mc"], 2], Reline::Unicode.split_by_width("\e[1ma\1\e[mzero\e[0m\2\e[2mbc", 2)
+    assert_equal [["\e[1ma\e[mzero\e[0m\e[2mb", nil, "\e[1m\e[2mc"], 2], Reline::Unicode.split_by_width("\e[1ma\1\e[mzero\e[0m\2\e[2mbc", 2)
   end
 
   def test_take_range
     assert_equal 'cdef', Reline::Unicode.take_range('abcdefghi', 2, 4)
     assert_equal 'あde', Reline::Unicode.take_range('abあdef', 2, 4)
-    assert_equal "\1zero\2cdef", Reline::Unicode.take_range("ab\1zero\2cdef", 2, 4)
-    assert_equal "b\1zero\2cde", Reline::Unicode.take_range("ab\1zero\2cdef", 1, 4)
+    assert_equal '[zero]cdef', Reline::Unicode.take_range("ab\1[zero]\2cdef", 2, 4)
+    assert_equal 'b[zero]cde', Reline::Unicode.take_range("ab\1[zero]\2cdef", 1, 4)
     assert_equal "\e[31mcd\e[42mef", Reline::Unicode.take_range("\e[31mabcd\e[42mefg", 2, 4)
     assert_equal "\e]0;1\acd", Reline::Unicode.take_range("ab\e]0;1\acd", 2, 3)
     assert_equal 'いう', Reline::Unicode.take_range('あいうえお', 2, 4)
+  end
+
+  def test_nonprinting_start_end
+    # \1 and \2 should be removed
+    assert_equal 'ab[zero]cd', Reline::Unicode.take_range("ab\1[zero]\2cdef", 0, 4)
+    assert_equal [['ab[zero]cd', nil, 'ef'], 2], Reline::Unicode.split_by_width("ab\1[zero]\2cdef", 4)
+    # CSI between \1 and \2 does not need to be applied to the sebsequent line
+    assert_equal [["\e[31mab\e[32mcd", nil, "\e[31mef"], 2], Reline::Unicode.split_by_width("\e[31mab\1\e[32m\2cdef", 4)
+  end
+
+  def test_strip_non_printing_start_end
+    assert_equal "ab[zero]cd[ze\1ro]ef[zero]", Reline::Unicode.strip_non_printing_start_end("ab\1[zero]\2cd\1[ze\1ro]\2ef\1[zero]")
   end
 
   def test_calculate_width
@@ -58,8 +70,8 @@ class Reline::Unicode::Test < Reline::TestCase
     assert_equal 9, Reline::Unicode.calculate_width('abcdefghi', true)
     assert_equal 7, Reline::Unicode.calculate_width('abあdef')
     assert_equal 7, Reline::Unicode.calculate_width('abあdef', true)
-    assert_equal 14, Reline::Unicode.calculate_width("ab\1zero\2cdef")
-    assert_equal 6, Reline::Unicode.calculate_width("ab\1zero\2cdef", true)
+    assert_equal 16, Reline::Unicode.calculate_width("ab\1[zero]\2cdef")
+    assert_equal 6, Reline::Unicode.calculate_width("ab\1[zero]\2cdef", true)
     assert_equal 19, Reline::Unicode.calculate_width("\e[31mabcd\e[42mefg")
     assert_equal 7, Reline::Unicode.calculate_width("\e[31mabcd\e[42mefg", true)
     assert_equal 12, Reline::Unicode.calculate_width("ab\e]0;1\acd")
@@ -86,7 +98,7 @@ class Reline::Unicode::Test < Reline::TestCase
     assert_equal [' うえお   ', 3, 10], Reline::Unicode.take_mbchar_range('あいうえお', 3, 10, padding: true)
     assert_equal [" \e[41mうえお\e[0m   ", 3, 10], Reline::Unicode.take_mbchar_range("あい\e[41mうえお", 3, 10, padding: true)
     assert_equal ["\e[41m \e[42mい\e[43m ", 1, 4], Reline::Unicode.take_mbchar_range("\e[41mあ\e[42mい\e[43mう", 1, 4, padding: true)
-    assert_equal ["\e[31mc\1ABC\2d\e[0mef", 2, 4], Reline::Unicode.take_mbchar_range("\e[31mabc\1ABC\2d\e[0mefghi", 2, 4)
+    assert_equal ["\e[31mc[ABC]d\e[0mef", 2, 4], Reline::Unicode.take_mbchar_range("\e[31mabc\1[ABC]\2d\e[0mefghi", 2, 4)
     assert_equal ["\e[41m \e[42mい\e[43m ", 1, 4], Reline::Unicode.take_mbchar_range("\e[41mあ\e[42mい\e[43mう", 1, 4, padding: true)
   end
 


### PR DESCRIPTION
Fixes #770

```ruby
Reline::Unicode.take_range("ABC\1[zero]\2DEFGHIJ", 0, 6)
# => "ABC\u0001[zero]\u0002DEF" (before)
# => "ABC[zero]DEF" (after)
```

Readline removes `\1` and `\2`. Reline was doing the same until 0.3.2 but broken since 0.3.3
```ruby
# Readline 8.2
PTY.spawn('ruby', '-e', %q(require 'readline'; Readline.readline "prompt\1[invis]\2>")){|r,w|p r.readpartial(1024)}
#=> "...prompt[invis]>..."

# Reline
PTY.spawn('ruby', '-e', %q(require 'reline'; Reline.readline "prompt\1[invis]\2>")){|r,w|20.times{p s=r.readpartial(1024);w.write "\e[1;1R" if s=~/\[6n/}}
#=> "...prompt\x01[invis]\x02>..." # \x01 and \x02 should be removed
```