### PR TITLE
Enter newline if cursor position is middle of input

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -1684,6 +1684,11 @@ class Reline::LineEditor
     end
   end
 
+  private def ed_force_submit(_key)
+    process_insert(force: true)
+    finish
+  end
+
   private def em_delete_prev_char(key, arg: 1)
     arg.times do
       if @byte_pointer == 0 and @line_index > 0

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -1673,17 +1673,10 @@ class Reline::LineEditor
           finish
         end
       else
-        if @line_index == (@buffer_of_lines.size - 1)
-          if confirm_multiline_termination
-            finish
-          else
-            key_newline(key)
-          end
-        else
-          # should check confirm_multiline_termination to finish?
-          @line_index = @buffer_of_lines.size - 1
-          @byte_pointer = current_line.bytesize
+        if @line_index == @buffer_of_lines.size - 1 && confirm_multiline_termination
           finish
+        else
+          key_newline(key)
         end
       end
     else

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -813,15 +813,15 @@ begin
       close
     end
 
-    def test_terminate_in_the_middle_of_lines
+    def test_newline_in_the_middle_of_lines
       start_terminal(5, 20, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
       write("def hoge\n  1\n  2\n  3\n  4\nend\n")
       write("\C-p\C-p\C-p\C-e\n")
       assert_screen(<<~EOC)
+        prompt> def hoge
+        prompt>   1
+        prompt>   2
         prompt>   3
-        prompt>   4
-        prompt> end
-        => :hoge
         prompt>
       EOC
       close

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -827,6 +827,23 @@ begin
       close
     end
 
+    def test_ed_force_submit_in_the_middle_of_lines
+      write_inputrc <<~LINES
+        "\\C-a": ed_force_submit
+      LINES
+      start_terminal(5, 20, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
+      write("def hoge\nend")
+      write("\C-p\C-a")
+      assert_screen(<<~EOC)
+        Multiline REPL.
+        prompt> def hoge
+        prompt> end
+        => :hoge
+        prompt>
+      EOC
+      close
+    end
+
     def test_dynamic_prompt_returns_empty
       start_terminal(5, 20, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --dynamic-prompt-returns-empty}, startup_message: 'Multiline REPL.')
       write("def hoge\nend\n")


### PR DESCRIPTION
I have changed the Enter key behavior so that pressing Enter in the middle of a line adds a new line even if the input can be confirmed. Pressing Enter at the end of a line will confirm the input as before.
If you prefer the previous behavior, you can set `ed_force_newline` in inputrc to allow confirmation when pressing Enter in the middle of a line. The existing Alt+Enter functionality remains unchanged.

https://github.com/user-attachments/assets/f326345b-540b-45e8-ba1f-705f61177bd6

