### PR TITLE
Extract TruffleRuby workflow from reline.yml

### DIFF
--- a/.github/workflows/truffle-ruby-test.yml
+++ b/.github/workflows/truffle-ruby-test.yml
@@ -1,8 +1,9 @@
-name: CI
+name: build-with-truffleruby-head
 
 on:
   push:
   pull_request:
+  workflow_dispatch:
   schedule:
     - cron: "30 14 * * *"
 
@@ -10,7 +11,7 @@ jobs:
   ruby-versions:
     uses: ruby/actions/.github/workflows/ruby_versions.yml@master
     with:
-      engine: cruby
+      engine: cruby-truffleruby
       min_version: 2.6
 
   reline:
@@ -21,8 +22,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        ruby: [truffleruby-head]
+        os: [ubuntu-latest, macos-latest]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -41,37 +42,6 @@ jobs:
           TERM: xterm-256color
         run: bundle exec rake test RUBYOPT="--enable-frozen-string-literal"
 
-  readline:
-    name: >-
-      readline ${{ matrix.ruby }}  ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - { ruby: head, os: ubuntu-latest }
-          - { ruby: head, os: macos-latest }
-          - { ruby: mingw, os: windows-latest }
-          - { ruby: mswin, os: windows-latest }
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby }}
-      - name: Install dependencies
-        run: bundle install
-      - name: Download test readline
-        run: ruby download-test_readline.rb
-      - name: rake test
-        run: bundle exec rake test
-      - name: rake ci-test
-        env:
-          TEST_READLINE_OR_RELINE: Reline
-          TERM: xterm-256color
-        run: bundle exec rake ci-test
-
   irb:
     needs: ruby-versions
     name: >-
@@ -80,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
+        ruby: [truffleruby-head]
         os: [ubuntu-latest]
         exclude:
           - ruby: 2.6
@@ -112,14 +82,6 @@ jobs:
         run: |
           bundle install
           bundle exec rake test
-      - name: Run irb yamatanooroti test
-        working-directory: ./irb
-        env:
-          WITH_VTERM: 1
-        run: |
-          gem rdoc --all --ri --no-rdoc
-          bundle install
-          bundle exec rake test_yamatanooroti
 
   vterm-yamatanooroti:
     needs: ruby-versions
@@ -129,7 +91,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
+        ruby: [truffleruby-head]
         os: [ubuntu-latest]
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
Background: https://github.com/ruby/irb/issues/1032
Ref: https://github.com/ruby/irb/pull/1035

Similar to IRB, I have separated the TruffleRuby workflow from reline.yml.