### PR TITLE
[Reline::Unicode] Explicitly set join field so setting $, doesn't break it

### DIFF
--- a/lib/reline/unicode.rb
+++ b/lib/reline/unicode.rb
@@ -51,7 +51,7 @@ class Reline::Unicode
       else
         EscapedPairs[gr.ord] || gr
       end
-    }.join
+    }.join('')
   end
 
   def self.safe_encode(str, encoding)


### PR DESCRIPTION
This PR updates `Reline::Unicode.escape_for_print` so it explicitly joins with `''`, instead of `$,`. 

Using `$,`causes errors in IRB. For example, trying to type `puts "hi"`:

# Before
```
% irb
irb(main):001> $, = 'q'
=> "q"
irb(main):002> pquqtqs "hqi"
hi
=> nqiql
```

# After
```
% irb
irb(main):001> $, = 'q'
=> "q"
irb(main):002> puts "hi"
hi
=> nil
irb(main):003> 
```