### PR TITLE
Implement buffered output to Reline::ANSI

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -181,9 +181,7 @@ module Reline
     def output=(val)
       raise TypeError unless val.respond_to?(:write) or val.nil?
       @output = val
-      if io_gate.respond_to?(:output=)
-        io_gate.output = val
-      end
+      io_gate.output = val
     end
 
     def vi_editing_mode
@@ -317,7 +315,6 @@ module Reline
       else
         line_editor.multiline_off
       end
-      line_editor.output = output
       line_editor.completion_proc = completion_proc
       line_editor.completion_append_character = completion_append_character
       line_editor.output_modifier_proc = output_modifier_proc

--- a/lib/reline/io/dumb.rb
+++ b/lib/reline/io/dumb.rb
@@ -3,8 +3,11 @@ require 'io/wait'
 class Reline::Dumb < Reline::IO
   RESET_COLOR = '' # Do not send color reset sequence
 
+  attr_writer :output
+
   def initialize(encoding: nil)
     @input = STDIN
+    @output = STDOUT
     @buf = []
     @pasting = false
     @encoding = encoding
@@ -36,6 +39,14 @@ class Reline::Dumb < Reline::IO
   end
 
   def with_raw_input
+    yield
+  end
+
+  def write(string)
+    @output.write(string)
+  end
+
+  def buffered_output
     yield
   end
 

--- a/lib/reline/io/windows.rb
+++ b/lib/reline/io/windows.rb
@@ -1,6 +1,9 @@
 require 'fiddle/import'
 
 class Reline::Windows < Reline::IO
+
+  attr_writer :output
+
   def initialize
     @input_buf = []
     @output_buf = []
@@ -305,6 +308,14 @@ class Reline::Windows < Reline::IO
   end
 
   def with_raw_input
+    yield
+  end
+
+  def write(string)
+    @output.write(string)
+  end
+
+  def buffered_output
     yield
   end
 

--- a/test/reline/test_line_editor.rb
+++ b/test/reline/test_line_editor.rb
@@ -61,6 +61,10 @@ class Reline::LineEditor
 
   class RenderLineDifferentialTest < Reline::TestCase
     class TestIO < Reline::IO
+      def write(string)
+        @output << string
+      end
+
       def move_cursor_column(col)
         @output << "[COL_#{col}]"
       end
@@ -76,7 +80,6 @@ class Reline::LineEditor
       @original_iogate = Reline::IOGate
       @output = StringIO.new
       @line_editor.instance_variable_set(:@screen_size, [24, 80])
-      @line_editor.instance_variable_set(:@output, @output)
       Reline.send(:remove_const, :IOGate)
       Reline.const_set(:IOGate, TestIO.new)
       Reline::IOGate.instance_variable_set(:@output, @output)

--- a/test/reline/test_macro.rb
+++ b/test/reline/test_macro.rb
@@ -6,7 +6,7 @@ class Reline::MacroTest < Reline::TestCase
     @config = Reline::Config.new
     @encoding = Reline.core.encoding
     @line_editor = Reline::LineEditor.new(@config)
-    @output = @line_editor.output = File.open(IO::NULL, "w")
+    @output = Reline::IOGate.output = File.open(IO::NULL, "w")
   end
 
   def teardown


### PR DESCRIPTION
Rendering gets slow after you enter `Thread.new{loop{}}` to IRB.
Every `STDOUT.write` call seems to pass execution to the cpu bound thread, making rendering slow.
Minimizing the number of STDOUT.write call will improve it.

Before
https://github.com/user-attachments/assets/b34dd1f2-bb79-4373-88d5-353fda2fe3bf

After
https://github.com/user-attachments/assets/a33f2e01-2591-4d45-84f5-6f43d1a067da


While trying `Thread.new{loop{}}`, be careful not to press TAB key. Loading RDoc document will hang up.