### PR TITLE
Avoid terminal rendering for non-TTY readline output

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -296,10 +296,6 @@ module Reline
       input.respond_to?(:tty?) && input.tty? && output.respond_to?(:tty?) && output.tty?
     end
 
-    private def terminal_rendering?
-      terminal? && !io_gate.dumb?
-    end
-
     private def inner_readline(prompt, add_history, multiline, rprompt: nil, &confirm_multiline_termination)
       if ENV['RELINE_STDERR_TTY']
         if io_gate.win?
@@ -343,7 +339,7 @@ module Reline
         end
       end
 
-      if terminal_rendering?
+      if terminal?
         line_editor.update_dialogs
         line_editor.rerender
       else
@@ -368,18 +364,18 @@ module Reline
             end
           }
           if line_editor.finished?
-            if terminal_rendering?
+            if terminal?
               line_editor.render_finished
-            elsif !terminal?
+            else
               line = line_editor.line
               output.write("#{line}\n") if line
             end
             break
-          elsif terminal_rendering?
+          elsif terminal?
             line_editor.rerender
           end
         end
-        io_gate.move_cursor_column(0) if terminal_rendering?
+        io_gate.move_cursor_column(0) if terminal?
       rescue Errno::EIO
         # Maybe the I/O has been closed.
       ensure

--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -58,7 +58,7 @@ module Reline
     attr_accessor :key_stroke
     attr_accessor :line_editor
     attr_accessor :last_incremental_search
-    attr_reader :output
+    attr_reader :input, :output
 
     extend Forwardable
     def_delegators :config,
@@ -66,6 +66,7 @@ module Reline
       :autocompletion=
 
     def initialize
+      self.input = STDIN
       self.output = STDOUT
       @mutex = Mutex.new
       @dialog_proc_list = {}
@@ -175,6 +176,7 @@ module Reline
 
     def input=(val)
       raise TypeError unless val.respond_to?(:getc) or val.nil?
+      @input = val
       if val.respond_to?(:getc) && io_gate.respond_to?(:input=)
         io_gate.input = val
       end
@@ -290,6 +292,14 @@ module Reline
       end
     end
 
+    private def terminal?
+      input.respond_to?(:tty?) && input.tty? && output.respond_to?(:tty?) && output.tty?
+    end
+
+    private def terminal_rendering?
+      terminal? && !io_gate.dumb?
+    end
+
     private def inner_readline(prompt, add_history, multiline, rprompt: nil, &confirm_multiline_termination)
       if ENV['RELINE_STDERR_TTY']
         if io_gate.win?
@@ -333,8 +343,12 @@ module Reline
         end
       end
 
-      line_editor.update_dialogs
-      line_editor.rerender
+      if terminal_rendering?
+        line_editor.update_dialogs
+        line_editor.rerender
+      else
+        output.write(prompt)
+      end
 
       begin
         line_editor.set_signal_handlers
@@ -354,13 +368,18 @@ module Reline
             end
           }
           if line_editor.finished?
-            line_editor.render_finished
+            if terminal_rendering?
+              line_editor.render_finished
+            elsif !terminal?
+              line = line_editor.line
+              output.write("#{line}\n") if line
+            end
             break
-          else
+          elsif terminal_rendering?
             line_editor.rerender
           end
         end
-        io_gate.move_cursor_column(0)
+        io_gate.move_cursor_column(0) if terminal_rendering?
       rescue Errno::EIO
         # Maybe the I/O has been closed.
       ensure

--- a/test/reline/test_reline.rb
+++ b/test/reline/test_reline.rb
@@ -420,12 +420,22 @@ class Reline::Test < Reline::TestCase
 
   def test_readline_reads_piped_stdin
     out = readline_from_piped_stdin("input\n")
-    assert_include(out, { result: 'input' }.inspect)
+    assert_equal(">input\n#{ { result: 'input' }.inspect }\n", out)
+  end
+
+  def test_readline_with_dumb_terminal_outputs_plain_piped_stdin
+    out = readline_from_dumb_terminal_piped_stdin("input\n")
+    assert_equal("> input\n#{ { result: 'input' }.inspect }\n", out)
   end
 
   def test_readline_returns_nil_on_piped_stdin_eof
     out = readline_from_piped_stdin("")
-    assert_include(out, { result: nil }.inspect)
+    assert_equal(">#{ { result: nil }.inspect }\n", out)
+  end
+
+  def test_readline_with_dumb_terminal_outputs_plain_piped_stdin_eof
+    out = readline_from_dumb_terminal_piped_stdin("")
+    assert_equal("> #{ { result: nil }.inspect }\n", out)
   end
 
   def test_read_eof_returns_input
@@ -482,6 +492,17 @@ class Reline::Test < Reline::TestCase
     RUBY
 
     IO.popen([Reline.test_rubybin, "-I#{lib}", "-rreline", "-e", code], "r+") do |io|
+      io.write stdin
+      io.close_write
+      io.read
+    end
+  end
+
+  def readline_from_dumb_terminal_piped_stdin(stdin)
+    lib = File.expand_path("../../lib", __dir__)
+    code = "p result: Reline.readline('> ')"
+
+    IO.popen([{"TERM" => "dumb"}, Reline.test_rubybin, "-I#{lib}", "-rreline", "-e", code], "r+") do |io|
       io.write stdin
       io.close_write
       io.read


### PR DESCRIPTION
## Problem

Reline decides which IO gate to use before `readline` knows whether it is actually writing to a terminal. On non-Windows platforms, `Reline::IO.decide_io_gate` [can select `Reline::ANSI`](https://github.com/ruby/reline/blob/3ad04537c58fec9cfbbdb3d4b93e91779a0802d1/lib/reline/io.rb#L6-L29) whenever `TERM` is not `dumb`.

That selection is currently treated as enough for `inner_readline` to run the interactive display path. It [updates dialogs, renders the line editor, renders the accepted line, and finally moves the cursor back to column 0](https://github.com/ruby/reline/blob/3ad04537c58fec9cfbbdb3d4b93e91779a0802d1/lib/reline.rb#L336-L363). That is fine when stdout is a terminal, because those operations update what the user sees in place. It is an issue when stdout is a pipe, because the display output is captured as ordinary output.

With the ANSI IO gate, the final cursor movement [writes an escape sequence](https://github.com/ruby/reline/blob/3ad04537c58fec9cfbbdb3d4b93e91779a0802d1/lib/reline/io/ansi.rb#L233-L235), so captured output can contain bytes such as `\e[1G`. That is the escape-sequence symptom in [#886](https://github.com/ruby/reline/issues/886).

`TERM=dumb` doesn't help. It switches to `Reline::Dumb`, where cursor methods [intentionally do nothing](https://github.com/ruby/reline/blob/3ad04537c58fec9cfbbdb3d4b93e91779a0802d1/lib/reline/io/dumb.rb#L76-L87). But `inner_readline` is still trying to render the line editor. Since the cursor methods do not move back over the previous display, the prompt and input text are left in place and appended again. That is the repeated-output symptom in [#886](https://github.com/ruby/reline/issues/886), and related `TERM=dumb` behaviour is discussed in [#660](https://github.com/ruby/reline/issues/660).

## Reproduction

The first commit on this branch adds failing coverage for the non-TTY cases this PR changes. It can be checked out independently to see the behaviour currently on `master`.

## Solution

`Reline::Core` already [stores the configured output](https://github.com/ruby/reline/blob/3ad04537c58fec9cfbbdb3d4b93e91779a0802d1/lib/reline.rb#L61-L69), but `input=` [only forwards the input to the IO gate](https://github.com/ruby/reline/blob/3ad04537c58fec9cfbbdb3d4b93e91779a0802d1/lib/reline.rb#L176-L187). This change stores the configured input as well.

`readline` now uses the interactive display path only when both input and output are TTYs. When that check passes, the existing terminal behaviour is unchanged. When it fails, `readline` writes plain output instead: the prompt once, then the accepted line once. EOF [still returns `nil`](https://github.com/ruby/reline/blob/3ad04537c58fec9cfbbdb3d4b93e91779a0802d1/lib/reline/line_editor.rb#L1134-L1136), so there is no accepted line to echo.

This PR only changes the non-TTY path. It does not try to fix rendering in real TTY sessions, including `TERM=dumb` TTY sessions. Those still use the existing terminal path.