### PR TITLE
Undo and redo should restore indentation

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -252,7 +252,7 @@ class Reline::LineEditor
     @rendered_screen = RenderedScreen.new(base_y: 0, lines: [], cursor_y: 0)
     @input_lines = [[[""], 0, 0]]
     @input_lines_position = 0
-    @undoing = false
+    @restoring = false
     @prev_action_state = NullActionState
     @next_action_state = NullActionState
     reset_line
@@ -1070,8 +1070,8 @@ class Reline::LineEditor
       @completion_journey_state = nil
     end
 
-    push_input_lines unless @undoing
-    @undoing = false
+    push_input_lines unless @restoring
+    @restoring = false
 
     if @in_pasting
       clear_dialogs
@@ -2357,7 +2357,7 @@ class Reline::LineEditor
   end
 
   private def move_undo_redo(direction)
-    @undoing = true
+    @restoring = true
     return unless (0..@input_lines.size - 1).cover?(@input_lines_position + direction)
 
     @input_lines_position += direction

--- a/test/reline/test_key_actor_emacs.rb
+++ b/test/reline/test_key_actor_emacs.rb
@@ -1676,6 +1676,20 @@ class Reline::KeyActor::EmacsTest < Reline::TestCase
     assert_line_around_cursor('3', '')
   end
 
+  def test_undo_redo_restores_indentation
+    @line_editor.multiline_on
+    @line_editor.confirm_multiline_termination_proc = proc {}
+    input_keys(" 1", false)
+    assert_whole_lines([' 1'])
+    input_keys("2", false)
+    assert_whole_lines([' 12'])
+    @line_editor.auto_indent_proc = proc { 2 }
+    input_keys("\C-_", false)
+    assert_whole_lines([' 1'])
+    input_keys("\M-\C-_", false)
+    assert_whole_lines([' 12'])
+  end
+
   def test_redo_with_many_times
     str = "a" + "b" * 98 + "c"
     input_keys(str, false)


### PR DESCRIPTION
Undo and redo should not perform auto indentation. It should not change the indentation. Instead, it should restore previous indentation and revert to the previous state.

```
irb(main):001>
```
Paste `"  1\n  2"`
```
irb(main):001>   1
irb(main):002>   2
```
Paste `"  1\n  2"`
```
irb(main):001>   1
irb(main):002>   2  1
irb(main):003>   2
```
Undo
```
before
irb(main):001>   1
irb(main):002> 2

after
irb(main):001>   1
irb(main):002>   2
```
Redo
```
before
irb(main):001>   1
irb(main):002>   2  1
irb(main):003> 2

after
irb(main):001>   1
irb(main):002>   2  1
irb(main):003>   2
```