### PR TITLE
Implement end-of-history

### DIFF
--- a/lib/reline/key_actor/emacs.rb
+++ b/lib/reline/key_actor/emacs.rb
@@ -377,7 +377,7 @@ module Reline::KeyActor
     # 187 M-;
     nil,
     # 188 M-<
-    nil,
+    :beginning_of_history,
     # 189 M-=
     nil,
     # 190 M->

--- a/lib/reline/key_actor/emacs.rb
+++ b/lib/reline/key_actor/emacs.rb
@@ -381,7 +381,7 @@ module Reline::KeyActor
     # 189 M-=
     nil,
     # 190 M->
-    nil,
+    :end_of_history,
     # 191 M-?
     nil,
     # 192 M-@

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -1654,6 +1654,11 @@ class Reline::LineEditor
   end
   alias_method :next_history, :ed_next_history
 
+  private def ed_end_of_history(key)
+    move_history(Reline::HISTORY.size, line: :end, cursor: :end)
+  end
+  alias_method :end_of_history, :ed_end_of_history
+
   private def ed_newline(key)
     process_insert(force: true)
     if @is_multiline

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -1654,6 +1654,11 @@ class Reline::LineEditor
   end
   alias_method :next_history, :ed_next_history
 
+  private def ed_beginning_of_history(key)
+    move_history(0, line: :end, cursor: :end)
+  end
+  alias_method :beginning_of_history, :ed_beginning_of_history
+
   private def ed_end_of_history(key)
     move_history(Reline::HISTORY.size, line: :end, cursor: :end)
   end

--- a/test/reline/test_key_actor_emacs.rb
+++ b/test/reline/test_key_actor_emacs.rb
@@ -1416,6 +1416,15 @@ class Reline::KeyActor::EmacsTest < Reline::TestCase
     assert_line_around_cursor('abcd', '')
   end
 
+  def test_end_of_history
+    Reline::HISTORY.concat(['abc', '123'])
+    input_keys("def\C-p\C-pd")
+    assert_line_around_cursor('abcd', '')
+    # \M->: move history to end
+    input_key_by_symbol(:end_of_history)
+    assert_line_around_cursor('def', '')
+  end
+
   # Unicode emoji test
   def test_ed_insert_for_include_zwj_emoji
     omit_unless_utf8

--- a/test/reline/test_key_actor_emacs.rb
+++ b/test/reline/test_key_actor_emacs.rb
@@ -1416,6 +1416,13 @@ class Reline::KeyActor::EmacsTest < Reline::TestCase
     assert_line_around_cursor('abcd', '')
   end
 
+  def test_beginning_of_history
+    Reline::HISTORY.concat(['abc', '123'])
+    # \M-<: move history to beginning
+    input_key_by_symbol(:beginning_of_history)
+    assert_line_around_cursor('abc', '')
+  end
+
   def test_end_of_history
     Reline::HISTORY.concat(['abc', '123'])
     input_keys("def\C-p\C-pd")


### PR DESCRIPTION
After using incremental search, I sometime want to go back to the end of history.

Reline is missing an implementation for [`end-of-history` from Readline](https://tiswww.case.edu/php/chet/readline/rluserman.html#index-end_002dof_002dhistory-_0028M_002d_003e_0029).

This adds it.