### PR TITLE
Removed redundant argument at Reline::LineEditor::CompletionBlockTest

### DIFF
--- a/test/reline/test_line_editor.rb
+++ b/test/reline/test_line_editor.rb
@@ -8,7 +8,7 @@ class Reline::LineEditor
     def setup
       @original_quote_characters = Reline.completer_quote_characters
       @original_word_break_characters = Reline.completer_word_break_characters
-      @line_editor = Reline::LineEditor.new(nil, Encoding::UTF_8)
+      @line_editor = Reline::LineEditor.new(nil)
     end
 
     def retrieve_completion_block(lines, line_index, byte_pointer)


### PR DESCRIPTION
* http://rubyci.s3.amazonaws.com/ubuntu/ruby-master/log/20241124T211003Z.fail.html.gz
* https://github.com/ruby/ruby/actions/runs/11997494018/job/33443159770