### PR TITLE
Use bundler/setup instead of Bunlder.require in multiline_repl

### DIFF
--- a/test/reline/yamatanooroti/multiline_repl
+++ b/test/reline/yamatanooroti/multiline_repl
@@ -1,8 +1,6 @@
 #!/usr/bin/env ruby
 
-
-require 'bundler'
-Bundler.require
+require 'bundler/setup'
 
 require 'reline'
 require 'optparse'


### PR DESCRIPTION
Bundler.require requires all gems including gems multiline_repl doesn't need.
This will fix ci failure in ruby-2.7 caused by warning message displayed while requiring power_assert.

Failure error message:
```
Error: RuntimeError: Startup message didn't arrive within timeout: 
"/opt/hostedtoolcache/Ruby/2.7.8/x64/lib/ruby/gems/2.7.0/gems/power_assert-3.0.1
/lib/power_assert/parser.rb:106: warning: Pattern matching is experimental, and 
the behavior may change in future versions of Ruby!\r\n/opt/hostedtoolcache/Ruby
/2.7.8/x64/lib/ruby/gems/2.7.0/gems/power_assert-3.0.1/lib/power_assert/parser.r
b:106: warning: Pattern matching is experimental, and the behavior may change in
 future versions of Ruby!\r\nMultiline REPL.\r\n\e[?2004h\e[1G\xE2\x96\xBD\e[6n\
e[1G\e[K\e[6n\e[?25l\e[1G\e[K\e[1G\e[0m\e[1mprompt>\e[m \e[0m\e[?25h\e[9G"
```