### PR TITLE
Change quoted_insert and bracketed_paste to a single key input

### DIFF
--- a/lib/reline/io.rb
+++ b/lib/reline/io.rb
@@ -35,6 +35,20 @@ module Reline
     def reset_color_sequence
       self.class::RESET_COLOR
     end
+
+    # Read a single encoding valid character from the input.
+    def read_single_char(keyseq_timeout)
+      buffer = String.new(encoding: Encoding::ASCII_8BIT)
+      loop do
+        timeout = buffer.empty? ? Float::INFINITY : keyseq_timeout
+        c = getc(timeout)
+        return unless c
+
+        buffer << c
+        encoded = buffer.dup.force_encoding(encoding)
+        return encoded if encoded.valid_encoding?
+      end
+    end
   end
 end
 

--- a/lib/reline/key_actor/vi_insert.rb
+++ b/lib/reline/key_actor/vi_insert.rb
@@ -97,25 +97,25 @@ module Reline::KeyActor
     #  47 /
     :ed_insert,
     #  48 0
-    :ed_insert,
+    :ed_digit,
     #  49 1
-    :ed_insert,
+    :ed_digit,
     #  50 2
-    :ed_insert,
+    :ed_digit,
     #  51 3
-    :ed_insert,
+    :ed_digit,
     #  52 4
-    :ed_insert,
+    :ed_digit,
     #  53 5
-    :ed_insert,
+    :ed_digit,
     #  54 6
-    :ed_insert,
+    :ed_digit,
     #  55 7
-    :ed_insert,
+    :ed_digit,
     #  56 8
-    :ed_insert,
+    :ed_digit,
     #  57 9
-    :ed_insert,
+    :ed_digit,
     #  58 :
     :ed_insert,
     #  59 ;

--- a/test/reline/helper.rb
+++ b/test/reline/helper.rb
@@ -108,9 +108,9 @@ class Reline::TestCase < Test::Unit::TestCase
     input
   end
 
-  def input_key_by_symbol(method_symbol, csi: false)
-    dummy_char = csi ? "\e[A" : "\C-a"
-    @line_editor.input_key(Reline::Key.new(dummy_char, method_symbol, false))
+  def input_key_by_symbol(method_symbol, char: nil, csi: false)
+    char ||= csi ? "\e[A" : "\C-a"
+    @line_editor.input_key(Reline::Key.new(char, method_symbol, false))
   end
 
   def input_keys(input, convert = true)

--- a/test/reline/test_key_actor_emacs.rb
+++ b/test/reline/test_key_actor_emacs.rb
@@ -138,11 +138,25 @@ class Reline::KeyActor::EmacsTest < Reline::TestCase
     assert_line_around_cursor("か\u3099", '')
   end
 
+  def test_bracketed_paste_insert
+    set_line_around_cursor('A', 'Z')
+    input_key_by_symbol(:insert_multiline_text, char: "abc\n\C-abc")
+    assert_whole_lines(['Aabc', "\C-abcZ"])
+    assert_line_around_cursor("\C-abc", 'Z')
+  end
+
   def test_ed_quoted_insert
-    input_keys("ab\C-v\C-acd")
-    assert_line_around_cursor("ab\C-acd", '')
-    input_keys("\C-q\C-b")
-    assert_line_around_cursor("ab\C-acd\C-b", '')
+    set_line_around_cursor('A', 'Z')
+    input_key_by_symbol(:insert_raw_char, char: "\C-a")
+    assert_line_around_cursor("A\C-a", 'Z')
+  end
+
+  def test_ed_quoted_insert_with_vi_arg
+    input_keys("a\C-[3")
+    input_key_by_symbol(:insert_raw_char, char: "\C-a")
+    input_keys("b\C-[4")
+    input_key_by_symbol(:insert_raw_char, char: '1')
+    assert_line_around_cursor("a\C-a\C-a\C-ab1111", '')
   end
 
   def test_ed_kill_line
@@ -1474,7 +1488,9 @@ class Reline::KeyActor::EmacsTest < Reline::TestCase
   end
 
   def test_ignore_NUL_by_ed_quoted_insert
-    input_keys(%Q{"\C-v\C-@"}, false)
+    input_keys('"')
+    input_key_by_symbol(:insert_raw_char, char: 0.chr)
+    input_keys('"')
     assert_line_around_cursor('""', '')
   end
 

--- a/test/reline/test_key_actor_vi.rb
+++ b/test/reline/test_key_actor_vi.rb
@@ -344,13 +344,17 @@ class Reline::ViInsertTest < Reline::TestCase
   end
 
   def test_ed_quoted_insert
-    input_keys("ab\C-v\C-acd")
-    assert_line_around_cursor("ab\C-acd", '')
+    input_keys('ab')
+    input_key_by_symbol(:insert_raw_char, char: "\C-a")
+    assert_line_around_cursor("ab\C-a", '')
   end
 
   def test_ed_quoted_insert_with_vi_arg
-    input_keys("ab\C-[3\C-v\C-aacd")
-    assert_line_around_cursor("a\C-a\C-a\C-abcd", '')
+    input_keys("ab\C-[3")
+    input_key_by_symbol(:insert_raw_char, char: "\C-a")
+    input_keys('4')
+    input_key_by_symbol(:insert_raw_char, char: '1')
+    assert_line_around_cursor("a\C-a\C-a\C-a1111", 'b')
   end
 
   def test_vi_replace_char


### PR DESCRIPTION
Bracketed paste will be changed to `Reline::Key.new(pasted_content, :insert_multiline_text)`.
This will simplify handling undo/redo of bracketed paste.

Quoted insert will be changed to `Reline::Key.new(char_to_be_inserted, :insert_raw_char)`.
`def ed_quoted_insert`(renamed to `insert_raw_char`) does not need to use `waiting_proc` anymore.
