### PR TITLE
Add gem readline to Gemfile to fix failing ci jobs: readline 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,6 @@ end
 gem 'bundler'
 gem 'rake'
 gem 'test-unit'
+
+# Only used in ci to run readline-ext test using Reline as Readline
+gem 'readline'


### PR DESCRIPTION
Need for running readline-ext test using Reline as Readline. readline is changed from default gem to bundled gem in Ruby 3.5.0.dev