### PR TITLE
Proposal to add common prefix completion for autocompletion mode

### DIFF
--- a/test/reline/test_key_actor_emacs.rb
+++ b/test/reline/test_key_actor_emacs.rb
@@ -841,6 +841,10 @@ class Reline::KeyActor::EmacsTest < Reline::TestCase
     input_keys('Re')
     assert_line_around_cursor('Re', '')
     input_keys("\C-i")
+    # First tab completes to common prefix (which is 'Re' in this case)
+    assert_line_around_cursor('Re', '')
+    input_keys("\C-i")
+    # Second tab shows menu and selects first candidate
     assert_line_around_cursor('Readline', '')
     input_keys("\C-i")
     assert_line_around_cursor('Regexp', '')

--- a/test/reline/test_key_actor_vi.rb
+++ b/test/reline/test_key_actor_vi.rb
@@ -667,6 +667,10 @@ class Reline::ViInsertTest < Reline::TestCase
     input_keys('Re')
     assert_line_around_cursor('Re', '')
     input_keys("\C-i")
+    # First tab completes to common prefix
+    assert_line_around_cursor('Re', '')
+    input_keys("\C-i")
+    # Second tab selects first candidate
     assert_line_around_cursor('Readline', '')
     input_keys("\C-i")
     assert_line_around_cursor('Regexp', '')
@@ -690,6 +694,10 @@ class Reline::ViInsertTest < Reline::TestCase
     input_keys('Re')
     assert_line_around_cursor('Re', '')
     input_keys("\C-i")
+    # First tab completes to common prefix
+    assert_line_around_cursor('Re', '')
+    input_keys("\C-i")
+    # Second tab selects first candidate
     assert_line_around_cursor('Readline', '')
     input_keys("\C-i")
     assert_line_around_cursor('Regexp', '')


### PR DESCRIPTION
Let me propose to add the "common prefix completion" for the first tab hit on autocompletion mode.
The behavior is similar to the tab hit on non-autocompletion mode, and then it cycles through the candidates just as the current autocompletion mode behaves. I think this is how most of the modern shells e.g., bash, zsh, etc. behave by default.

As a realistic example, when having candidates
```
instance_of?
instance_variable_defined?
instance_variable_get
instance_variable_set
instance_variables
```
now we can get to "instance_variable_get" with the following three steps:

1. User hits Tab: Complete to common prefix, "instance_" with menu displayed
2. User types "v" + Tab: Complete to common prefix, "instance_variable"
3. User types "_g" + Tab: Complete "instance_variable_get"

You can confirm this exact behavior with this one liner on this branch:
`ruby -Ilib -rreline -e "Reline.autocompletion = true; Reline.completion_proc = proc { |s| %w[instance_of? instance_variable_defined? instance_variable_get instance_variable_set instance_variables].select { |i| i.start_with?(s) } }; puts Reline.readline('> ')"`