### PR TITLE
New yamatanooroti for win

### DIFF
--- a/lib/reline/io/windows.rb
+++ b/lib/reline/io/windows.rb
@@ -350,9 +350,12 @@ class Reline::Windows < Reline::IO
 
   def get_screen_size
     unless csbi = get_console_screen_buffer_info
-      return [1, 1]
+      return [24, 80]
     end
-    csbi[0, 4].unpack('SS').reverse
+    top = csbi[12, 2].unpack1('S')
+    bottom = csbi[16, 2].unpack1('S')
+    width = csbi[0, 2].unpack1('S')
+    [bottom - top + 1, width]
   end
 
   def cursor_pos

--- a/lib/reline/io/windows.rb
+++ b/lib/reline/io/windows.rb
@@ -115,7 +115,7 @@ class Reline::Windows < Reline::IO
       def call(*args)
         import = @proto.split("")
         args.each_with_index do |x, i|
-          args[i], = [x == 0 ? nil : +x].pack("p").unpack(POINTER_TYPE) if import[i] == "S"
+          args[i], = [x == 0 ? nil : x&.+@].pack("p").unpack(POINTER_TYPE) if import[i] == "S"
           args[i], = [x].pack("I").unpack("i") if import[i] == "I"
         end
         ret, = @func.call(*args)

--- a/lib/reline/io/windows.rb
+++ b/lib/reline/io/windows.rb
@@ -171,7 +171,7 @@ class Reline::Windows < Reline::IO
   end
 
   private def getconsolemode
-    mode = "\000\000\000\000"
+    mode = +"\0\0\0\0"
     call_with_console_handle(@GetConsoleMode, mode)
     mode.unpack1('L')
   end

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -472,8 +472,11 @@ class Reline::LineEditor
   end
 
   def print_nomultiline_prompt
+    Reline::IOGate.disable_auto_linewrap(true) if Reline::IOGate.win?
     # Readline's test `TestRelineAsReadline#test_readline` requires first output to be prompt, not cursor reset escape sequence.
     @output.write Reline::Unicode.strip_non_printing_start_end(@prompt) if @prompt && !@is_multiline
+  ensure
+    Reline::IOGate.disable_auto_linewrap(false) if Reline::IOGate.win?
   end
 
   def render
@@ -509,6 +512,7 @@ class Reline::LineEditor
   # by calculating the difference from the previous render.
 
   private def render_differential(new_lines, new_cursor_x, new_cursor_y)
+    Reline::IOGate.disable_auto_linewrap(true) if Reline::IOGate.win?
     rendered_lines = @rendered_screen.lines
     cursor_y = @rendered_screen.cursor_y
     if new_lines != rendered_lines
@@ -539,6 +543,8 @@ class Reline::LineEditor
     Reline::IOGate.move_cursor_column new_cursor_x
     Reline::IOGate.move_cursor_down new_cursor_y - cursor_y
     @rendered_screen.cursor_y = new_cursor_y
+  ensure
+    Reline::IOGate.disable_auto_linewrap(false) if Reline::IOGate.win?
   end
 
   private def clear_rendered_screen_cache

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -89,7 +89,12 @@ begin
     end
 
     def test_fullwidth
-      start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
+      unless Yamatanooroti.win? && Yamatanooroti.options.windows == :"legacy-conhost"
+        start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
+      else
+        start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.', codepage: 932)
+        omit "codepage 932 not supported" if !codepage_success?
+      end
       write(":あ\n")
       assert_screen(<<~EOC)
         Multiline REPL.
@@ -101,7 +106,12 @@ begin
     end
 
     def test_two_fullwidth
-      start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
+      unless Yamatanooroti.win? && Yamatanooroti.options.windows == :"legacy-conhost"
+        start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
+      else
+        start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.', codepage: 932)
+        omit "codepage 932 not supported" if !codepage_success?
+      end
       write(":あい\n")
       assert_screen(<<~EOC)
         Multiline REPL.
@@ -377,7 +387,12 @@ begin
     end
 
     def test_nearest_cursor
-      start_terminal(10, 20, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
+      unless Yamatanooroti.win? && Yamatanooroti.options.windows == :"legacy-conhost"
+        start_terminal(10, 20, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
+      else
+        start_terminal(10, 20, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.', codepage: 932)
+        omit "codepage 932 not supported" if !codepage_success?
+      end
       write("def ああ\n  :いい\nend\C-pbb\C-pcc")
       assert_screen(<<~EOC)
         Multiline REPL.
@@ -718,7 +733,12 @@ begin
     end
 
     def test_auto_indent_multibyte_insert_line
-      start_terminal(10, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --auto-indent}, startup_message: 'Multiline REPL.')
+      unless Yamatanooroti.win? && Yamatanooroti.options.windows == :"legacy-conhost"
+        start_terminal(10, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --auto-indent}, startup_message: 'Multiline REPL.')
+      else
+        start_terminal(10, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --auto-indent}, startup_message: 'Multiline REPL.', codepage: 932)
+        omit "codepage 932 not supported" if !codepage_success?
+      end
       write "if true\n"
       write "あいうえお\n"
       4.times { write "\C-b\C-b\C-b\C-b\e\r" }
@@ -763,7 +783,12 @@ begin
     end
 
     def test_suppress_auto_indent_for_adding_newlines_in_pasting
-      start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --auto-indent}, startup_message: 'Multiline REPL.')
+      unless Yamatanooroti.win? && Yamatanooroti.options.windows == :"legacy-conhost"
+        start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --auto-indent}, startup_message: 'Multiline REPL.')
+      else
+        start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --auto-indent}, startup_message: 'Multiline REPL.', codepage: 932)
+        omit "codepage 932 not supported" if !codepage_success?
+      end
       write("<<~Q\n")
       write("{\n  #\n}")
       write("#")
@@ -854,7 +879,12 @@ begin
     end
 
     def test_not_meta_key
-      start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
+      unless Yamatanooroti.win? && Yamatanooroti.options.windows == :"legacy-conhost"
+        start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
+      else
+        start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.', codepage: 932)
+        omit "codepage 932 not supported" if !codepage_success?
+      end
       write("おだんご") # "だ" in UTF-8 contains "\xA0"
       assert_screen(<<~EOC)
         Multiline REPL.

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -1796,6 +1796,7 @@ begin
     end
 
     def test_stop_continue
+      omit if Reline.core.io_gate.win?
       pidfile = Tempfile.create('pidfile')
       rubyfile = Tempfile.create('rubyfile')
       rubyfile.write <<~RUBY

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -25,8 +25,8 @@ begin
         config_file = Tempfile.create(%w{face_config- .rb})
         config_file.write face_config
         block.call(config_name, config_file)
-        config_file.close
       ensure
+        config_file.close
         File.delete(config_file)
       end
     end
@@ -1816,6 +1816,7 @@ begin
       close
     ensure
       File.delete(rubyfile.path) if rubyfile
+      pidfile.close if pidfile
       File.delete(pidfile.path) if pidfile
     end
 

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -1065,7 +1065,7 @@ begin
 
     def test_simple_dialog_with_scroll_screen
       iterate_over_face_configs do |config_name, config_file|
-        start_terminal(5, 50, %W{ruby -I#{@pwd}/lib -r#{config_file.path} #{@pwd}/test/reline/yamatanooroti/multiline_repl --dialog simple}, startup_message: 'Multiline REPL.')
+        start_terminal(5, 50, %W{ruby -I#{@pwd}/lib -r#{config_file.path} #{@pwd}/test/reline/yamatanooroti/multiline_repl --dialog simple}, startup_message: /prompt>/)
         write("if 1\n  2\n  3\n  4\n  5\n  6")
         write("\C-p\C-n\C-p\C-p\C-p#")
         close

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -1256,11 +1256,9 @@ begin
         start_terminal(20, 5, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --dialog fullwidth,scrollkey,scrollbar}, startup_message: 'Multiline REPL.', codepage: 932)
         omit "codepage 932 not supported" if !codepage_success?
       end
+      write("\C-l")
       6.times{ write('j') }
       assert_screen(<<~'EOC')
-        Multi
-        line
-        REPL.
         >
         オー
         グ言▄

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -1227,7 +1227,9 @@ begin
         omit "codepage 932 not supported" if !codepage_success?
       end
       6.times{ write('j') }
-      unless Yamatanooroti.win? && Yamatanooroti.options.windows == :"legacy-conhost"
+      unless Yamatanooroti.win? &&
+         (Yamatanooroti.options.windows == :"legacy-conhost" ||
+          Yamatanooroti.options.windows == :conhost && (RUBY_VERSION < "3.0" || RUBY_ENGINE != "ruby"))
         assert_screen(<<~'EOC')
           Multi
           line
@@ -1240,6 +1242,8 @@ begin
         EOC
       else
         # "Multiline REPL." is printed with ```puts``` and causes forced line break. This behavior is out of scope.
+        # legacy-conhost has forced linebreak at EOL
+        # ruby >= 3.0 enables VT output at startup on conhost but prior versions not. So same as legacy-conhost behavior.
         assert_screen(<<~'EOC')
           Multi
           line

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -1222,16 +1222,31 @@ begin
       ENV['RELINE_TEST_PROMPT'] = '> '
       start_terminal(20, 5, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --dialog fullwidth,scrollkey,scrollbar}, startup_message: 'Multiline REPL.')
       6.times{ write('j') }
-      assert_screen(<<~'EOC')
-        Multi
-        line
-        REPL.
-        >
-        オー
-        グ言▄
-        備え█
-        ち、█
-      EOC
+      unless Yamatanooroti.win? && Yamatanooroti.options.windows == :"legacy-conhost"
+        assert_screen(<<~'EOC')
+          Multi
+          line
+          REPL.
+          >
+          オー
+          グ言▄
+          備え█
+          ち、█
+        EOC
+      else
+        # "Multiline REPL." is printed with ```puts``` and causes forced line break. This behavior is out of scope.
+        assert_screen(<<~'EOC')
+          Multi
+          line
+          REPL.
+          
+          >
+          オー
+          グ言▄
+          備え█
+          ち、█
+        EOC
+      end
       close
     end
 

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -1220,7 +1220,12 @@ begin
 
     def test_dialog_with_fullwidth_chars
       ENV['RELINE_TEST_PROMPT'] = '> '
-      start_terminal(20, 5, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --dialog fullwidth,scrollkey,scrollbar}, startup_message: 'Multiline REPL.')
+      unless Yamatanooroti.win? && Yamatanooroti.options.windows == :"legacy-conhost"
+        start_terminal(20, 5, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --dialog fullwidth,scrollkey,scrollbar}, startup_message: 'Multiline REPL.')
+      else
+        start_terminal(20, 5, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --dialog fullwidth,scrollkey,scrollbar}, startup_message: 'Multiline REPL.', codepage: 932)
+        omit "codepage 932 not supported" if !codepage_success?
+      end
       6.times{ write('j') }
       unless Yamatanooroti.win? && Yamatanooroti.options.windows == :"legacy-conhost"
         assert_screen(<<~'EOC')
@@ -1252,7 +1257,12 @@ begin
 
     def test_dialog_with_fullwidth_chars_split
       ENV['RELINE_TEST_PROMPT'] = '> '
-      start_terminal(20, 6, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --dialog fullwidth,scrollkey,scrollbar}, startup_message: 'Multiline REPL.')
+      unless Yamatanooroti.win? && Yamatanooroti.options.windows == :"legacy-conhost"
+        start_terminal(20, 6, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --dialog fullwidth,scrollkey,scrollbar}, startup_message: 'Multiline REPL.')
+      else
+        start_terminal(20, 6, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --dialog fullwidth,scrollkey,scrollbar}, startup_message: 'Multiline REPL.', codepage: 932)
+        omit "codepage 932 not supported" if !codepage_success?
+      end
       6.times{ write('j') }
       assert_screen(<<~'EOC')
         Multil

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -1257,31 +1257,16 @@ begin
         omit "codepage 932 not supported" if !codepage_success?
       end
       6.times{ write('j') }
-      unless Yamatanooroti.win? && Yamatanooroti.options.windows == :"legacy-conhost"
-        assert_screen(<<~'EOC')
-          Multi
-          line
-          REPL.
-          >
-          オー
-          グ言▄
-          備え█
-          ち、█
-        EOC
-      else
-        # "Multiline REPL." is printed with ```puts``` and causes forced line break. This behavior is out of scope.
-        assert_screen(<<~'EOC')
-          Multi
-          line
-          REPL.
-          
-          >
-          オー
-          グ言▄
-          備え█
-          ち、█
-        EOC
-      end
+      assert_screen(<<~'EOC')
+        Multi
+        line
+        REPL.
+        >
+        オー
+        グ言▄
+        備え█
+        ち、█
+      EOC
       close
     end
 

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -1257,9 +1257,7 @@ begin
         omit "codepage 932 not supported" if !codepage_success?
       end
       6.times{ write('j') }
-      unless Yamatanooroti.win? &&
-         (Yamatanooroti.options.windows == :"legacy-conhost" ||
-          Yamatanooroti.options.windows == :conhost && (RUBY_VERSION < "3.0" || RUBY_ENGINE != "ruby"))
+      unless Yamatanooroti.win? && Yamatanooroti.options.windows == :"legacy-conhost"
         assert_screen(<<~'EOC')
           Multi
           line
@@ -1272,8 +1270,6 @@ begin
         EOC
       else
         # "Multiline REPL." is printed with ```puts``` and causes forced line break. This behavior is out of scope.
-        # legacy-conhost has forced linebreak at EOL
-        # ruby >= 3.0 enables VT output at startup on conhost but prior versions not. So same as legacy-conhost behavior.
         assert_screen(<<~'EOC')
           Multi
           line


### PR DESCRIPTION
This is part of supporting windows for reline CI using yamatanooroti.
This PR follows PR#775.
This PR contains the following test_yamatanooroti changes.
- Change codepage when needed. (depend to yamatanooroti api change)
- Changes to avoid affecting the behavior of windows console.
The merge requires finalizing api changes to the code page settings on the yamatanooroti side.