### PR TITLE
Add a test for non-ascii char input escaped with C-v

### DIFF
--- a/lib/reline/io/ansi.rb
+++ b/lib/reline/io/ansi.rb
@@ -124,6 +124,10 @@ class Reline::ANSI < Reline::IO
       Reline.core.line_editor.handle_signal
     end
     c = @input.getbyte
+
+    # When "Escape non-ASCII Input with Control-V" is enabled in macOS Terminal.app,
+    # all non-ascii bytes are automatically escaped with `C-v`.
+    # "\xE3\x81\x82" (U+3042) becomes "\x16\xE3\x16\x81\x16\x82".
     (c == 0x16 && @input.tty? && @input.raw(min: 0, time: 0, &:getbyte)) || c
   rescue Errno::EIO
     # Maybe the I/O has been closed.


### PR DESCRIPTION
There was a mystery of `0x16` in Reline. There is no test and no source code comment.
`0x16` seems to be inserted in some case (what case?) in some way (how?) but nobody knows how and why.
```ruby
(c == 0x16 && @input.tty? && @input.raw(min: 0, time: 0, &:getbyte)) || c
```

It turned out that this is 0x16 came from a configuration of terminal emulator `Escape non-ASCII input with Control-V`
(https://github.com/ohmyzsh/ohmyzsh/issues/7412)

![ctrlv_escape_config](https://github.com/user-attachments/assets/dd40f3ec-e2df-464c-8131-cdf592fb96dd)

With this configuration, every non-ascii byte will be escaped with `\C-v`
```ruby
irb> STDIN.raw{STDIN.readpartial(100)} # input あ = "\xE3\x81\x82"
=> "\x16\xE3\x16\x81\x16\x82"

# Bracketed paste also includes \x16
irb> print "\e[?2004h"; STDIN.raw{STDIN.readpartial(100)+STDIN.readpartial(100)} # paste あ
=> "\e[200~\x16\xE3\x16\x81\x16\x82\e[201~"
```

Now we can add a test and a comment