### PR TITLE
Fix tab completion appending quote

### DIFF
--- a/test/reline/helper.rb
+++ b/test/reline/helper.rb
@@ -135,6 +135,13 @@ class Reline::TestCase < Test::Unit::TestCase
     end
   end
 
+  def set_line_around_cursor(before, after)
+    input_keys("\C-a\C-k")
+    input_keys(after)
+    input_keys("\C-a")
+    input_keys(before)
+  end
+
   def assert_line_around_cursor(before, after)
     before = convert_str(before)
     after = convert_str(after)

--- a/test/reline/test_key_actor_emacs.rb
+++ b/test/reline/test_key_actor_emacs.rb
@@ -933,6 +933,30 @@ class Reline::KeyActor::EmacsTest < Reline::TestCase
     assert_line_around_cursor('foo_fooX foo_barX', '')
   end
 
+  def test_completion_with_quote_append
+    @line_editor.completion_proc = proc { |word|
+      %w[foo bar baz].select { |s| s.start_with? word }
+    }
+    set_line_around_cursor('x = "b', '')
+    input_keys("\C-i", false)
+    assert_line_around_cursor('x = "ba', '')
+    set_line_around_cursor('x = "f', ' ')
+    input_keys("\C-i", false)
+    assert_line_around_cursor('x = "foo', ' ')
+    set_line_around_cursor("x = 'f", '')
+    input_keys("\C-i", false)
+    assert_line_around_cursor("x = 'foo'", '')
+    set_line_around_cursor('"a "f', '')
+    input_keys("\C-i", false)
+    assert_line_around_cursor('"a "foo', '')
+    set_line_around_cursor('"a\\" "f', '')
+    input_keys("\C-i", false)
+    assert_line_around_cursor('"a\\" "foo', '')
+    set_line_around_cursor('"a" "f', '')
+    input_keys("\C-i", false)
+    assert_line_around_cursor('"a" "foo"', '')
+  end
+
   def test_completion_with_completion_ignore_case
     @line_editor.completion_proc = proc { |word|
       %w{

--- a/test/reline/test_line_editor.rb
+++ b/test/reline/test_line_editor.rb
@@ -15,16 +15,12 @@ class Reline::LineEditor
       @line_editor.instance_variable_set(:@buffer_of_lines, lines)
       @line_editor.instance_variable_set(:@line_index, line_index)
       @line_editor.instance_variable_set(:@byte_pointer, byte_pointer)
-      @line_editor.retrieve_completion_block(false)
+      @line_editor.retrieve_completion_block
     end
 
     def retrieve_completion_quote(line)
-      retrieve_completion_block([line], 0, line.bytesize)
-      _, target = @line_editor.retrieve_completion_block(false)
-      _, target2 = @line_editor.retrieve_completion_block(true)
-      # This is a hack to get the quoted character.
-      # retrieve_completion_block should be refactored to return the quoted character.
-      target2.chars.last if target2 != target
+      _, _, _, quote = retrieve_completion_block([line], 0, line.bytesize)
+      quote
     end
 
     def teardown
@@ -35,20 +31,20 @@ class Reline::LineEditor
     def test_retrieve_completion_block
       Reline.completer_word_break_characters = ' ([{'
       Reline.completer_quote_characters = ''
-      assert_equal(['', '', 'foo'], retrieve_completion_block(['foo'], 0, 0))
-      assert_equal(['', 'f', 'oo'], retrieve_completion_block(['foo'], 0, 1))
-      assert_equal(['foo ', 'ba', 'r baz'], retrieve_completion_block(['foo bar baz'], 0, 6))
-      assert_equal(['foo([', 'b', 'ar])baz'], retrieve_completion_block(['foo([bar])baz'], 0, 6))
-      assert_equal(['foo([{', '', '}])baz'], retrieve_completion_block(['foo([{}])baz'], 0, 6))
-      assert_equal(["abc\nfoo ", 'ba', "r baz\ndef"], retrieve_completion_block(['abc', 'foo bar baz', 'def'], 1, 6))
+      assert_equal(['', '', 'foo', nil], retrieve_completion_block(['foo'], 0, 0))
+      assert_equal(['', 'f', 'oo', nil], retrieve_completion_block(['foo'], 0, 1))
+      assert_equal(['foo ', 'ba', 'r baz', nil], retrieve_completion_block(['foo bar baz'], 0, 6))
+      assert_equal(['foo([', 'b', 'ar])baz', nil], retrieve_completion_block(['foo([bar])baz'], 0, 6))
+      assert_equal(['foo([{', '', '}])baz', nil], retrieve_completion_block(['foo([{}])baz'], 0, 6))
+      assert_equal(["abc\nfoo ", 'ba', "r baz\ndef", nil], retrieve_completion_block(['abc', 'foo bar baz', 'def'], 1, 6))
     end
 
     def test_retrieve_completion_block_with_quote_characters
       Reline.completer_word_break_characters = ' ([{'
       Reline.completer_quote_characters = ''
-      assert_equal(['"" ', '"wo', 'rd'], retrieve_completion_block(['"" "word'], 0, 6))
+      assert_equal(['"" ', '"wo', 'rd', nil], retrieve_completion_block(['"" "word'], 0, 6))
       Reline.completer_quote_characters = '"'
-      assert_equal(['"" "', 'wo', 'rd'], retrieve_completion_block(['"" "word'], 0, 6))
+      assert_equal(['"" "', 'wo', 'rd', nil], retrieve_completion_block(['"" "word'], 0, 6))
     end
 
     def test_retrieve_completion_quote

--- a/test/reline/test_string_processing.rb
+++ b/test/reline/test_string_processing.rb
@@ -29,40 +29,18 @@ class Reline::LineEditor::StringProcessingTest < Reline::TestCase
 
     @line_editor.instance_variable_set(:@is_multiline, true)
     @line_editor.instance_variable_set(:@buffer_of_lines, buf)
-    @line_editor.instance_variable_set(:@byte_pointer, 3)
-    @line_editor.instance_variable_set(:@line_index, 1)
-    @line_editor.instance_variable_set(:@completion_proc, proc { |target|
-      assert_equal('p', target)
-    })
-    @line_editor.__send__(:call_completion_proc)
-
-    @line_editor.instance_variable_set(:@is_multiline, true)
-    @line_editor.instance_variable_set(:@buffer_of_lines, buf)
     @line_editor.instance_variable_set(:@byte_pointer, 6)
     @line_editor.instance_variable_set(:@line_index, 1)
+    completion_proc_called = false
     @line_editor.instance_variable_set(:@completion_proc, proc { |target, pre, post|
       assert_equal('puts', target)
       assert_equal("def hoge\n  ", pre)
       assert_equal(" :aaa\nend", post)
+      completion_proc_called = true
     })
-    @line_editor.__send__(:call_completion_proc)
 
-    @line_editor.instance_variable_set(:@byte_pointer, 6)
-    @line_editor.instance_variable_set(:@line_index, 0)
-    @line_editor.instance_variable_set(:@completion_proc, proc { |target, pre, post|
-      assert_equal('ho', target)
-      assert_equal('def ', pre)
-      assert_equal("ge\n  puts :aaa\nend", post)
-    })
-    @line_editor.__send__(:call_completion_proc)
-
-    @line_editor.instance_variable_set(:@byte_pointer, 1)
-    @line_editor.instance_variable_set(:@line_index, 2)
-    @line_editor.instance_variable_set(:@completion_proc, proc { |target, pre, post|
-      assert_equal('e', target)
-      assert_equal("def hoge\n  puts :aaa\n", pre)
-      assert_equal('nd', post)
-    })
-    @line_editor.__send__(:call_completion_proc)
+    assert_equal(["def hoge\n  ", 'puts', " :aaa\nend", nil], @line_editor.retrieve_completion_block)
+    @line_editor.__send__(:call_completion_proc, "def hoge\n  ", 'puts', " :aaa\nend", nil)
+    assert(completion_proc_called)
   end
 end


### PR DESCRIPTION
Fixes #444

When complecion candidates are `%w[foo bar baz]`
| input before tab complete | master | this pull request | readline-ext |
| --- | --- | --- | --- |
| `x = "f█` |  `x = "f"█` | `x = "foo"█` | same |
| `x = 'f█` | `x = 'f'█` |`x = 'foo'█` | same |
| `x = "b█` | `x = "b"█` | `x = "ba█` | same |
| `["a", "f█` | `["a", "f"█` | `["a", "foo"█` | same |
| `["a"b", "f█` | `["a"b", "f█` | `["a"b", "foo█` | `["a"b", "foo"█` |
| `["a\"b", "f█` | `["a\"b", "f"█` | `["a\"b", "foo"█` | same |
| `x = "f█ bar baz` | `x = "f"█ bar baz` | `x = "foo█ bar baz` | same |

```ruby
require 'readline'
Readline.completion_proc = proc { |word,preposing|
  %w[foo bar baz].select { |w| w.start_with?(word) }
}
Readline.readline('> ')
```