### PR TITLE
Set default value for Reline.input, Reline.output and Reline.special_prefixes

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -114,7 +114,11 @@ module Reline
     end
 
     def special_prefixes=(v)
-      @special_prefixes = v.encode(encoding)
+      if v.nil?
+        @special_prefixes = ''
+      else
+        @special_prefixes = v.encode(encoding)
+      end
     end
 
     def completion_case_fold=(v)
@@ -174,14 +178,25 @@ module Reline
     end
 
     def input=(val)
-      raise TypeError unless val.respond_to?(:getc) or val.nil?
+      raise TypeError unless val.respond_to?(:getc)
       if val.respond_to?(:getc) && io_gate.respond_to?(:input=)
         io_gate.input = val
+      elsif val.nil?
+        io_gate.input = STDIN
+        return
+      else
+        # noop
+        # Reline::Windows does not suppport input= method
       end
     end
 
     def output=(val)
-      raise TypeError unless val.respond_to?(:write) or val.nil?
+      if val.nil?
+        val = STDOUT
+      elsif !val.respond_to?(:write)
+        raise TypeError
+      end
+
       @output = val
       io_gate.output = val
     end


### PR DESCRIPTION
Close https://github.com/ruby/reline/issues/774

I have changed that default values are assigned to `Reline.input=`, `Reline.output=`, and `Reline.special_prefixes=` when `nil` is passed to these methods. This change aligns the behavior of Reline with that of readline-ext. 

readline-ext sets `special_prefixes=nil` to nil, but I think the method name suggests that a string is expected. `Reline.special_prefixes` has been modified to default to an empty string instead of `nil`.

```
❯ ASDF_RUBY_VERSION=2.6.10 irb
irb(main):001> Readline.special_prefixes = nil
nil
irb(main):002> Readline.special_prefixes
nil
```

## readline-ext

https://github.com/ruby/readline-ext/blob/9ee1b1a2f848ebb98b8ea07969a100dd24548411/ext/readline/readline.c#L561-L629

https://github.com/ruby/readline-ext/blob/9ee1b1a2f848ebb98b8ea07969a100dd24548411/ext/readline/readline.c#L1463-L1494
