### PR TITLE
Fix line wrapped cursor position

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -436,7 +436,7 @@ class Reline::LineEditor
   # Calculate cursor position in word wrapped content.
   def wrapped_cursor_position
     prompt_width = calculate_width(prompt_list[@line_index], true)
-    line_before_cursor = whole_lines[@line_index].byteslice(0, @byte_pointer)
+    line_before_cursor = Reline::Unicode.escape_for_print(whole_lines[@line_index].byteslice(0, @byte_pointer))
     wrapped_line_before_cursor = split_line_by_width(' ' * prompt_width + line_before_cursor, screen_width)
     wrapped_cursor_y = wrapped_prompt_and_input_lines[0...@line_index].sum(&:size) + wrapped_line_before_cursor.size - 1
     wrapped_cursor_x = calculate_width(wrapped_line_before_cursor.last)

--- a/test/reline/test_line_editor.rb
+++ b/test/reline/test_line_editor.rb
@@ -59,6 +59,35 @@ class Reline::LineEditor
     end
   end
 
+  class CursorPositionTest < Reline::TestCase
+    def setup
+      @line_editor = Reline::LineEditor.new(nil)
+      @line_editor.instance_variable_set(:@config, Reline::Config.new)
+    end
+
+    def test_cursor_position_with_escaped_input
+      @line_editor.instance_variable_set(:@screen_size, [4, 16])
+      @line_editor.instance_variable_set(:@prompt, "\e[1mprompt\e[0m> ")
+      @line_editor.instance_variable_set(:@buffer_of_lines, ["\e[1m\0\1\2\3\4\5\6\7abcd"])
+      @line_editor.instance_variable_set(:@line_index, 0)
+      # prompt> ^[[1m^@^
+      # A^B^C^D^E^F^Gabc
+      # d
+      @line_editor.instance_variable_set(:@byte_pointer, 0)
+      assert_equal [8, 0], @line_editor.wrapped_cursor_position
+      @line_editor.instance_variable_set(:@byte_pointer, 5)
+      assert_equal [15, 0], @line_editor.wrapped_cursor_position
+      @line_editor.instance_variable_set(:@byte_pointer, 6)
+      assert_equal [1, 1], @line_editor.wrapped_cursor_position
+      @line_editor.instance_variable_set(:@byte_pointer, 14)
+      assert_equal [15, 1], @line_editor.wrapped_cursor_position
+      @line_editor.instance_variable_set(:@byte_pointer, 15)
+      assert_equal [0, 2], @line_editor.wrapped_cursor_position
+      @line_editor.instance_variable_set(:@byte_pointer, 16)
+      assert_equal [1, 2], @line_editor.wrapped_cursor_position
+    end
+  end
+
   class RenderLineDifferentialTest < Reline::TestCase
     class TestIO < Reline::IO
       def write(string)


### PR DESCRIPTION
Cursor position calculation was wrong when the input line contains `"\1"` or CSI escape sequence.

Input: `"\C-v\C-a\C-v\C-a\C-v\C-a\C-v\C-a\C-v\C-a\C-v\C-a\C-v\C-a"`
Expected cursor position: just after closing quote

Reline version: `"0.5.0".."0.5.10"` 
![cursorpos_0_5_0](https://github.com/user-attachments/assets/ebc208b5-e1e5-469a-8f44-8c96d2b219cc)
Reline version: `"0.5.11".."0.5.12"` 
![cursorpos_0_5_12](https://github.com/user-attachments/assets/560540f1-7dad-4da4-ac8f-fa018873ddc3)
This pull request
![cursorpos_pullreq](https://github.com/user-attachments/assets/99be3321-568d-4c26-b454-b3ea5dbb4d40)

