### PR TITLE
Add gem fiddle to Gemfile (Only used in windows)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,3 +15,6 @@ gem 'test-unit'
 
 # Only used in ci to run readline-ext test using Reline as Readline
 gem 'readline'
+
+# Only used in windows
+gem 'fiddle'


### PR DESCRIPTION
Fix ci failure.

Fiddle is only used in windows. I think we need to do these later
- Show a warning message when `require 'fiddle` fails
- Determine which to use: Reline::Windows(fiddle) or Reline::ANSI(no fiddle) without using fiddle in windows.
