### PR TITLE
Support grapheme cluster that has width >= 3

### DIFF
--- a/lib/reline/unicode.rb
+++ b/lib/reline/unicode.rb
@@ -220,7 +220,7 @@ class Reline::Unicode
           next
         elsif padding && !cover_begin && prev_width < start_col && start_col < total_width
           # Add preceding padding. This padding might have background color.
-          chunk << ' '
+          chunk << ' ' * (total_width - start_col)
           chunk_start_col ||= start_col
           chunk_end_col = total_width
           next
@@ -234,7 +234,7 @@ class Reline::Unicode
           # Current character exceeds end_col
           if padding && end_col < total_width
             # Add succeeding padding. This padding might have background color.
-            chunk << ' '
+            chunk << ' ' * (end_col - prev_width)
             chunk_start_col ||= prev_width
             chunk_end_col = end_col
           end

--- a/test/reline/test_unicode.rb
+++ b/test/reline/test_unicode.rb
@@ -107,6 +107,21 @@ class Reline::Unicode::Test < Reline::TestCase
     assert_equal ["\e[41m \e[42mい\e[43m ", 1, 4], Reline::Unicode.take_mbchar_range("\e[41mあ\e[42mい\e[43mう", 1, 4, padding: true)
   end
 
+  def test_three_width_characters_take_mbchar_range
+    halfwidth_dakuten = 0xFF9E.chr('utf-8')
+    a = 'あ' + halfwidth_dakuten
+    b = 'い' + halfwidth_dakuten
+    c = 'う' + halfwidth_dakuten
+    line = 'x' + a + b + c + 'x'
+    assert_equal ['  ' + b + ' ', 2, 6], Reline::Unicode.take_mbchar_range(line, 2, 6, padding: true)
+    assert_equal [' ' + b + '  ', 3, 6], Reline::Unicode.take_mbchar_range(line, 3, 6, padding: true)
+    assert_equal [b + c, 4, 6], Reline::Unicode.take_mbchar_range(line, 4, 6, padding: true)
+    assert_equal [a + b, 1, 6], Reline::Unicode.take_mbchar_range(line, 2, 6, cover_begin: true)
+    assert_equal [a + b, 1, 6], Reline::Unicode.take_mbchar_range(line, 3, 6, cover_begin: true)
+    assert_equal [b + c, 4, 6], Reline::Unicode.take_mbchar_range(line, 2, 6, cover_end: true)
+    assert_equal [b + c, 4, 6], Reline::Unicode.take_mbchar_range(line, 3, 6, cover_end: true)
+  end
+
   def test_common_prefix
     assert_equal('', Reline::Unicode.common_prefix([]))
     assert_equal('abc', Reline::Unicode.common_prefix(['abc']))


### PR DESCRIPTION
Currently, Reline assumes that a grapheme cluster has 0, 1 or 2 width.
This assumption is not correct. A single grapheme cluster `はﾟ` will be rendered in three column width. (#832)
