### PR TITLE
Migration for bundled gems

### DIFF
--- a/reline.gemspec
+++ b/reline.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'Ruby'
 
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+    Dir['BSDL', 'COPYING', 'README.md', 'license_of_rb-readline', 'lib/**/*']
   end
   spec.require_paths = ['lib']
   spec.metadata = {

--- a/reline.gemspec
+++ b/reline.gemspec
@@ -16,7 +16,9 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/ruby/reline'
   spec.license       = 'Ruby'
 
-  spec.files         = Dir['BSDL', 'COPYING', 'README.md', 'license_of_rb-readline', 'lib/**/*']
+  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  end
   spec.require_paths = ['lib']
   spec.metadata = {
     "bug_tracker_uri"   => "https://github.com/ruby/reline/issues",


### PR DESCRIPTION
The installer of `ruby/ruby` don't support `Dir.glob` style gemspec. We need to specify all of file list explicitly.