### PR TITLE
Remove retrieve_keybuffer

### DIFF
--- a/lib/reline/io/ansi.rb
+++ b/lib/reline/io/ansi.rb
@@ -167,17 +167,6 @@ class Reline::ANSI < Reline::IO
     @buf.unshift(c)
   end
 
-  def retrieve_keybuffer
-    begin
-      return unless @input.wait_readable(0.001)
-      str = @input.read_nonblock(1024)
-      str.bytes.each do |c|
-        @buf.push(c)
-      end
-    rescue EOFError
-    end
-  end
-
   def get_screen_size
     s = @input.winsize
     return s if s[0] > 0 && s[1] > 0
@@ -309,7 +298,6 @@ class Reline::ANSI < Reline::IO
   def prep
     # Enable bracketed paste
     write "\e[?2004h" if Reline.core.config.enable_bracketed_paste && both_tty?
-    retrieve_keybuffer
     nil
   end
 


### PR DESCRIPTION
`ANSI#cursor_pos` was throwing away the pre_match part of cursor position report escape sequence. `ANSI#retrieve_keybuffer` is added to avoid this. We don't need it anymore because cursor_pos is already fixed 6 years ago.

retrieve_keybuffer added in 444267b644a736d2633880eb522bf72629c86dee
cursor_pos fixed in 4a8cca331f7c70e6927953a16c0449520a1fc186
