### PR TITLE
Refactor handling key in LineEditor

### DIFF
--- a/test/reline/test_key_actor_emacs.rb
+++ b/test/reline/test_key_actor_emacs.rb
@@ -1502,6 +1502,16 @@ class Reline::KeyActor::EmacsTest < Reline::TestCase
     assert_line_around_cursor('abcd', '')
   end
 
+  def test_ed_digit_with_ed_argument_digit
+    input_keys('1' * 30)
+    assert_line_around_cursor('1' * 30, '')
+    input_keys("\M-2", false)
+    input_keys('3')
+    input_keys("\C-h", false)
+    input_keys('4')
+    assert_line_around_cursor('1' * 7 + '4', '')
+  end
+
   def test_halfwidth_kana_width_dakuten
     omit "This test is for UTF-8 but the locale is #{Reline.core.encoding}" if Reline.core.encoding != Encoding::UTF_8
     input_raw_keys('ｶﾞｷﾞｹﾞｺﾞ')


### PR DESCRIPTION
Simplify the complicated flow of waiting_proc, wrap_method_call and run_for_operation.


1. Block passed to run_for_operators was always the same. Change to just simply call `wrap_method_call`.
2. Stop passing `method_obj` to another method.
3. wrap_method_call now handles waiting_proc (to reduce duplicated code)
4. Reduce duplicated code in `process_key`
5. Reduce duplicated code that handles `@vi_waiting_operator` in `process_key` and in `run_for_operators`
6. Use `__send__` instead of `wrap_method_call(@vi_waiting_operator, ...)`  because `@vi_waiting_operator` is not a key-bounded method.
7. Stop calling `ed_argument_digit` in specific condition. Instead, implement vi_zero and ed_digit correctly.