### PR TITLE
Don't print useless prompt before escape sequence

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -324,8 +324,6 @@ module Reline
       line_editor.auto_indent_proc = auto_indent_proc
       line_editor.dig_perfect_match_proc = dig_perfect_match_proc
 
-      # Readline calls pre_input_hook just after printing the first prompt.
-      line_editor.print_nomultiline_prompt
       pre_input_hook&.call
 
       unless Reline::IOGate.dumb?

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -470,14 +470,6 @@ class Reline::LineEditor
     end
   end
 
-  def print_nomultiline_prompt
-    Reline::IOGate.disable_auto_linewrap(true) if Reline::IOGate.win?
-    # Readline's test `TestRelineAsReadline#test_readline` requires first output to be prompt, not cursor reset escape sequence.
-    Reline::IOGate.write Reline::Unicode.strip_non_printing_start_end(@prompt) if @prompt && !@is_multiline
-  ensure
-    Reline::IOGate.disable_auto_linewrap(false) if Reline::IOGate.win?
-  end
-
   def render
     wrapped_cursor_x, wrapped_cursor_y = wrapped_cursor_position
     new_lines = wrapped_prompt_and_input_lines.flatten(1)[screen_scroll_top, screen_height].map do |prompt, line|

--- a/test/reline/test_reline.rb
+++ b/test/reline/test_reline.rb
@@ -382,18 +382,6 @@ class Reline::Test < Reline::TestCase
     assert_match(/#<Reline::Dumb/, out.chomp)
   end
 
-  def test_print_prompt_before_everything_else
-    pend if win?
-    lib = File.expand_path("../../lib", __dir__)
-    code = "p Reline::IOGate.class; p Reline.readline 'prompt> '"
-    out = IO.popen([Reline.test_rubybin, "-I#{lib}", "-rreline", "-e", code], "r+") do |io|
-      io.write "abc\n"
-      io.close_write
-      io.read
-    end
-    assert_match(/\AReline::ANSI\nprompt> /, out)
-  end
-
   def test_read_eof_returns_input
     pend if win?
     lib = File.expand_path("../../lib", __dir__)


### PR DESCRIPTION
Fixes #833

Reline used to print prompt in nomultiline mode before printing any escape sequence because readline-ext's test was requiring.
It's completely useless because printed prompt will be cleared immediately.
This behavior causes line-wrapped long prompt displayed twice.

Before:
```
Reline.readline 'prompt'+'>'*50
prompt>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
prompt>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
>>>>>> Prompt displayed twice
```
After:
```
Reline.readline 'prompt'+'>'*50
prompt>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
>>>>>> OK
```

## Side effect

Test code that depend on this behavior needs to be modified.
- rubygems/rubygems: two test fails
  - `bundler/spec/commands/info_spec.rb`
  - `bundler/spec/commands/show_spec.rb`
- ruby/debug
  - console_test seems to pass
- ruby/rdoc
  - ri test seems to pass

