### PR TITLE
Basic setup for Reline's official documentation website

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,46 @@
+name: Deploy Reline documentation to GitHub Pages
+
+on:
+  push:
+    branches: ["master"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'ruby/reline' && !startsWith(github.event_name, 'pull') }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@f26937343756480a8cb3ae1f623b9c8d89ed6984 # v1.196.0
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+      - name: Build with Reline
+        run: bundle exec rake rdoc
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 *.swp
 Gemfile.lock
 /.idea/
+/_site/

--- a/.rdoc_options
+++ b/.rdoc_options
@@ -1,0 +1,3 @@
+page_dir: doc
+autolink_excluded_words:
+- Reline

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ if is_unix && ENV['WITH_VTERM']
 end
 
 gem 'bundler'
+gem 'rdoc'
 gem 'rake'
 gem 'test-unit'
 

--- a/Rakefile
+++ b/Rakefile
@@ -49,6 +49,7 @@ task default: :test
 
 RDoc::Task.new do |rdoc|
   rdoc.title = "Reline Documentation"
-  rdoc.main = "lib/reline.rb"
+  rdoc.main = "Index.md"
   rdoc.rdoc_dir = "_site"
+  rdoc.options.push("lib")
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 require 'bundler/gem_tasks'
 require 'rake/testtask'
+require 'rdoc/task'
 
 ENCODING_LIST = {
   test_shift_jis: Encoding::Shift_JIS,
@@ -45,3 +46,9 @@ end
 
 
 task default: :test
+
+RDoc::Task.new do |rdoc|
+  rdoc.title = "Reline Documentation"
+  rdoc.main = "lib/reline.rb"
+  rdoc.rdoc_dir = "_site"
+end

--- a/doc/Index.md
+++ b/doc/Index.md
@@ -1,0 +1,38 @@
+# Reline
+
+[![Gem Version](https://badge.fury.io/rb/reline.svg)](https://badge.fury.io/rb/reline)
+[![build](https://github.com/ruby/reline/actions/workflows/reline.yml/badge.svg)](https://github.com/ruby/reline/actions/workflows/test.yml)
+
+## Overview
+
+Reline is Ruby's official library for input editing and history management.
+
+## Installation
+
+To install it with `bundler`, add this line to your application's Gemfile:
+
+```ruby
+gem 'reline'
+```
+
+Then execute:
+
+```console
+$ bundle
+```
+
+Or install it directly with:
+
+```console
+$ gem install reline
+```
+
+## Usage
+
+See `Reline` module for public API.
+
+See [Face.md](rdoc-ref:reline/face.md) for customizing Reline's UI appearance.
+
+## License
+
+The gem is available as open source under the terms of the [Ruby License](https://www.ruby-lang.org/en/about/license.txt).

--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -12,10 +12,10 @@ require 'rbconfig'
 
 module Reline
   # NOTE: For making compatible with the rb-readline gem
-  FILENAME_COMPLETION_PROC = nil
-  USERNAME_COMPLETION_PROC = nil
+  FILENAME_COMPLETION_PROC = nil # :nodoc:
+  USERNAME_COMPLETION_PROC = nil # :nodoc:
 
-  class ConfigEncodingConversionError < StandardError; end
+  class ConfigEncodingConversionError < StandardError; end # :nodoc:
 
   # EOF key: { char: nil, method_symbol: nil }
   # Other key: { char: String, method_symbol: Symbol }
@@ -24,8 +24,8 @@ module Reline
     def match?(sym)
       method_symbol && method_symbol == sym
     end
-  end
-  CursorPos = Struct.new(:x, :y)
+  end # :nodoc:
+  CursorPos = Struct.new(:x, :y) # :nodoc:
   DialogRenderInfo = Struct.new(
     :pos,
     :contents,
@@ -35,7 +35,7 @@ module Reline
     :height,
     :scrollbar,
     keyword_init: true
-  )
+  ) # :nodoc:
 
   class Core
     ATTR_READER_NAMES = %i(
@@ -244,8 +244,8 @@ module Reline
         height: [15, preferred_dialog_height].min,
         face: :completion_dialog
       )
-    }
-    Reline::DEFAULT_DIALOG_CONTEXT = Array.new
+    } # :nodoc:
+    Reline::DEFAULT_DIALOG_CONTEXT = Array.new # :nodoc:
 
     def readmultiline(prompt = '', add_hist = false, &confirm_multiline_termination)
       @mutex.synchronize do
@@ -439,6 +439,17 @@ module Reline
   }
   def_single_delegators :core, :input=, :output=
   def_single_delegators :core, :vi_editing_mode, :emacs_editing_mode
+
+  ##
+  # :singleton-method: readmultiline
+  # :call-seq:
+  #   readmultiline(prompt = '', add_hist = false, &confirm_multiline_termination) -> string or nil
+  def_single_delegators :core, :readmultiline
+
+  ##
+  # :singleton-method: readline
+  # :call-seq:
+  #   readline(prompt = '', add_hist = false) -> string or nil
   def_single_delegators :core, :readline
   def_single_delegators :core, :completion_case_fold, :completion_case_fold=
   def_single_delegators :core, :completion_quote_character
@@ -474,11 +485,10 @@ module Reline
   def_single_delegators :core, :dialog_proc
   def_single_delegators :core, :autocompletion, :autocompletion=
 
-  def_single_delegators :core, :readmultiline
   def_instance_delegators self, :readmultiline
   private :readmultiline
 
-  def self.encoding_system_needs
+  def self.encoding_system_needs # :nodoc:
     self.core.encoding
   end
 
@@ -511,7 +521,7 @@ end
 Reline::IOGate = Reline::IO.decide_io_gate
 
 # Deprecated
-Reline::GeneralIO = Reline::Dumb.new
+Reline::GeneralIO = Reline::Dumb.new # :nodoc:
 
 Reline::Face.load_initial_configs
 


### PR DESCRIPTION
Similar to `ruby/irb`'s setup:

### Home page

<img width="60%" alt="Screenshot 2025-02-15 at 22 25 01" src="https://github.com/user-attachments/assets/a83b97dc-a043-4771-9063-c932f30c02ee" />

### Reline module's page
<img width="60%" alt="Screenshot 2025-02-15 at 22 30 21" src="https://github.com/user-attachments/assets/5e91ec79-2698-4966-b88a-cac7cee0cc51" />
