### PR TITLE
Fix negative argument exception when pressing Ctrl+C after long paste

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -188,7 +188,7 @@ class Reline::LineEditor
     @interrupted = false
     clear_dialogs
     render
-    cursor_to_bottom_offset = @rendered_screen.lines.size - @rendered_screen.cursor_y
+    cursor_to_bottom_offset = [@rendered_screen.lines.size - @rendered_screen.cursor_y, 1].max    
     Reline::IOGate.scroll_down cursor_to_bottom_offset
     Reline::IOGate.move_cursor_column 0
     clear_rendered_screen_cache


### PR DESCRIPTION
To reproduce, copy and paste more lines that can fit the screen, and press immediately afterwards Ctrl+C.

```
  /home/shai/.local/share/mise/installs/ruby/3.3.7/lib/ruby/gems/3.3.0/gems/reline-0.6.0/lib/reline/io/ansi.rb:289:in `*': negative argument (ArgumentError)

    write "\n" * x
                 ^
  from /home/shai/.local/share/mise/installs/ruby/3.3.7/lib/ruby/gems/3.3.0/gems/reline-0.6.0/lib/reline/io/ansi.rb:289:in `scroll_down'
  from /home/shai/.local/share/mise/installs/ruby/3.3.7/lib/ruby/gems/3.3.0/gems/reline-0.6.0/lib/reline/line_editor.rb:192:in `handle_interrupted'
  from /home/shai/.local/share/mise/installs/ruby/3.3.7/lib/ruby/gems/3.3.0/gems/reline-0.6.0/lib/reline/line_editor.rb:169:in `handle_signal'
```

Ensure there's at least 1 line so that the ^C is visible.


