### PR TITLE
explicitly require fiddle

### DIFF
--- a/reline.gemspec
+++ b/reline.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = Gem::Requirement.new('>= 2.6')
 
   spec.add_dependency 'io-console', '~> 0.5'
+  spec.add_dependency 'fiddle'
 end


### PR DESCRIPTION
`fiddle` has been removed from ruby 3.5 standard gems.
This makes the gem dependency explicit.

```
ruby-3.3.5/lib/ruby/3.3.0/reline.rb:9: warning:
fiddle was loaded from the standard library,
but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add fiddle to your Gemfile or gemspec to silence this warning.
```
