### PR TITLE
Fix CSI pattern regexp to accept parameter bytes and intermediate bytes

### DIFF
--- a/lib/reline/unicode.rb
+++ b/lib/reline/unicode.rb
@@ -37,7 +37,7 @@ class Reline::Unicode
 
   NON_PRINTING_START = "\1"
   NON_PRINTING_END = "\2"
-  CSI_REGEXP = /\e\[[\d;]*[ABCDEFGHJKSTfminsuhl]/
+  CSI_REGEXP = /\e\[[\x30-\x3f]*[\x20-\x2f]*[a-zA-Z]/
   OSC_REGEXP = /\e\]\d+(?:;[^;\a\e]+)*(?:\a|\e\\)/
   WIDTH_SCANNER = /\G(?:(#{NON_PRINTING_START})|(#{NON_PRINTING_END})|(#{CSI_REGEXP})|(#{OSC_REGEXP})|(\X))/o
 

--- a/test/reline/test_unicode.rb
+++ b/test/reline/test_unicode.rb
@@ -19,7 +19,7 @@ class Reline::Unicode::Test < Reline::TestCase
   end
 
   def test_csi_regexp
-    csi_sequences = ["\e[m", "\e[1m", "\e[12;34m", "\e[12;34H"]
+    csi_sequences = ["\e[m", "\e[1m", "\e[12;34m", "\e[12;34H", "\e[5 q", "\e[?2004h"]
     assert_equal(csi_sequences, "text#{csi_sequences.join('text')}text".scan(Reline::Unicode::CSI_REGEXP))
   end
 


### PR DESCRIPTION
Fix CSI_REGEXP pattern.
Reline::Unicode will handle CSI escape sequence like `"\e[1 q"` `\e[?1234h` correctly.
Example inputrc
```inputrc
set show-mode-in-prompt on
set vi-cmd-mode-string "\1\033[1 q\2"
set vi-ins-mode-string "\1\033[5 q\2"
```

Fixes https://github.com/ruby/irb/issues/1118
