### PR TITLE
Fix quoted insert with invalid byte input

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -347,7 +347,8 @@ module Reline
                 # io_gate is Reline::ANSI because the key :bracketed_paste_start is only assigned in Reline::ANSI
                 key = Reline::Key.new(io_gate.read_bracketed_paste, :insert_multiline_text)
               when :quoted_insert, :ed_quoted_insert
-                key = Reline::Key.new(io_gate.read_single_char(config.keyseq_timeout), :insert_raw_char)
+                char = io_gate.read_single_char(config.keyseq_timeout.fdiv(1000))
+                key = Reline::Key.new(char || '', :insert_raw_char)
               end
               line_editor.set_pasting_state(io_gate.in_pasting?)
               line_editor.update(key)

--- a/lib/reline/io.rb
+++ b/lib/reline/io.rb
@@ -37,10 +37,10 @@ module Reline
     end
 
     # Read a single encoding valid character from the input.
-    def read_single_char(keyseq_timeout)
+    def read_single_char(timeout_second)
       buffer = String.new(encoding: Encoding::ASCII_8BIT)
       loop do
-        timeout = buffer.empty? ? Float::INFINITY : keyseq_timeout
+        timeout = buffer.empty? ? Float::INFINITY : timeout_second
         c = getc(timeout)
         return unless c
 

--- a/lib/reline/io/ansi.rb
+++ b/lib/reline/io/ansi.rb
@@ -299,7 +299,7 @@ class Reline::ANSI < Reline::IO
     # Signal.trap may raise an ArgumentError if the platform doesn't support the signal.
   end
 
-  def read_single_char(keyseq_timeout)
+  def read_single_char(timeout_second)
     # Disable intr to read `C-c` `C-z` `C-\` for quoted insert
     @input.raw(intr: false) do
       super

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -1798,6 +1798,21 @@ begin
       close
     end
 
+    def test_quoted_insert_timeout
+      omit if Reline.core.io_gate.win?
+
+      start_terminal(5, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl}, startup_message: 'Multiline REPL.')
+      write "\C-v"
+      write "\C-a"
+      write "\C-v"
+      # broken bytes should be ignored with timeout
+      write_without_meta_conversion "\xE3\xE4\xE5"
+      sleep 1
+      write "\C-v"
+      write "\C-b"
+      assert_screen(/prompt> \^A\^B/)
+    end
+
     def test_print_before_readline
       code = <<~RUBY
         puts 'Multiline REPL.'


### PR DESCRIPTION
quoted_insert timeout was 1000 times larger. (forgot to do `.fdiv(1000)`)
Fix a bug that readline unexpedly end when quoted_insert timed out. (Avoid insert_raw_char char=nil and use `''` instead when timed out)

Fix this bug:
```
$ LANG=C irb
irb(main):001> (input \C-v あ)
(irb hangs and exits after 500 second)
```
