### PR TITLE
Don't skip start_with check on encoding-incompatible candidates

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -812,8 +812,6 @@ class Reline::LineEditor
         if defined?(::Readline) && ::Readline == ::Reline
           raise Encoding::CompatibilityError, "incompatible character encodings: #{target.encoding} and #{item.encoding}"
         end
-
-        next true
       end
 
       if @config.completion_ignore_case


### PR DESCRIPTION
When target and candidate encoding is incompatible, `item.start_with?(target)` check was skipped.