### PR TITLE
Rescue more errors in get/set_screen_size

### DIFF
--- a/lib/reline/io/ansi.rb
+++ b/lib/reline/io/ansi.rb
@@ -180,14 +180,14 @@ class Reline::ANSI < Reline::IO
     s = [ENV["LINES"].to_i, ENV["COLUMNS"].to_i]
     return s if s[0] > 0 && s[1] > 0
     [24, 80]
-  rescue Errno::ENOTTY, Errno::ENODEV
+  rescue Errno::ENOTTY, Errno::ENODEV, Errno::EINVAL, Errno::EOPNOTSUPP
     [24, 80]
   end
 
   def set_screen_size(rows, columns)
     @input.winsize = [rows, columns]
     self
-  rescue Errno::ENOTTY, Errno::ENODEV
+  rescue Errno::ENOTTY, Errno::ENODEV, Errno::EINVAL, Errno::EOPNOTSUPP
     self
   end
 

--- a/lib/reline/io/ansi.rb
+++ b/lib/reline/io/ansi.rb
@@ -180,14 +180,14 @@ class Reline::ANSI < Reline::IO
     s = [ENV["LINES"].to_i, ENV["COLUMNS"].to_i]
     return s if s[0] > 0 && s[1] > 0
     [24, 80]
-  rescue Errno::ENOTTY, Errno::ENODEV, Errno::EINVAL, Errno::EOPNOTSUPP
+  rescue SystemCallError
     [24, 80]
   end
 
   def set_screen_size(rows, columns)
     @input.winsize = [rows, columns]
     self
-  rescue Errno::ENOTTY, Errno::ENODEV, Errno::EINVAL, Errno::EOPNOTSUPP
+  rescue SystemCallError
     self
   end
 


### PR DESCRIPTION
There are some environment that IO#winsize raises Errno::EINVAL and Errno::EOPNOTSUPP

Errno::EOPNOTSUPP reported in https://github.com/ruby/irb/issues/1090
Errno::EINVAL is rescued in irb(https://github.com/ruby/irb/pull/657#discussion_r1274546479)

Instead of rescuing ENOTTY, ENODEV, EINVAL, EOPNOTSUPP (and maybe more errnos), this pull request changes to rescue SystemCallError.
