### PR TITLE
Refactor perform_completon

### DIFF
--- a/lib/reline/unicode.rb
+++ b/lib/reline/unicode.rb
@@ -670,6 +670,19 @@ class Reline::Unicode
     [byte_size, width]
   end
 
+  def self.common_prefix(list, ignore_case: false)
+    return '' if list.empty?
+
+    common_prefix_gcs = list.first.grapheme_clusters
+    list.each do |item|
+      gcs = item.grapheme_clusters
+      common_prefix_gcs = common_prefix_gcs.take_while.with_index do |gc, i|
+        ignore_case ? gc.casecmp?(gcs[i]) : gc == gcs[i]
+      end
+    end
+    common_prefix_gcs.join
+  end
+
   def self.vi_first_print(line)
     width = 0
     byte_size = 0

--- a/test/reline/test_key_actor_emacs.rb
+++ b/test/reline/test_key_actor_emacs.rb
@@ -986,6 +986,9 @@ class Reline::KeyActor::EmacsTest < Reline::TestCase
     input_keys('b')
     input_keys("\C-i", false)
     assert_line_around_cursor('foo_ba', '')
+    input_keys('Z')
+    input_keys("\C-i", false)
+    assert_line_around_cursor('Foo_baz', '')
   end
 
   def test_completion_in_middle_of_line

--- a/test/reline/test_unicode.rb
+++ b/test/reline/test_unicode.rb
@@ -102,6 +102,16 @@ class Reline::Unicode::Test < Reline::TestCase
     assert_equal ["\e[41m \e[42mい\e[43m ", 1, 4], Reline::Unicode.take_mbchar_range("\e[41mあ\e[42mい\e[43mう", 1, 4, padding: true)
   end
 
+  def test_common_prefix
+    assert_equal('', Reline::Unicode.common_prefix([]))
+    assert_equal('abc', Reline::Unicode.common_prefix(['abc']))
+    assert_equal('12', Reline::Unicode.common_prefix(['123', '123️⃣']))
+    assert_equal('', Reline::Unicode.common_prefix(['abc', 'xyz']))
+    assert_equal('ab', Reline::Unicode.common_prefix(['abcd', 'abc', 'abx', 'abcd']))
+    assert_equal('A', Reline::Unicode.common_prefix(['AbcD', 'ABC', 'AbX', 'AbCD']))
+    assert_equal('Ab', Reline::Unicode.common_prefix(['AbcD', 'ABC', 'AbX', 'AbCD'], ignore_case: true))
+  end
+
   def test_encoding_conversion
     texts = [
       String.new("invalid\xFFutf8", encoding: 'utf-8'),


### PR DESCRIPTION
`LineEditor#perform_completion` was complicated.
When autocomplete is off, state is NORMAL, show_all_if_ambiguous is set, input is `1.ab[TAB]`
```
L857: state change to COMPLETION
L874: calls complete_internal_proc to retrieve completion
L888: state change to MENU_WITH_PERFECT_MATCH
L889: calls perform_completion itself recursively
L874: calls complete_internal_proc just to set menu
L876: state change to PERFECT_MATCH
```
It turned out that CompletionState::COMPLETION was not needed at all.

This pull request simplifies the flow.
Fixes tab completion with completion-ignore-case.
Unintentionally fixes bug related to the complex flow. Typing `1.ab[TAB][DELETE_CHAR_OR_LIST]` wrongly triggered show_document.