### PR TITLE
Fix io_gate.encoding raises IOError in ruby <= 3.0

### DIFF
--- a/lib/reline/io/ansi.rb
+++ b/lib/reline/io/ansi.rb
@@ -38,6 +38,9 @@ class Reline::ANSI < Reline::IO
 
   def encoding
     @input.external_encoding || Encoding.default_external
+  rescue IOError
+    # STDIN.external_encoding raises IOError in Ruby <= 3.0 when STDIN is closed
+    Encoding.default_external
   end
 
   def set_default_key_bindings(config)

--- a/lib/reline/io/dumb.rb
+++ b/lib/reline/io/dumb.rb
@@ -21,8 +21,11 @@ class Reline::Dumb < Reline::IO
     elsif RUBY_PLATFORM =~ /mswin|mingw/
       Encoding::UTF_8
     else
-      @input.external_encoding || Encoding::default_external
+      @input.external_encoding || Encoding.default_external
     end
+  rescue IOError
+    # STDIN.external_encoding raises IOError in Ruby <= 3.0 when STDIN is closed
+    Encoding.default_external
   end
 
   def set_default_key_bindings(_)


### PR DESCRIPTION
In Ruby <= 3.0, STDIN.external_encoding raises IOError when STDIN is closed.
readline-ext test seems failing with this
https://github.com/ruby/readline-ext/actions/runs/12054933292