### PR TITLE
Fix iogate.getc input byte order shuffled bug

### DIFF
--- a/lib/reline/io/ansi.rb
+++ b/lib/reline/io/ansi.rb
@@ -114,13 +114,15 @@ class Reline::ANSI < Reline::IO
   end
 
   def inner_getc(timeout_second)
-    unless @buf.empty?
-      return @buf.shift
-    end
-    until @input.wait_readable(0.01)
+    while true
+      # @buf may change while handling signal, so we need to check it in each loop iteration.
+      return @buf.shift unless @buf.empty?
+      break if @input.wait_readable(0.01)
+
       timeout_second -= 0.01
       return nil if timeout_second <= 0
 
+      # handle_signal may call cursor_pos which modifies @buf
       Reline.core.line_editor.handle_signal
     end
     c = @input.getbyte


### PR DESCRIPTION
Fixes this bug:
<img width="368" height="235" alt="image" src="https://github.com/user-attachments/assets/b52e6448-1d4a-4ab2-8b37-7803877aa98e" />
Sometimes, something like `"[10;16R"` is input to reline, very rarely when a computer(macOS) wakes up from sleep mode, in Terminal.app. I think additional situation (external display triggers WIHCN) is needed to reproduce.

Here's a timeline of a situation that this bug happens. (found by inserting many debug log output to ansi.rb)

1. Reline calls `IOGate.getc`
2. WINCH signal is received more than 3 times with more than 0.01s intervals
3. `IOGate.cursor_pos` is called for each WINCH signal. Reline sends `"\e[6n"` (CPR, Cursor Position Request) and waits for `0.5sec`
4. First `cursor_pos` timed out
5. Second `cursor_pos` timed out
6. Third `cursor_pos` receives `"\e[1;1R\e[2;2R"` (response to the first and second CPR)
7. IOGate consumes first `"\e[1;1R"` and put `"\e[2;2R"` to `@buf`
8. IOGate reads `"\e"`, the leading byte of `"\e[3;3R"` (response to the third CPR)
9. Reline reads `"\e\e[2;2R"`, resolved to ALT_KEY + unbound CSI escape sequence
10. Reline reads `"3;3R"`, resolved to normal ascii key input

Input to Reline is `"\e[1;1R\e[2;2R\e[3;3R"` but Reline thinks the input is `"\e[1;1R\e\e[2;2R[3;3R"`.

Fix: Always check `@buf.empty?` after calling `Reline.core.line_editor.handle_signal`
