### PR TITLE
Avoid repeated TTY readline output with TERM=dumb

### DIFF
--- a/lib/reline/io/dumb.rb
+++ b/lib/reline/io/dumb.rb
@@ -53,16 +53,22 @@ class Reline::Dumb < Reline::IO
   end
 
   def buffered_output
-    return yield unless @input.respond_to?(:tty?) && @input.tty? && @output.respond_to?(:tty?) && @output.tty?
+    return yield unless tty?
 
     @output_buffer = +''
     yield
-    if @first_render
+    # render_finished writes complete transcript lines ending in CRLF. Keep those
+    # while dropping redraws that this IO gate cannot apply in place.
+    if @first_render || @output_buffer.end_with?("\n")
       @output.write(@output_buffer)
       @first_render = false
     end
   ensure
     @output_buffer = nil
+  end
+
+  private def tty?
+    @input.respond_to?(:tty?) && @input.tty? && @output.respond_to?(:tty?) && @output.tty?
   end
 
   def getc(_timeout_second)

--- a/lib/reline/io/dumb.rb
+++ b/lib/reline/io/dumb.rb
@@ -57,8 +57,7 @@ class Reline::Dumb < Reline::IO
 
     @output_buffer = +''
     yield
-    # render_finished writes complete transcript lines ending in CRLF. Keep those
-    # while dropping redraws that this IO gate cannot apply in place.
+
     if @first_render || @output_buffer.end_with?("\n")
       @output.write(@output_buffer)
       @first_render = false

--- a/lib/reline/io/dumb.rb
+++ b/lib/reline/io/dumb.rb
@@ -9,9 +9,11 @@ class Reline::Dumb < Reline::IO
     @input = STDIN
     @output = STDOUT
     @buf = []
+    @output_buffer = nil
     @pasting = false
     @encoding = encoding
     @screen_size = [24, 80]
+    @first_render = true
   end
 
   def dumb?
@@ -43,11 +45,24 @@ class Reline::Dumb < Reline::IO
   end
 
   def write(string)
-    @output.write(string)
+    if @output_buffer
+      @output_buffer << string
+    else
+      @output.write(string)
+    end
   end
 
   def buffered_output
+    return yield unless @input.respond_to?(:tty?) && @input.tty? && @output.respond_to?(:tty?) && @output.tty?
+
+    @output_buffer = +''
     yield
+    if @first_render
+      @output.write(@output_buffer)
+      @first_render = false
+    end
+  ensure
+    @output_buffer = nil
   end
 
   def getc(_timeout_second)
@@ -113,6 +128,7 @@ class Reline::Dumb < Reline::IO
   end
 
   def prep
+    @first_render = true
   end
 
   def deprep(otio)

--- a/test/reline/test_reline.rb
+++ b/test/reline/test_reline.rb
@@ -428,6 +428,26 @@ class Reline::Test < Reline::TestCase
     assert_include(out, { result: nil }.inspect)
   end
 
+  def test_dumb_tty_buffered_output_keeps_first_and_finished_renders
+    input = StringIO.new
+    output = StringIO.new
+
+    [input, output].each do |io|
+      def io.tty?
+        true
+      end
+    end
+    io_gate = Reline::Dumb.new
+    io_gate.input = input
+    io_gate.output = output
+
+    io_gate.buffered_output { io_gate.write("first render") }
+    io_gate.buffered_output { io_gate.write("rerender") }
+    io_gate.buffered_output { io_gate.write("finished render\n") }
+
+    assert_equal("first renderfinished render\n", output.string)
+  end
+
   def test_read_eof_returns_input
     pend if win?
     lib = File.expand_path("../../lib", __dir__)


### PR DESCRIPTION
## Problem

Reline's dumb IO gate can be attached to a TTY, but it cannot repaint one.

When `TERM=dumb` is set, Reline [selects `Reline::Dumb`](https://github.com/ruby/reline/blob/24ebad7a28f6a269b5e7d7ed08eaf2ca52fa1621/lib/reline/io.rb#L6-L8). `inner_readline` still drives the display machinery: it [renders the line editor](https://github.com/ruby/reline/blob/24ebad7a28f6a269b5e7d7ed08eaf2ca52fa1621/lib/reline.rb#L336-L337), rerenders after input changes, [renders the accepted line](https://github.com/ruby/reline/blob/24ebad7a28f6a269b5e7d7ed08eaf2ca52fa1621/lib/reline.rb#L356-L360), and then [moves the cursor back to column 0](https://github.com/ruby/reline/blob/24ebad7a28f6a269b5e7d7ed08eaf2ca52fa1621/lib/reline.rb#L363).

That is fine for an IO gate that can move the cursor over the previous frame. It is an issue for `Reline::Dumb`, where the cursor movement methods [intentionally do nothing](https://github.com/ruby/reline/blob/24ebad7a28f6a269b5e7d7ed08eaf2ca52fa1621/lib/reline/io/dumb.rb#L86-L99). `Reline::Dumb#buffered_output` also [just yields](https://github.com/ruby/reline/blob/24ebad7a28f6a269b5e7d7ed08eaf2ca52fa1621/lib/reline/io/dumb.rb#L49-L51), so those render writes go straight to output.

With a TTY, submitted input is already echoed by the terminal. Reline then appends intermediate render output after that. Typing `hello` can produce output like:

```text
0> hello
hhehelhellhello0> hello
"hello"
```

This is related to [#660](https://github.com/ruby/reline/issues/660).

## Reproduction

The first commit on this branch adds failing coverage for this. It runs `Reline.readline` twice under a PTY with `TERM=dumb`, so both input and output are TTYs.

It can be checked out independently to see the current behaviour.

## Solution

Buffer writes inside `Reline::Dumb#buffered_output` when input and output are both TTYs.

The first buffered render is still written, so the prompt is visible. Complete lines are also still written, so accepted input remains visible in captured TTY output. Other render frames are dropped, because `Reline::Dumb` has no cursor operation that could apply them in place.

When input or output is not a TTY, `buffered_output` keeps yielding directly and preserves the existing write path.