### PR TITLE
Use Reline::ANSI when ruby is built with the msys/cygwin runtime

### DIFF
--- a/lib/reline/io.rb
+++ b/lib/reline/io.rb
@@ -10,15 +10,21 @@ module Reline
         require 'reline/io/ansi'
 
         case RbConfig::CONFIG['host_os']
-        when /mswin|msys|mingw|cygwin|bccwin|wince|emc/
+        when /mswin|mingw|bccwin|wince|emc/
           require 'reline/io/windows'
           io = Reline::Windows.new
           if io.msys_tty? || !STDIN.tty?
+            # In either case stdin is not a console (a Cygwin/MSYS pty pipe such
+            # as mintty, or a redirect), so the Win32 console input API cannot
+            # read it.
             Reline::ANSI.new
           else
             io
           end
         else
+          # Ruby built with the msys/cygwin runtime also reaches here. Its tty layer
+          # speaks ANSI in any terminal (mintty pty or Windows console), so the
+          # Win32 console API must not be used. https://github.com/ruby/reline/issues/903
           Reline::ANSI.new
         end
       end


### PR DESCRIPTION
A cygwin-built ruby (e.g. MSYS2's ruby package) routes all I/O through the Cygwin tty layer, which presents an ANSI terminal regardless of what stdin is attached to: a Cygwin pty pipe (mintty) or a Windows console (Windows Terminal, conhost). In console mode, Cygwin enables ENABLE_VIRTUAL_TERMINAL_INPUT, so arrow keys arrive as ESC [ A character events instead of VK_UP key events. Reline::Windows reads the console handle directly via ReadConsoleInputW, bypassing the tty layer, and has no CSI key bindings, so arrow keys were ignored.

cygwin/msys were originally not in this branch: until 1cfa5221 the condition was `RUBY_PLATFORM =~ /mswin|mingw/`. That commit switched to the generic "is Windows" host_os regex to support JRuby (whose RUBY_PLATFORM is always "java"); including cygwin/msys was incidental, not motivated by any case where a cygwin ruby needed the console API. JRuby on Windows reports host_os "mswin32" and is unaffected.

Fixes https://github.com/ruby/reline/issues/903