### PR TITLE
Add .rb extension to tempfile in vi mode

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -2264,7 +2264,7 @@ class Reline::LineEditor
   end
 
   private def vi_histedit(key)
-    path = Tempfile.open { |fp|
+    path = Tempfile.open(["reline", ".rb"]) { |fp|
       fp.write whole_lines.join("\n")
       fp.path
     }


### PR DESCRIPTION
## Problem

When you are in VI mode and you enter normal mode and press `v` it opens up your `$EDITOR` to edit the current context. The issue is that your `$EDITOR` does not know that you are editing Ruby code so you don't get any syntax highlighting or formatting.

## Solution

This change adds a `.rb` extension to the tempfile opened by the editor which then ensures you get the correct syntax highlighting and formatting.

## Demo

See the following demo to see how this changes things:

https://github.com/user-attachments/assets/86efdafd-f545-419e-936e-6baa47648029
