### PR TITLE
Fix bracketed paste and scrolling bug

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -341,7 +341,6 @@ module Reline
         line_editor.set_signal_handlers
         loop do
           read_io(config.keyseq_timeout) { |inputs|
-            line_editor.set_pasting_state(io_gate.in_pasting?)
             inputs.each do |key|
               case key.method_symbol
               when :bracketed_paste_start
@@ -350,6 +349,7 @@ module Reline
               when :quoted_insert, :ed_quoted_insert
                 key = Reline::Key.new(io_gate.read_single_char(config.keyseq_timeout), :insert_raw_char)
               end
+              line_editor.set_pasting_state(io_gate.in_pasting?)
               line_editor.update(key)
             end
           }
@@ -357,7 +357,6 @@ module Reline
             line_editor.render_finished
             break
           else
-            line_editor.set_pasting_state(io_gate.in_pasting?)
             line_editor.rerender
           end
         end

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -542,6 +542,7 @@ class Reline::LineEditor
       Reline::IOGate.show_cursor
     end
     Reline::IOGate.move_cursor_column new_cursor_x
+    new_cursor_y = new_cursor_y.clamp(0, screen_height - 1)
     Reline::IOGate.move_cursor_down new_cursor_y - cursor_y
     @rendered_screen.cursor_y = new_cursor_y
   ensure

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -550,6 +550,14 @@ begin
         prompt>   3
         prompt> end
       EOC
+      write("\e[200~.tap do\r\t4\r\t5\rend\e[201~")
+      assert_screen(<<~EOC)
+        prompt>   3
+        prompt> end.tap do
+        prompt>   4
+        prompt>   5
+        prompt> end
+      EOC
       close
     end
 


### PR DESCRIPTION
### Reproduce
Pasting 10 lines of code into terminal with screen height = 5

```
Actual screen (Reline 0.6.0)
irb(main):001> 1.tap do
irb(main):002>   2
irb(main):003>   3 
irb(main):004>   4
irb(main):005>   5█

Expected screen (Reline <= 0.5.12)
irb(main):006>   6
irb(main):007>   7
irb(main):008>   8 
irb(main):009>   9
irb(main):010> end█
```

2. If you press Ctrl+C, irb crashes with the error below. Pressing other key will update the screen to the expected result.
```
/Users/tomoya.ishida/.rbenv/versions/3.4.1/lib/ruby/3.4.0/reline/io/ansi.rb:289:in 'String#*': negative argument (ArgumentError)

    write "\n" * x
                 ^
	from /Users/tomoya.ishida/.rbenv/versions/3.4.1/lib/ruby/3.4.0/reline/io/ansi.rb:289:in 'Reline::ANSI#scroll_down'
	from /Users/tomoya.ishida/.rbenv/versions/3.4.1/lib/ruby/3.4.0/reline/line_editor.rb:192:in 'Reline::LineEditor#handle_interrupted'
	from /Users/tomoya.ishida/.rbenv/versions/3.4.1/lib/ruby/3.4.0/reline/line_editor.rb:169:in 'Reline::LineEditor#handle_signal'
```

### Reason

```ruby
# Set pasting=true because the content of bracketed_paste is not read from stdin
line_editor.set_pasting_state(io_gate.in_pasting?)

inputs.each do |key| # inputs.size is always 1 if you don't have custom .inputrc file
  ...
  key = Reline::Key.new(io_gate.read_bracketed_paste, :insert_multiline_text) # everything is all read from stdin
  ...
  # Calls update with pasting state = true. In this case, scroll_into_view is skipped (Bug1)
  line_editor.update(key)
end

# set pasting state to false
line_editor.set_pasting_state(io_gate.in_pasting?)
# renders the screen with cursor out of the screen. rendered_screen.cursor_y will be larger than screen height (Bug2)
line_editor.rerender
```

### Fixes
Bug1: scroll_into_view wrongly skipped, is fixed by the change in lib/reline.rb
Bug2: Fixed in lib/line_editor.rb, in case of other unknown bug that cause calling render with cursor position out of the screen.
