### PR TITLE
Windows fix

### DIFF
--- a/lib/reline/io/windows.rb
+++ b/lib/reline/io/windows.rb
@@ -350,9 +350,12 @@ class Reline::Windows < Reline::IO
 
   def get_screen_size
     unless csbi = get_console_screen_buffer_info
-      return [1, 1]
+      return [24, 80]
     end
-    csbi[0, 4].unpack('SS').reverse
+    top = csbi[12, 2].unpack1('S')
+    bottom = csbi[16, 2].unpack1('S')
+    width = csbi[0, 2].unpack1('S')
+    [bottom - top + 1, width]
   end
 
   def cursor_pos

--- a/lib/reline/io/windows.rb
+++ b/lib/reline/io/windows.rb
@@ -115,7 +115,7 @@ class Reline::Windows < Reline::IO
       def call(*args)
         import = @proto.split("")
         args.each_with_index do |x, i|
-          args[i], = [x == 0 ? nil : +x].pack("p").unpack(POINTER_TYPE) if import[i] == "S"
+          args[i], = [x == 0 ? nil : x&.+@].pack("p").unpack(POINTER_TYPE) if import[i] == "S"
           args[i], = [x].pack("I").unpack("i") if import[i] == "I"
         end
         ret, = @func.call(*args)

--- a/lib/reline/io/windows.rb
+++ b/lib/reline/io/windows.rb
@@ -113,13 +113,7 @@ class Reline::Windows < Reline::IO
       end
 
       def call(*args)
-        import = @proto.split("")
-        args.each_with_index do |x, i|
-          args[i], = [x == 0 ? nil : x&.+@].pack("p").unpack(POINTER_TYPE) if import[i] == "S"
-          args[i], = [x].pack("I").unpack("i") if import[i] == "I"
-        end
-        ret, = @func.call(*args)
-        return ret || 0
+        @func.call(*args)
       end
     end
   end

--- a/lib/reline/io/windows.rb
+++ b/lib/reline/io/windows.rb
@@ -171,7 +171,7 @@ class Reline::Windows < Reline::IO
   end
 
   private def getconsolemode
-    mode = "\000\000\000\000"
+    mode = +"\0\0\0\0"
     call_with_console_handle(@GetConsoleMode, mode)
     mode.unpack1('L')
   end

--- a/lib/reline/io/windows.rb
+++ b/lib/reline/io/windows.rb
@@ -115,7 +115,7 @@ class Reline::Windows < Reline::IO
       def call(*args)
         import = @proto.split("")
         args.each_with_index do |x, i|
-          args[i], = [x == 0 ? nil : x&.+@].pack("p").unpack(POINTER_TYPE) if import[i] == "S"
+          args[i], = [x == 0 ? nil : +x].pack("p").unpack(POINTER_TYPE) if import[i] == "S"
           args[i], = [x].pack("I").unpack("i") if import[i] == "I"
         end
         ret, = @func.call(*args)

--- a/lib/reline/io/windows.rb
+++ b/lib/reline/io/windows.rb
@@ -113,7 +113,13 @@ class Reline::Windows < Reline::IO
       end
 
       def call(*args)
-        @func.call(*args)
+        import = @proto.split("")
+        args.each_with_index do |x, i|
+          args[i], = [x == 0 ? nil : x&.+@].pack("p").unpack(POINTER_TYPE) if import[i] == "S"
+          args[i], = [x].pack("I").unpack("i") if import[i] == "I"
+        end
+        ret, = @func.call(*args)
+        return ret || 0
       end
     end
   end

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -472,8 +472,11 @@ class Reline::LineEditor
   end
 
   def print_nomultiline_prompt
+    Reline::IOGate.disable_auto_linewrap(true) if Reline::IOGate.win?
     # Readline's test `TestRelineAsReadline#test_readline` requires first output to be prompt, not cursor reset escape sequence.
     @output.write Reline::Unicode.strip_non_printing_start_end(@prompt) if @prompt && !@is_multiline
+  ensure
+    Reline::IOGate.disable_auto_linewrap(false) if Reline::IOGate.win?
   end
 
   def render
@@ -509,6 +512,7 @@ class Reline::LineEditor
   # by calculating the difference from the previous render.
 
   private def render_differential(new_lines, new_cursor_x, new_cursor_y)
+    Reline::IOGate.disable_auto_linewrap(true) if Reline::IOGate.win?
     rendered_lines = @rendered_screen.lines
     cursor_y = @rendered_screen.cursor_y
     if new_lines != rendered_lines
@@ -539,6 +543,8 @@ class Reline::LineEditor
     Reline::IOGate.move_cursor_column new_cursor_x
     Reline::IOGate.move_cursor_down new_cursor_y - cursor_y
     @rendered_screen.cursor_y = new_cursor_y
+  ensure
+    Reline::IOGate.disable_auto_linewrap(false) if Reline::IOGate.win?
   end
 
   private def clear_rendered_screen_cache

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -1796,6 +1796,7 @@ begin
     end
 
     def test_stop_continue
+      omit if Reline.core.io_gate.win?
       pidfile = Tempfile.create('pidfile')
       rubyfile = Tempfile.create('rubyfile')
       rubyfile.write <<~RUBY

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -25,8 +25,8 @@ begin
         config_file = Tempfile.create(%w{face_config- .rb})
         config_file.write face_config
         block.call(config_name, config_file)
-        config_file.close
       ensure
+        config_file.close
         File.delete(config_file)
       end
     end
@@ -1816,6 +1816,7 @@ begin
       close
     ensure
       File.delete(rubyfile.path) if rubyfile
+      pidfile.close if pidfile
       File.delete(pidfile.path) if pidfile
     end
 

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -1065,7 +1065,7 @@ begin
 
     def test_simple_dialog_with_scroll_screen
       iterate_over_face_configs do |config_name, config_file|
-        start_terminal(5, 50, %W{ruby -I#{@pwd}/lib -r#{config_file.path} #{@pwd}/test/reline/yamatanooroti/multiline_repl --dialog simple}, startup_message: 'Multiline REPL.')
+        start_terminal(5, 50, %W{ruby -I#{@pwd}/lib -r#{config_file.path} #{@pwd}/test/reline/yamatanooroti/multiline_repl --dialog simple}, startup_message: /prompt>/)
         write("if 1\n  2\n  3\n  4\n  5\n  6")
         write("\C-p\C-n\C-p\C-p\C-p#")
         close


### PR DESCRIPTION
This is part of supporting windows for reline CI using yamatanooroti.
This PR contains the following changes. There are independent to windows specific yamatanooroti changes.
- Windows specific test fix, not related yamatanooroti.
- Changes for conhostV1 (Command Prompt Window, legacy mode ON), includes bug fix.
- Follows reline changes.
- Supporting frozen string literal.