### PR TITLE
Use Relin::ANSI's buffer instead of calling STDIN.ungetc

### DIFF
--- a/lib/reline/io/ansi.rb
+++ b/lib/reline/io/ansi.rb
@@ -205,9 +205,7 @@ class Reline::ANSI < Reline::IO
           break
         end
       end
-      buf.chars.reverse_each do |ch|
-        stdin.ungetc ch
-      end
+      @buf.concat buf.bytes
     end
     [match[:column].to_i - 1, match[:row].to_i - 1] if match
   end


### PR DESCRIPTION
Reline::ANSI have a read buffer. We don't need to write read bytes back to STDIN only in a few case.

```ruby
@buf #=> [A, B, C]
@output << "\e[6n"
stdin.read_partial #=> "DE" + "\e[ROW;COLUMNR" + "FG"
@buf.concat ("DE" + "FG").bytes
@buf #=> [A, B, C, D, E, F, G]
```

### Background
This will reduce the effort (example: https://github.com/kateinoigakukun/irb.wasm/pull/24) of making Reline work with wasm
